### PR TITLE
OpenMP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ display sample output.
 
 #### Parallelism
 
-TDMS is paralleled with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The maximum 
+TDMS is parallelised with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The maximum 
 number of threads can be set with the `OMP_NUM_THREADS` environment variable. 
 For example, to use 4 threads, in a bash shell, use:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ This script will generate the input to the executable, run the executable and
 display sample output.
 
 
+#### Parallelism
+
+TDMS is paralleled with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The maximum 
+number of threads can be set with the `OMP_NUM_THREADS` environment variable. 
+For example, to use 4 threads, in a bash shell, use:
+
+```bash
+export OMP_NUM_THREADS=4
+```
+
+
 ## Contributing
 
 You are welcome to report new issues or submit pull requests.  For more information about how to contribute, please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) file.

--- a/tdms/src/openandorder_PSTD.cpp
+++ b/tdms/src/openandorder_PSTD.cpp
@@ -40,8 +40,6 @@ void freememory( int nmatrices, mxArray **matrixptrs);
 
 int main(int nargs,char *argv[], char **envp){
 
-  fprintf(stdout,"Using %d OMP threads\n", omp_get_max_threads());
-
   FILE *infile;
 
   /*

--- a/tdms/src/tdms_iterator.cpp
+++ b/tdms/src/tdms_iterator.cpp
@@ -458,6 +458,8 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
   char *sourcemodestr;
   char *tdfdirstr;
 
+  fprintf(stdout,"Using %d OMP threads\n", omp_get_max_threads());
+
   FILE *outfile;
   if(poutfile){
     outfile = fopen("out.1.2.txt","w");


### PR DESCRIPTION
- Closes #38 
- Moves the OMP print statement from the main function into the only parallelised function