### PR TITLE
#54 run_pstd_bscan.m now creates missing directories

### DIFF
--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -31,7 +31,7 @@ save('gridfile_cyl', 'composition_matrix', 'material_matrix');
 composition_matrix = [];
 save(sprintf('gridfile_fs'), 'composition_matrix', 'material_matrix');
 
-%generate C input files and save to directory in/
+%generate tdms executable input files
 [fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in_pstd_cyl','gridfile_cyl.mat','');
 [fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in_pstd_fs','gridfile_fs.mat','');
 

--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -29,7 +29,7 @@ material_matrix = [1 refind^2 1 0 0 0     0     0     0 0 0];
 save('gridfile_cyl', 'composition_matrix', 'material_matrix');
 %setup free space matrix and save to directory gridfiles/
 composition_matrix = [];
-save(sprintf('gridfile_fs'), 'composition_matrix', 'material_matrix');
+save('gridfile_fs', 'composition_matrix', 'material_matrix');
 
 %generate tdms executable input files
 [fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in_pstd_cyl','gridfile_cyl.mat','');

--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -25,13 +25,26 @@ inds = find(I(:));
 [ii,jj,kk] = ind2sub(size(I), inds);
 composition_matrix = [ii jj kk ones(size(ii))];
 material_matrix = [1 refind^2 1 0 0 0     0     0     0 0 0];
-save(sprintf('gridfiles/gridfile_cyl'), 'composition_matrix', 'material_matrix');
 
-%setup free space matrix
+%check whether the directories gridfiles/, in/, and out/ exist before we
+%attempt to save to them.
+%if they do not exist, create them
+if ~exist('gridfiles', 'dir')
+    mkdir gridfiles;
+end %if (directory gridfiles/ exists)
+if ~exist('in', 'dir')
+    mkdir in;
+end %if (directory in/ exists
+if ~exist('out', 'dir')
+    mkdir out;
+end %if (directory out/ exists
+
+save(sprintf('gridfiles/gridfile_cyl'), 'composition_matrix', 'material_matrix');
+%setup free space matrix and save to directory gridfiles/
 composition_matrix = [];
 save(sprintf('gridfiles/gridfile_fs'), 'composition_matrix', 'material_matrix');
 
-%generate C input files
+%generate C input files and save to directory in/
 [fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in/pstd_cyl','gridfiles/gridfile_cyl.mat','');
 [fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in/pstd_fs','gridfiles/gridfile_fs.mat','');
 

--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -26,7 +26,7 @@ inds = find(I(:));
 composition_matrix = [ii jj kk ones(size(ii))];
 material_matrix = [1 refind^2 1 0 0 0     0     0     0 0 0];
 
-save(sprintf('gridfile_cyl'), 'composition_matrix', 'material_matrix');
+save('gridfile_cyl', 'composition_matrix', 'material_matrix');
 %setup free space matrix and save to directory gridfiles/
 composition_matrix = [];
 save(sprintf('gridfile_fs'), 'composition_matrix', 'material_matrix');

--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -26,38 +26,25 @@ inds = find(I(:));
 composition_matrix = [ii jj kk ones(size(ii))];
 material_matrix = [1 refind^2 1 0 0 0     0     0     0 0 0];
 
-%check whether the directories gridfiles/, in/, and out/ exist before we
-%attempt to save to them.
-%if they do not exist, create them
-if ~exist('gridfiles', 'dir')
-    mkdir gridfiles;
-end %if (directory gridfiles/ exists)
-if ~exist('in', 'dir')
-    mkdir in;
-end %if (directory in/ exists
-if ~exist('out', 'dir')
-    mkdir out;
-end %if (directory out/ exists
-
-save(sprintf('gridfiles/gridfile_cyl'), 'composition_matrix', 'material_matrix');
+save(sprintf('gridfile_cyl'), 'composition_matrix', 'material_matrix');
 %setup free space matrix and save to directory gridfiles/
 composition_matrix = [];
-save(sprintf('gridfiles/gridfile_fs'), 'composition_matrix', 'material_matrix');
+save(sprintf('gridfile_fs'), 'composition_matrix', 'material_matrix');
 
 %generate C input files and save to directory in/
-[fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in/pstd_cyl','gridfiles/gridfile_cyl.mat','');
-[fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in/pstd_fs','gridfiles/gridfile_fs.mat','');
+[fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in_pstd_cyl','gridfile_cyl.mat','');
+[fdtdgrid, Exs,Eys,Ezs,Hxs,Hys,Hzs,grid_labels,camplitudes,vertices,facets,Id] = iteratefdtd_matrix('pstd_input_file.m','filesetup','in_pstd_fs','gridfile_fs.mat','');
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %Now run the executeables
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-eval('!tdms in/pstd_fs.mat out/pstd_fs.mat');
-eval('!tdms in/pstd_cyl.mat out/pstd_cyl.mat');
+eval('!tdms in_pstd_fs.mat out_pstd_fs.mat');
+eval('!tdms in_pstd_cyl.mat out_pstd_cyl.mat');
 
 %plot the data
-dat_cyl = load('out/pstd_cyl');
-dat_fs = load('out/pstd_fs');
+dat_cyl = load('out_pstd_cyl');
+dat_fs = load('out_pstd_fs');
 
 figure(1);clf;
 subplot(2,1,1);


### PR DESCRIPTION
#54 Fixes error thrown in `run_pstd_bscan.m` by getting MATLAB to create the directories `gridfiles/`, `in/`, and `out/`, if they do not exist prior to running the script.

Also some other things I'm dumping here as afterthoughts:
- Rather than displaying the figures in MATLAB, we could just save them as images? This would mean the MATLAB GUI wouldn't need to load up every time, and we can stick to something like `matlab -nodesktop -nosplash -r run_pstd_bscan` in the command line.
- On a note related to the above, MATLAB does not exit upon completion of a script, unless you explicitly give it the `exit()` command at the end of the script!