### PR TITLE
Throw exceptions rather than return codes

### DIFF
--- a/tdms/include/interpolate.h
+++ b/tdms/include/interpolate.h
@@ -1,75 +1,75 @@
 double interp1(double v1, double v2, double v3, double v4);
 double interp2(double v1, double v2, double v3, double v4);
 double interp3(double v1, double v2, double v3, double v4);
-int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 			      double ***Ex    , double ***Ey    , double ***Ez    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 			      double ***Ex    , double ***Ey    , double ***Ez    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateFieldCentralE_TH( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE_TH( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 			      double ***Ex    , double ***Ey    , double ***Ez    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 			        mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 			        mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 			        mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 			      double ***Hx    , double ***Hy    , double ***Hz    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 			      double ***Hx    , double ***Hy    , double ***Hz    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateFieldCentralH_TH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH_TH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 			      double ***Hx    , double ***Hy    , double ***Hz    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 			        mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 			        mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 			        mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-int interpolateTimeDomainFieldCentralE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 			       int i, int j, int k,
 					 double *Ex, double *Ey, double *Ez);
-int interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					 int i, int j, int k,
 						    double *Ex, double *Ey, double *Ez);
-int interpolateTimeDomainFieldCentralE_2Dy(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_2Dy(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 			       int i, int j, int k,
 			       double *Ex, double *Ey, double *Ez);
-int interpolateTimeDomainFieldCentralE_TE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_TE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 			       int i, int j, int k,
 			       double *Ex, double *Ey, double *Ez);
-int interpolateTimeDomainFieldCentralE_TM(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_TM(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 			       int i, int j, int k,
 			       double *Ex, double *Ey, double *Ez);
-int interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz);
-int interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz);
-int interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz);
-int interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz);
-int interpolateTimeDomainFieldCentralHBandLimited( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralHBandLimited( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 						   double *Hx, double *Hy, double *Hz);

--- a/tdms/matlabio/matlabio.h
+++ b/tdms/matlabio/matlabio.h
@@ -1,9 +1,11 @@
+#include "complex"
+
 void updateMatlabArray(double *mArray, double arrayVal, int i, int j, int nrows);
 void updateMatlab3DArray(double *mArray, double arrayVal, int i, int j, int k, int nrows, int ncols);
 double getMatlab3DArray(double *mArray, int i, int j, int k, int nrows, int ncols);
 double getMatlabArray(double *mArray, int i, int j, int nrows);
 void MatlabDisplayDouble(char *desc,double x);
-void MatlabDisplayComplex(char *desc,complex<double> x);
+void MatlabDisplayComplex(char *desc,std::complex<double> x);
 void MatlabDisplayString(char *desc,char *outstring);
 void MatlabDisplayString(char *desc,char outchar);
 int ReportVerbosely();

--- a/tdms/src/interpolate.cpp
+++ b/tdms/src/interpolate.cpp
@@ -90,9 +90,9 @@ void interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_
     throw runtime_error("Error in interpolateFieldCentralE, k_u too large\n");
     
   }
-  //throw runtime_error("interpolateFieldCentralE 01\n");
+  //fprintf(stderr, "interpolateFieldCentralE 01\n");
   if(j_u<j_l){
-    //throw runtime_error("interpolateFieldCentralE 02\n");
+    //fprintf(stderr, "interpolateFieldCentralE 02\n");
     j=0;
     for(k=k_l;k<=k_u;k++)
       for(i=i_l;i<=i_u;i++){
@@ -100,7 +100,7 @@ void interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_
 	  Ey[k-k_l][0][i-i_l] = Ey_yee[k][0][i];
 	  Ez[k-k_l][0][i-i_l] = interp1(Ez_yee[k-2][j][i], Ez_yee[k-1][j][i], Ez_yee[k][j][i], Ez_yee[k+1][j][i]);
 	}
-    //throw runtime_error("interpolateFieldCentralE 03\n");
+    //fprintf(stderr, "interpolateFieldCentralE 03\n");
   }
   else
     for(k=k_l;k<=k_u;k++)
@@ -263,16 +263,16 @@ void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez
   double ***ExR, ***ExI, ***EyR, ***EyI, ***EzR, ***EzI,***Ex_yee_R, ***Ex_yee_I, ***Ey_yee_R, ***Ey_yee_I, ***Ez_yee_R, ***Ez_yee_I;
   const int *indims;
   int outdims[3], ndims;
-  //throw runtime_error("mxInterpolateFieldCentralE Pos 00\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE Pos 00\n");
   if( (int)mxGetNumberOfDimensions( (const mxArray *)Ex_yee) < 3){
     throw runtime_error("Error in mxInterpolateFieldCentralE, Ex_yee does not have 3 dimensions\n");
     
     
   }
-  //throw runtime_error("mxInterpolateFieldCentralE Pos 01\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE Pos 01\n");
   indims = (int *)mxGetDimensions( (mxArray *)Ex_yee);
