### PR TITLE
Use CMake `CTest` module to choose whether to build tests

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tests:
-    name: Test - ${{ matrix.os }} - ${{ matrix.build_type }}
+    name: Test - ${{ matrix.os }} - Build type ${{ matrix.build_type }} - Build testing ${{ matrix.build_testing }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -17,8 +17,10 @@ jobs:
         os:
           - ubuntu-latest
         build_type:
-          - Test
           - Release
+        build_testing:
+          - ON
+          - OFF
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -53,7 +55,7 @@ jobs:
         env:
           CXXFLAGS: -Werror
         run: |
-          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING=${{ matrix.build_testing }}
 
       - name: Build TDMS
         working-directory: ${{runner.workspace}}/build
@@ -62,7 +64,7 @@ jobs:
           cmake --build . --config ${{ matrix.build_type }}
 
       - name: Run TDMS unit tests
-        if: matrix.build_type == 'Test'
+        if: matrix.build_testing == 'ON'
         working-directory: ${{runner.workspace}}/build
         run: |
           export OMP_NUM_THREADS=1

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -9,8 +9,17 @@ on:
 
 jobs:
   tests:
-    name: Test - Windows - Release
-    runs-on: windows-latest
+    name: Test - ${{ matrix.os }} - Build type ${{ matrix.build_type }} - Build testing ${{ matrix.build_testing }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+        build_type:
+          - Release
+        build_testing:
+          - OFF
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -50,7 +59,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Release
+          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING=${{ matrix.build_testing }}
 
       - name: Build TDMS
         working-directory: ${{runner.workspace}}/build

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(tdms LANGUAGES CXX)
+include(CTest)
 
 # Allow RPATH on mac
 set(CMAKE_MACOSX_RPATH TRUE)
@@ -72,7 +73,7 @@ set(SOURCES
     matlabio/matlabio.cpp
     )
 
-if (CMAKE_BUILD_TYPE STREQUAL "Test")
+if (BUILD_TESTING)
     test_target()
 else()
     release_target()
@@ -95,7 +96,7 @@ endif()
 install(TARGETS tdms)
 
 # Testing ---------------------------------------------------------------------
-if (CMAKE_BUILD_TYPE STREQUAL "Test")
+if (BUILD_TESTING)
     enable_testing()
 
     add_executable(tdms_tests


### PR DESCRIPTION
This is a more standard way to enable/disable CMake tests, instead of (ab)using the build type.