### PR TITLE
Reset the maxfield to zero

### DIFF
--- a/tdms/src/tdms_iterator.cpp
+++ b/tdms/src/tdms_iterator.cpp
@@ -6087,28 +6087,31 @@ if(runmode == rm_complete && (nvertices>0) )
   }
   
   //now find the maximum absolute value of residual field in the grid
-  for(k=0;k<(K_tot+1);k++)
-    for(j=0;j<(J_tot+1);j++)
-      for(i=0;i<(I_tot+1);i++){
-	tempfield = fabs(Exy[k][j][i]+Exz[k][j][i]);
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
-	tempfield = fabs(Eyx[k][j][i]+Eyz[k][j][i]);
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
-	tempfield = fabs(Ezx[k][j][i]+Ezy[k][j][i]);	
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
-	tempfield = fabs(Hxy[k][j][i]+Hxz[k][j][i]);	
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
-	tempfield = fabs(Hyx[k][j][i]+Hyz[k][j][i]);	
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
-	tempfield = fabs(Hzx[k][j][i]+Hzy[k][j][i]);	
-	if( maxfield < tempfield )
-	  maxfield = tempfield;
+  maxfield = 0.0;
+  for(k=0;k<(K_tot+1);k++) {
+    for (j = 0; j < (J_tot + 1); j++) {
+      for (i = 0; i < (I_tot + 1); i++) {
+        tempfield = fabs(Exy[k][j][i] + Exz[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
+        tempfield = fabs(Eyx[k][j][i] + Eyz[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
+        tempfield = fabs(Ezx[k][j][i] + Ezy[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
+        tempfield = fabs(Hxy[k][j][i] + Hxz[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
+        tempfield = fabs(Hyx[k][j][i] + Hyz[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
+        tempfield = fabs(Hzx[k][j][i] + Hzy[k][j][i]);
+        if (maxfield < tempfield)
+          maxfield = tempfield;
       }
+    }
+  }
   
   //fprintf(stderr,"Pos 15\n");
   //noe set the output


### PR DESCRIPTION
Solves a bug initially thought to be Mac-specific but was the cause of flaky system tests (see #31)

The `maxfield` updated in the loop could exceed all the `tempfield` values, meaning that it was not updated upon loop completion. This PR simply resets `maxfield` to zero (and adds some explicit for loop scopes).