-  //throw runtime_error("mxInterpolateFieldCentralE(indims): (%d,%d,%d)\n",indims[0],indims[1],indims[2]);
-  //throw runtime_error("mxInterpolateFieldCentralE: j_u: %d, j_l: %d\n",j_u,j_l);
+  //fprintf(stderr, "mxInterpolateFieldCentralE(indims): (%d,%d,%d)\n",indims[0],indims[1],indims[2]);
+  //fprintf(stderr, "mxInterpolateFieldCentralE: j_u: %d, j_l: %d\n",j_u,j_l);
   //assume that all matrices have the same dimensions
   if( !mxIsComplex(Ex_yee) ){
     mexErrMsgTxt("Ex_yee is not complex");
@@ -283,7 +283,7 @@ void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez
   if( !mxIsComplex(Ez_yee) ){
     mexErrMsgTxt("Ez_yee is not complex");
   }
-  //throw runtime_error("mxInterpolateFieldCentralE Pos 02\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE Pos 02\n");
   Ex_yee_R = castMatlab3DArray(mxGetPr(Ex_yee), indims[0], indims[1], indims[2]);
   Ex_yee_I = castMatlab3DArray(mxGetPi(Ex_yee), indims[0], indims[1], indims[2]);
 
@@ -292,7 +292,7 @@ void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez
 
   Ez_yee_R = castMatlab3DArray(mxGetPr(Ez_yee), indims[0], indims[1], indims[2]);
   Ez_yee_I = castMatlab3DArray(mxGetPi(Ez_yee), indims[0], indims[1], indims[2]);
-  //throw runtime_error("mxInterpolateFieldCentralE Pos 03\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE Pos 03\n");
   //now construct the output matrices
   ndims = 3;
   
@@ -301,21 +301,21 @@ void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez
   if(outdims[1]<1)
     outdims[1]=1;
   outdims[2] = k_u - k_l + 1;
-  //throw runtime_error("mxInterpolateFieldCentralE(outdims): (%d,%d,%d)\n",outdims[0],outdims[1],outdims[2]);
-    //throw runtime_error("mxInterpolateFieldCentralE Pos 04\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE(outdims): (%d,%d,%d)\n",outdims[0],outdims[1],outdims[2]);
+    //fprintf(stderr, "mxInterpolateFieldCentralE Pos 04\n");
   *Ex = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
   *Ey = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
   *Ez = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
-//throw runtime_error("mxInterpolateFieldCentralE Pos 04a\n");
+//fprintf(stderr, "mxInterpolateFieldCentralE Pos 04a\n");
   ExR = castMatlab3DArray(mxGetPr(*Ex), outdims[0], outdims[1], outdims[2]);
   ExI = castMatlab3DArray(mxGetPi(*Ex), outdims[0], outdims[1], outdims[2]);
-//throw runtime_error("mxInterpolateFieldCentralE Pos 04b\n");
+//fprintf(stderr, "mxInterpolateFieldCentralE Pos 04b\n");
   EyR = castMatlab3DArray(mxGetPr(*Ey), outdims[0], outdims[1], outdims[2]);
   EyI = castMatlab3DArray(mxGetPi(*Ey), outdims[0], outdims[1], outdims[2]);
-//throw runtime_error("mxInterpolateFieldCentralE Pos 04c\n");
+//fprintf(stderr, "mxInterpolateFieldCentralE Pos 04c\n");
   EzR = castMatlab3DArray(mxGetPr(*Ez), outdims[0], outdims[1], outdims[2]);
   EzI = castMatlab3DArray(mxGetPi(*Ez), outdims[0], outdims[1], outdims[2]);
-  //throw runtime_error("mxInterpolateFieldCentralE Pos 05\n");
+  //fprintf(stderr, "mxInterpolateFieldCentralE Pos 05\n");
   //now finally ready for interpolation
   interpolateFieldCentralE( Ex_yee_I, Ey_yee_I, Ez_yee_I,
 			    ExI     , EyI     , EzI    ,
@@ -601,7 +601,7 @@ void interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_
     
   }
   if(j_u<j_l){
-    //throw runtime_error("interpolateFieldCentralH 02\n");
+    //fprintf(stderr, "interpolateFieldCentralH 02\n");
     j=0;
     for(k=k_l;k<=k_u;k++)
       for(i=i_l;i<=i_u;i++){

--- a/tdms/src/interpolate.cpp
+++ b/tdms/src/interpolate.cpp
@@ -1,30 +1,18 @@
-/*****************************************************************
- *
- *  Project.....:  isotropic FDTD code
+/******************************************************************************
  *  Application.:  interpolation of field values within FDTD grid
- *  Module......:  interpolate.cpp
+ *
  *  Description.:  The Yee cell specifies the 6 field components at
  *                 different points in space. Interpolation is required
  *                 to calculate the 6 field components at the same 
  *                 spatial position.
- *  Compiler....:  g++
- *  Written by..:  Peter Munro, Imperial College London, 2002-2008
- *  Environment.:  Linux
- *  Modified....:  Numerous times
- *
- ******************************************************************/
-
-/*---------------------------------------------------------------*/
-//                        INCLUDE section
-/*---------------------------------------------------------------*/
-
-#include "math.h"
-#include <complex>
+ *****************************************************************************/
+#include "stdexcept"
 #include "matio.h"
-
-using namespace std;
 #include "interpolate.h"
 #include "matlabio.h"
+
+using namespace std;
+
 
 /*Use cubic interpolation to interpolate in the middle of 4 points
  * v1    v2    v3    v4
@@ -71,7 +59,7 @@ double interp3(double v1, double v2, double v3, double v4){
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 			      double ***Ex    , double ***Ey    , double ***Ez    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -80,32 +68,31 @@ int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_y
  
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_l too small");
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_u too large\n");
+    
   }
   if( k_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_l too small\n");
+    
   }
   else if( k_u > K - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_u too large\n");
+    
   }
-  //fprintf(stderr,"interpolateFieldCentralE 01\n");
+  //throw runtime_error("interpolateFieldCentralE 01\n");
   if(j_u<j_l){
-    //fprintf(stderr,"interpolateFieldCentralE 02\n");
+    //throw runtime_error("interpolateFieldCentralE 02\n");
     j=0;
     for(k=k_l;k<=k_u;k++)
       for(i=i_l;i<=i_u;i++){
@@ -113,7 +100,7 @@ int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_y
 	  Ey[k-k_l][0][i-i_l] = Ey_yee[k][0][i];
 	  Ez[k-k_l][0][i-i_l] = interp1(Ez_yee[k-2][j][i], Ez_yee[k-1][j][i], Ez_yee[k][j][i], Ez_yee[k+1][j][i]);
 	}
-    //fprintf(stderr,"interpolateFieldCentralE 03\n");
+    //throw runtime_error("interpolateFieldCentralE 03\n");
   }
   else
     for(k=k_l;k<=k_u;k++)
@@ -123,7 +110,7 @@ int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_y
 	  Ey[k-k_l][j-j_l][i-i_l] = interp1(Ey_yee[k][j-2][i], Ey_yee[k][j-1][i], Ey_yee[k][j][i], Ey_yee[k][j+1][i]);
 	  Ez[k-k_l][j-j_l][i-i_l] = interp1(Ez_yee[k-2][j][i], Ez_yee[k-1][j][i], Ez_yee[k][j][i], Ez_yee[k+1][j][i]);
 	}
-  return 0;
+
 }
 /*Interpolate the electric field to the origin of the Yee cell
  *
@@ -146,7 +133,7 @@ int interpolateFieldCentralE( double ***Ex_yee, double ***Ey_yee, double ***Ez_y
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 				 double ***Ex    , double ***Ey    , double ***Ez    ,
 				 int       I     , int       J     , int       K     ,
 				 int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -155,28 +142,28 @@ int interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***E
  
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_l too small\n");
+    
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_u too large\n");
+    
   }
   if( k_l < 0 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_l too small\n");
+    
   }
   else if( k_u > 0){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_u too large\n");
+    
   }
   for(k=k_l;k<=k_u;k++)
     for(j=j_l;j<=j_u;j++)
@@ -185,7 +172,7 @@ int interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***E
 	Ey[k-k_l][j-j_l][i-i_l] = interp1(Ey_yee[k][j-2][i], Ey_yee[k][j-1][i], Ey_yee[k][j][i], Ey_yee[k][j+1][i]);
 	Ez[k-k_l][j-j_l][i-i_l] = 0.;
       }
-  return 0;
+
 }
 
 /*Interpolate the electric field to the origin of the Yee cell
@@ -209,7 +196,7 @@ int interpolateFieldCentralE_TE( double ***Ex_yee, double ***Ey_yee, double ***E
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralE_TM( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
+void interpolateFieldCentralE_TM( double ***Ex_yee, double ***Ey_yee, double ***Ez_yee,
 				 double ***Ex    , double ***Ey    , double ***Ez    ,
 				 int       I     , int       J     , int       K     ,
 				 int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -218,28 +205,28 @@ int interpolateFieldCentralE_TM( double ***Ex_yee, double ***Ey_yee, double ***E
  
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_l too small\n");
+    
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralE, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, j_u too large\n");
+    
   }
   if( k_l < 0 ){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_l too small\n");
+    
   }
   else if( k_u > 0){
-    fprintf(stderr,"Error in interpolateFieldCentralE, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralE, k_u too large\n");
+    
   }
   
   for(k=k_l;k<=k_u;k++)
@@ -249,7 +236,7 @@ int interpolateFieldCentralE_TM( double ***Ex_yee, double ***Ey_yee, double ***E
 	Ey[k-k_l][j-j_l][i-i_l] = 0.;
 	Ez[k-k_l][j-j_l][i-i_l] = Ez_yee[k][j][i];
       }
-  return 0;
+
 }
 
  
@@ -269,23 +256,23 @@ int interpolateFieldCentralE_TM( double ***Ex_yee, double ***Ey_yee, double ***E
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 				mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
   double ***ExR, ***ExI, ***EyR, ***EyI, ***EzR, ***EzI,***Ex_yee_R, ***Ex_yee_I, ***Ey_yee_R, ***Ey_yee_I, ***Ez_yee_R, ***Ez_yee_I;
   const int *indims;
   int outdims[3], ndims;
-  //fprintf(stderr,"mxInterpolateFieldCentralE Pos 00\n");
+  //throw runtime_error("mxInterpolateFieldCentralE Pos 00\n");
   if( (int)mxGetNumberOfDimensions( (const mxArray *)Ex_yee) < 3){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralE, Ex_yee does not have 3 dimensions\n");
-    return -1;
+    throw runtime_error("Error in mxInterpolateFieldCentralE, Ex_yee does not have 3 dimensions\n");
+    
     
   }
-  //fprintf(stderr,"mxInterpolateFieldCentralE Pos 01\n");
+  //throw runtime_error("mxInterpolateFieldCentralE Pos 01\n");
   indims = (int *)mxGetDimensions( (mxArray *)Ex_yee);
-  //fprintf(stderr,"mxInterpolateFieldCentralE(indims): (%d,%d,%d)\n",indims[0],indims[1],indims[2]);
-  //fprintf(stderr,"mxInterpolateFieldCentralE: j_u: %d, j_l: %d\n",j_u,j_l);
+  //throw runtime_error("mxInterpolateFieldCentralE(indims): (%d,%d,%d)\n",indims[0],indims[1],indims[2]);
+  //throw runtime_error("mxInterpolateFieldCentralE: j_u: %d, j_l: %d\n",j_u,j_l);
   //assume that all matrices have the same dimensions
   if( !mxIsComplex(Ex_yee) ){
     mexErrMsgTxt("Ex_yee is not complex");
@@ -296,7 +283,7 @@ int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_
   if( !mxIsComplex(Ez_yee) ){
     mexErrMsgTxt("Ez_yee is not complex");
   }
-  //fprintf(stderr,"mxInterpolateFieldCentralE Pos 02\n");
+  //throw runtime_error("mxInterpolateFieldCentralE Pos 02\n");
   Ex_yee_R = castMatlab3DArray(mxGetPr(Ex_yee), indims[0], indims[1], indims[2]);
   Ex_yee_I = castMatlab3DArray(mxGetPi(Ex_yee), indims[0], indims[1], indims[2]);
 
@@ -305,7 +292,7 @@ int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_
 
   Ez_yee_R = castMatlab3DArray(mxGetPr(Ez_yee), indims[0], indims[1], indims[2]);
   Ez_yee_I = castMatlab3DArray(mxGetPi(Ez_yee), indims[0], indims[1], indims[2]);
-  //fprintf(stderr,"mxInterpolateFieldCentralE Pos 03\n");
+  //throw runtime_error("mxInterpolateFieldCentralE Pos 03\n");
   //now construct the output matrices
   ndims = 3;
   
@@ -314,21 +301,21 @@ int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_
   if(outdims[1]<1)
     outdims[1]=1;
   outdims[2] = k_u - k_l + 1;
-  //fprintf(stderr,"mxInterpolateFieldCentralE(outdims): (%d,%d,%d)\n",outdims[0],outdims[1],outdims[2]);
-    //fprintf(stderr,"mxInterpolateFieldCentralE Pos 04\n");
+  //throw runtime_error("mxInterpolateFieldCentralE(outdims): (%d,%d,%d)\n",outdims[0],outdims[1],outdims[2]);
+    //throw runtime_error("mxInterpolateFieldCentralE Pos 04\n");
   *Ex = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
   *Ey = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
   *Ez = mxCreateNumericArray( ndims, (const mwSize *)outdims, mxDOUBLE_CLASS, mxCOMPLEX);
-//fprintf(stderr,"mxInterpolateFieldCentralE Pos 04a\n");
+//throw runtime_error("mxInterpolateFieldCentralE Pos 04a\n");
   ExR = castMatlab3DArray(mxGetPr(*Ex), outdims[0], outdims[1], outdims[2]);
   ExI = castMatlab3DArray(mxGetPi(*Ex), outdims[0], outdims[1], outdims[2]);
-//fprintf(stderr,"mxInterpolateFieldCentralE Pos 04b\n");
+//throw runtime_error("mxInterpolateFieldCentralE Pos 04b\n");
   EyR = castMatlab3DArray(mxGetPr(*Ey), outdims[0], outdims[1], outdims[2]);
   EyI = castMatlab3DArray(mxGetPi(*Ey), outdims[0], outdims[1], outdims[2]);
-//fprintf(stderr,"mxInterpolateFieldCentralE Pos 04c\n");
+//throw runtime_error("mxInterpolateFieldCentralE Pos 04c\n");
   EzR = castMatlab3DArray(mxGetPr(*Ez), outdims[0], outdims[1], outdims[2]);
   EzI = castMatlab3DArray(mxGetPi(*Ez), outdims[0], outdims[1], outdims[2]);
-  //fprintf(stderr,"mxInterpolateFieldCentralE Pos 05\n");
+  //throw runtime_error("mxInterpolateFieldCentralE Pos 05\n");
   //now finally ready for interpolation
   interpolateFieldCentralE( Ex_yee_I, Ey_yee_I, Ez_yee_I,
 			    ExI     , EyI     , EzI    ,
@@ -355,7 +342,7 @@ int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_
   freeCastMatlab3DArray(EyI,outdims[2]);
   freeCastMatlab3DArray(EzR,outdims[2]);
   freeCastMatlab3DArray(EzI,outdims[2]);
-  return 0;
+
 }
 
 /*Interpolate the electric field to the origin of the Yee cell - matlab interface
@@ -374,7 +361,7 @@ int mxInterpolateFieldCentralE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 				   mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				   int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
@@ -383,8 +370,8 @@ int mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
   int outdims[3], ndims;
   
   if( mxGetNumberOfDimensions(Ex_yee) !=2 ){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralE_TE, Ex_yee does not have 2 dimensions\n");
-    return -1;
+    throw runtime_error("Error in mxInterpolateFieldCentralE_TE, Ex_yee does not have 2 dimensions\n");
+    
     
   }
   
@@ -452,8 +439,7 @@ int mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
   freeCastMatlab3DArray(EyI,outdims[2]);
   freeCastMatlab3DArray(EzR,outdims[2]);
   freeCastMatlab3DArray(EzI,outdims[2]);
-  return 0;
-  
+
 }
 
 
@@ -473,7 +459,7 @@ int mxInterpolateFieldCentralE_TE( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
+void mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *Ez_yee,
 				   mxArray **Ex    , mxArray **Ey    , mxArray **Ez    ,
 				   int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
@@ -482,8 +468,8 @@ int mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
   int outdims[3], ndims;
   
   if( mxGetNumberOfDimensions(Ex_yee) != 2){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralE_TM, Ex_yee does not have 2 dimensions\n");
-    return -1;
+    throw runtime_error("Error in mxInterpolateFieldCentralE_TM, Ex_yee does not have 2 dimensions\n");
+    
     
   }
   
@@ -555,7 +541,7 @@ int mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
   freeCastMatlab3DArray(EyI,outdims[2]);
   freeCastMatlab3DArray(EzR,outdims[2]);
   freeCastMatlab3DArray(EzI,outdims[2]);
-  return 0;
+
 }
 
 
@@ -580,7 +566,7 @@ int mxInterpolateFieldCentralE_TM( mxArray *Ex_yee , mxArray *Ey_yee , mxArray *
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 			      double ***Hx    , double ***Hy    , double ***Hz    ,
                               int       I     , int       J     , int       K     ,
 			      int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -588,34 +574,34 @@ int interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_y
   int i,j,k;
   double res1, res2, res3, res4;
  
-  //  fprintf(stderr,"Entering interpolateFieldCentralH\n");
+  //  throw runtime_error("Entering interpolateFieldCentralH\n");
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_l too small\n");
+    
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_u too large\n");
+    
   }
   if( k_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_l too small\n");
+    
   }
   else if( k_u > K - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_u too large\n");
+    
   }
   if(j_u<j_l){
-    //fprintf(stderr,"interpolateFieldCentralH 02\n");
+    //throw runtime_error("interpolateFieldCentralH 02\n");
     j=0;
     for(k=k_l;k<=k_u;k++)
       for(i=i_l;i<=i_u;i++){
@@ -678,7 +664,6 @@ int interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_y
 	  res4 = interp1(Hz_yee[k][j-2][i+1],Hz_yee[k][j-2][i],Hz_yee[k][j-2][i-1],Hz_yee[k][j-2][i-2]);
 	  Hz[k-k_l][j-j_l][i-i_l] = interp1(res1, res2, res3, res4);
 	}
-  return 0;
 }
 
 /*Interpolate the electric field to the origin of the Yee cell
@@ -702,7 +687,7 @@ int interpolateFieldCentralH( double ***Hx_yee, double ***Hy_yee, double ***Hz_y
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 				 double ***Hx    , double ***Hy    , double ***Hz    ,
 				 int       I     , int       J     , int       K     ,
 				 int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -713,28 +698,28 @@ int interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***H
 
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_l too small\n");
+    
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_u too large\n");
+    
   }
   if( k_l < 0 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_l too small\n");
+    
   }
   else if( k_u > 0){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_u too large\n");
+    
   }
   
   for(k=k_l;k<=k_u;k++)
@@ -771,7 +756,7 @@ int interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***H
 	res4 = interp1(Hz_yee[k][j-2][i+1],Hz_yee[k][j-2][i],Hz_yee[k][j-2][i-1],Hz_yee[k][j-2][i-2]);
 	Hz[k-k_l][j-j_l][i-i_l] = interp1(res1, res2, res3, res4);
       }
-  return 0;
+
 }
 
 /*Interpolate the electric field to the origin of the Yee cell
@@ -795,7 +780,7 @@ int interpolateFieldCentralH_TE( double ***Hx_yee, double ***Hy_yee, double ***H
  *k_l[in]  - lowest i index into the FDTD grid to evaluate the field at. Should be >= 2.
  *k_u[out] - largest i index into the FDTD grid to evaluate the field at. Should be <= K-2.
  */
-int interpolateFieldCentralH_TM( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
+void interpolateFieldCentralH_TM( double ***Hx_yee, double ***Hy_yee, double ***Hz_yee,
 				 double ***Hx    , double ***Hy    , double ***Hz    ,
 				 int       I     , int       J     , int       K     ,
 				 int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
@@ -804,28 +789,28 @@ int interpolateFieldCentralH_TM( double ***Hx_yee, double ***Hy_yee, double ***H
 
   //first check that the limits of field extraction of within range
   if( i_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_l too small\n");
+    
   }
   else if( i_u > I - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, i_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, i_u too large\n");
+    
   }
   if( j_l < 2 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_l too small\n");
+    
   }
   else if( j_u > J - 2){
-    fprintf(stderr,"Error in interpolateFieldCentralH, j_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, j_u too large\n");
+    
   }
   if( k_l < 0 ){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_l too small\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_l too small\n");
+    
   }
   else if( k_u > 0){
-    fprintf(stderr,"Error in interpolateFieldCentralH, k_u too large\n");
-    return -1;
+    throw runtime_error("Error in interpolateFieldCentralH, k_u too large\n");
+    
   }
   
   for(k=k_l;k<=k_u;k++)
@@ -858,7 +843,6 @@ int interpolateFieldCentralH_TM( double ***Hx_yee, double ***Hy_yee, double ***H
 
 	Hz[k-k_l][j-j_l][i-i_l] = 0.;
       }
-  return 0;
 }
 
       
@@ -878,7 +862,7 @@ int interpolateFieldCentralH_TM( double ***Hx_yee, double ***Hy_yee, double ***H
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 			        mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
@@ -887,8 +871,8 @@ int mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_
   int outdims[3], ndims;
   
   if( mxGetNumberOfDimensions(Hx_yee) < 3){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralH, Ex_yee does not have 3 dimensions\n");
-    return -1;
+    throw runtime_error("Error in mxInterpolateFieldCentralH, Ex_yee does not have 3 dimensions\n");
+    
     
   }
   
@@ -962,7 +946,7 @@ int mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_
   freeCastMatlab3DArray(HyI,outdims[2]);
   freeCastMatlab3DArray(HzR,outdims[2]);
   freeCastMatlab3DArray(HzI,outdims[2]);
-  return 0;
+
 }
       
 /*Interpolate the magnetic field to the origin of the Yee cell - matlab interface
@@ -981,7 +965,7 @@ int mxInterpolateFieldCentralH( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 				   mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				   int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
@@ -990,8 +974,8 @@ int mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
   int outdims[3], ndims;
   
   if( mxGetNumberOfDimensions(Hx_yee) != 2){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralH_TE, Ex_yee does not have 3 dimensions\n");
-    return -1;
+    throw runtime_error("Error in mxInterpolateFieldCentralH_TE, Ex_yee does not have 3 dimensions\n");
+    
     
   }
   
@@ -1063,7 +1047,7 @@ int mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
   freeCastMatlab3DArray(HyI,outdims[2]);
   freeCastMatlab3DArray(HzR,outdims[2]);
   freeCastMatlab3DArray(HzI,outdims[2]);
-  return 0;
+
 }
 
      
@@ -1083,7 +1067,7 @@ int mxInterpolateFieldCentralH_TE( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
  * J - number of elements in the j direction of the FDTD grid
  * K - number of elements in the k direction of the FDTD grid)
  */
-int mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
+void mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *Hz_yee,
 				   mxArray **Hx    , mxArray **Hy    , mxArray **Hz    ,
 				   int i_l, int i_u, int j_l, int j_u, int k_l, int k_u){
 
@@ -1092,9 +1076,7 @@ int mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
   int outdims[3], ndims;
   
   if( mxGetNumberOfDimensions(Hx_yee) != 2){
-    fprintf(stderr,"Error in mxInterpolateFieldCentralH_TM, Ex_yee does not have 3 dimensions\n");
-    return -1;
-    
+    throw runtime_error("Error in mxInterpolateFieldCentralH_TM, Ex_yee does not have 3 dimensions\n");
   }
   
   indims = (int *)mxGetDimensions(Hx_yee);
@@ -1165,7 +1147,7 @@ int mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
   freeCastMatlab3DArray(HyI,outdims[2]);
   freeCastMatlab3DArray(HzR,outdims[2]);
   freeCastMatlab3DArray(HzI,outdims[2]);
-  return 0;
+
 }
 
 
@@ -1177,7 +1159,7 @@ int mxInterpolateFieldCentralH_TM( mxArray *Hx_yee , mxArray *Hy_yee , mxArray *
  *
  *[out]Hx to Hz are the field components interpolated to the origin of the Yee cell
  */
-int interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz){
   
@@ -1201,8 +1183,6 @@ int interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***
   res3 = interp1(Hzx[k][j-1][i+1]+Hzy[k][j-1][i+1],Hzx[k][j-1][i]+Hzy[k][j-1][i],Hzx[k][j-1][i-1]+Hzy[k][j-1][i-1],Hzx[k][j-1][i-2]+Hzy[k][j-1][i-2]);
   res4 = interp1(Hzx[k][j-2][i+1]+Hzy[k][j-2][i+1],Hzx[k][j-2][i]+Hzy[k][j-2][i],Hzx[k][j-2][i-1]+Hzy[k][j-2][i-1],Hzx[k][j-2][i-2]+Hzy[k][j-2][i-2]);
   *Hz  = interp1(res1, res2, res3, res4);
-
-  return 0;
 }
 
 /*Interpolate the electric field to the origin of the Yee cell in the time domain using band limited interpolation
@@ -1212,7 +1192,7 @@ int interpolateTimeDomainFieldCentralH( double ***Hxy, double ***Hxz, double ***
  *
  *[out]Hx to Hz are the field components interpolated to the origin of the Yee cell
  */
-int interpolateTimeDomainFieldCentralHBandLimited( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralHBandLimited( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz){
 
@@ -1250,7 +1230,7 @@ int interpolateTimeDomainFieldCentralHBandLimited( double ***Hxy, double ***Hxz,
  *
  *[out]Hx to Hz are the field components interpolated to the origin of the Yee cell
  */
-int interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					int i, int j, int k,
 					double *Hx, double *Hy, double *Hz){
   
@@ -1264,11 +1244,7 @@ int interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double
   res3 = interp1(Hyx[k-1][j][i+1]+Hyz[k-1][j][i+1],Hyx[k-1][j][i]+Hyz[k-1][j][i],Hyx[k-1][j][i-1]+Hyz[k-1][j][i-1],Hyx[k-1][j][i-2]+Hyz[k-1][j][i-2]);
   res4 = interp1(Hyx[k-2][j][i+1]+Hyz[k-2][j][i+1],Hyx[k-2][j][i]+Hyz[k-2][j][i],Hyx[k-2][j][i-1]+Hyz[k-2][j][i-1],Hyx[k-2][j][i-2]+Hyz[k-2][j][i-2]);
   *Hy  = interp1(res1, res2, res3, res4);
-  
- 
   *Hz  = interp1(Hzx[k][j][i+1]+Hzy[k][j][i+1],Hzx[k][j][i]+Hzy[k][j][i],Hzx[k][j][i-1]+Hzy[k][j][i-1],Hzx[k][j][i-1]+Hzy[k][j][i-1]);
-
-  return 0;
 }
 
 
@@ -1279,7 +1255,7 @@ int interpolateTimeDomainFieldCentralH_2Dy( double ***Hxy, double ***Hxz, double
  *
  *[out]Hx to Hz are the field components interpolated to the origin of the Yee cell
  */
-int interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					   int i, int j, int k,
 					   double *Hx, double *Hy, double *Hz){
   
@@ -1294,8 +1270,6 @@ int interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double 
   res3 = interp1(Hzx[k][j-1][i+1]+Hzy[k][j-1][i+1],Hzx[k][j-1][i]+Hzy[k][j-1][i],Hzx[k][j-1][i-1]+Hzy[k][j-1][i-1],Hzx[k][j-1][i-2]+Hzy[k][j-1][i-2]);
   res4 = interp1(Hzx[k][j-2][i+1]+Hzy[k][j-2][i+1],Hzx[k][j-2][i]+Hzy[k][j-2][i],Hzx[k][j-2][i-1]+Hzy[k][j-2][i-1],Hzx[k][j-2][i-2]+Hzy[k][j-2][i-2]);
   *Hz  = interp1(res1, res2, res3, res4);
-
-  return 0;
 }
 
 /*Interpolate the electric field to the origin of the Yee cell in the time domain
@@ -1305,7 +1279,7 @@ int interpolateTimeDomainFieldCentralH_TE( double ***Hxy, double ***Hxz, double 
  *
  *[out]Hx to Hz are the field components interpolated to the origin of the Yee cell
  */
-int interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
+void interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double ***Hyx, double ***Hyz, double ***Hzx, double ***Hzy,
 					   int i, int j, int k,
 					   double *Hx, double *Hy, double *Hz){
   
@@ -1313,8 +1287,6 @@ int interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double 
   *Hx  = interp1(Hxy[k][j-2][i]+Hxz[k][j-2][i], Hxy[k][j-1][i]+Hxz[k][j-1][i], Hxy[k][j][i]+Hxz[k][j][i], Hxy[k][j+1][i]+Hxz[k][j+1][i]); 
   *Hy  = interp1(Hyx[k][j][i-2]+Hyz[k][j][i-2], Hyx[k][j][i-1]+Hyz[k][j][i-1], Hyx[k][j][i]+Hyz[k][j][i], Hyx[k][j][i+1]+Hyz[k][j][i+1]);
   *Hz  = 0.;
-
-  return 0;
 }
 
 /*Interpolate the electric field to the origin of the Yee cell in the time domain
@@ -1325,15 +1297,13 @@ int interpolateTimeDomainFieldCentralH_TM( double ***Hxy, double ***Hxz, double 
  *[out]Ex to Ez are the field components interpolated to the origin of the Yee cell
  *
  */
-int interpolateTimeDomainFieldCentralE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					 int i, int j, int k,
 					 double *Ex, double *Ey, double *Ez){
  
   *Ex = interp1(Exy[k][j][i-2]+Exz[k][j][i-2], Exy[k][j][i-1]+Exz[k][j][i-1], Exy[k][j][i]+Exz[k][j][i], Exy[k][j][i+1]+Exz[k][j][i+1]);
   *Ey = interp1(Eyx[k][j-2][i]+Eyz[k][j-2][i], Eyx[k][j-1][i]+Eyz[k][j-1][i], Eyx[k][j][i]+Eyz[k][j][i], Eyx[k][j+1][i]+Eyz[k][j+1][i]);
   *Ez = interp1(Ezy[k-2][j][i]+Ezx[k-2][j][i], Ezy[k-1][j][i]+Ezx[k-1][j][i], Ezy[k][j][i]+Ezx[k][j][i], Ezy[k+1][j][i]+Ezx[k+1][j][i]);
-		
-  return 0;
 }
 
 
@@ -1345,7 +1315,7 @@ int interpolateTimeDomainFieldCentralE(  double ***Exy, double ***Exz, double **
  *[out]Ex to Ez are the field components interpolated to the origin of the Yee cell
  *
  */
-int interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					 int i, int j, int k,
 					 double *Ex, double *Ey, double *Ez){
   
@@ -1370,8 +1340,7 @@ int interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz
     }
     *Ey = (Eyx[k][j][i]+Eyz[k][j][i]);
   }
-  		
-  return 0;
+
 }
 
 /*Interpolate the electric field to the origin of the Yee cell in the time domain
@@ -1382,14 +1351,12 @@ int interpolateTimeDomainFieldCentralEBandLimited(  double ***Exy, double ***Exz
  *[out]Ex to Ez are the field components interpolated to the origin of the Yee cell
  *
  */
-int interpolateTimeDomainFieldCentralE_2Dy(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_2Dy(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					 int i, int j, int k,
 					 double *Ex, double *Ey, double *Ez){
   *Ex = interp1(Exy[k][j][i-2]+Exz[k][j][i-2], Exy[k][j][i-1]+Exz[k][j][i-1], Exy[k][j][i]+Exz[k][j][i], Exy[k][j][i+1]+Exz[k][j][i+1]);
   *Ey = Eyx[k][j][i]+Eyz[k][j][i];
   *Ez = interp1(Ezy[k-2][j][i]+Ezx[k-2][j][i], Ezy[k-1][j][i]+Ezx[k-1][j][i], Ezy[k][j][i]+Ezx[k][j][i], Ezy[k+1][j][i]+Ezx[k+1][j][i]);
-		
-  return 0;
 }
 
 
@@ -1401,15 +1368,13 @@ int interpolateTimeDomainFieldCentralE_2Dy(  double ***Exy, double ***Exz, doubl
  *[out]Ex to Ez are the field components interpolated to the origin of the Yee cell
  *
  */
-int interpolateTimeDomainFieldCentralE_TE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_TE(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					    int i, int j, int k,
 					    double *Ex, double *Ey, double *Ez){
  
   *Ex = interp1(Exy[k][j][i-2]+Exz[k][j][i-2], Exy[k][j][i-1]+Exz[k][j][i-1], Exy[k][j][i]+Exz[k][j][i], Exy[k][j][i+1]+Exz[k][j][i+1]);
   *Ey = interp1(Eyx[k][j-2][i]+Eyz[k][j-2][i], Eyx[k][j-1][i]+Eyz[k][j-1][i], Eyx[k][j][i]+Eyz[k][j][i], Eyx[k][j+1][i]+Eyz[k][j+1][i]);
   *Ez = 0.;
-		
-  return 0;
 }
 
 /*Interpolate the electric field to the origin of the Yee cell in the time domain
@@ -1420,37 +1385,11 @@ int interpolateTimeDomainFieldCentralE_TE(  double ***Exy, double ***Exz, double
  *[out]Ex to Ez are the field components interpolated to the origin of the Yee cell
  *
  */
-int interpolateTimeDomainFieldCentralE_TM(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
+void interpolateTimeDomainFieldCentralE_TM(  double ***Exy, double ***Exz, double ***Eyx, double ***Eyz, double ***Ezx, double ***Ezy,
 					    int i, int j, int k,
 					    double *Ex, double *Ey, double *Ez){
  
   *Ex = 0.;
   *Ey = 0.;
   *Ez = Ezy[k][j][i]+Ezx[k][j][i];
-		
-  return 0;
 }
-
-/*
-
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs,const mxArray *prhs[]){
-int i_l, i_u, j_l, j_u, k_l, k_u;
-
-i_l = ((int) *(mxGetPr(prhs[3])));
-i_u = ((int) *(mxGetPr(prhs[4])));
-
-j_l = ((int) *(mxGetPr(prhs[5])));
-j_u = ((int) *(mxGetPr(prhs[6])));
-
-  
-k_l = ((int) *(mxGetPr(prhs[7])));
-k_u = ((int) *(mxGetPr(prhs[8])));
-
- 
-mxInterpolateFieldCentralH( (mxArray *)prhs[0] , (mxArray *)prhs[1] , (mxArray *)prhs[2]  ,
-&plhs[0], &plhs[1], &plhs[2] ,
-i_l, i_u, j_l, j_u, k_l, k_u);
-
-}
-
-*/


### PR DESCRIPTION
Starts a refactor of `interpolate.cpp` by removing the unused return codes in favour of void functions that throw runtime errors. Given the reasonably sized diff I think it's perhaps worth reviewing this first and merging, rather than waiting to add everything in #44 in(?)