### PR TITLE
Adds a spdlog logging

### DIFF
--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -62,15 +62,16 @@ endif()
 
 
 # spdlog ----------------------------------------------------------------------
-find_package(spdlog NO_CMAKE_PACKAGE_REGISTRY)
+find_package(spdlog NO_CMAKE_PACKAGE_REGISTRY QUIET)
 if(NOT spdlog_FOUND)
     include(FetchContent)
     FetchContent_Declare(spdlog
             GIT_REPOSITORY https://github.com/gabime/spdlog.git
-            GIT_TAG v1.3.1
+            GIT_TAG v1.10.0
             )
     FetchContent_MakeAvailable(spdlog)
 endif()
+
 # Set the active logging level
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Test")
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -75,8 +75,9 @@ if(NOT spdlog_FOUND)
     FetchContent_MakeAvailable(spdlog)
 endif()
 
-# Set the active logging level
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+# Set the active logging level to debug if required
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"
+        OR "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
 else()
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -61,6 +61,24 @@ else()
 endif()
 
 
+# spdlog ----------------------------------------------------------------------
+find_package(spdlog NO_CMAKE_PACKAGE_REGISTRY)
+if(NOT spdlog_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(spdlog
+            GIT_REPOSITORY https://github.com/gabime/spdlog.git
+            GIT_TAG v1.3.1
+            )
+    FetchContent_MakeAvailable(spdlog)
+endif()
+# Set the active logging level
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Test")
+    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+else()
+    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+endif()
+
+
 # TDMS target -----------------------------------------------------------------
 set(SOURCES
     src/argument_parser.cpp

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -76,7 +76,7 @@ if(NOT spdlog_FOUND)
 endif()
 
 # Set the active logging level
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL ""${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
 else()
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -10,6 +10,9 @@ include(CTest)
 # Allow RPATH on mac
 set(CMAKE_MACOSX_RPATH TRUE)
 
+# Add -fPIC flag
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Append the cmake/ directory to the search path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/targets.cmake)

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -76,7 +76,7 @@ if(NOT spdlog_FOUND)
 endif()
 
 # Set the active logging level
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Test")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR "${CMAKE_BUILD_TYPE}" STREQUAL ""${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"")
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
 else()
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)

--- a/tdms/cmake/targets.cmake
+++ b/tdms/cmake/targets.cmake
@@ -49,6 +49,10 @@ function(test_target)
             )
 
     target_link_libraries(tdms tdms_lib)
-    target_compile_options(tdms_lib PUBLIC -DMX_COMPAT_32 -c ${DFLAG} -O3)
+    target_compile_options(tdms_lib PUBLIC
+            -c ${DFLAG}
+            -O3
+            -DSPDLOG_BUILD_SHARED=ON
+            -DMX_COMPAT_32)
 
 endfunction()

--- a/tdms/cmake/targets.cmake
+++ b/tdms/cmake/targets.cmake
@@ -10,6 +10,7 @@ function(release_target)
             ${Matlab_MAT_LIBRARY}
             ${LIBCXX_LIBRARY}
             OpenMP::OpenMP_CXX
+            spdlog::spdlog
             )
 endfunction()
 
@@ -19,7 +20,7 @@ function(test_target)
         message(FATAL_ERROR Cannot build TDMS tests on Windows)
     endif(WIN32)
 
-    # catch2 tests ----------------------------------------------------------------
+    # catch2 tests ------------------------------------------------------------
     Include(FetchContent)
 
     FetchContent_Declare(
@@ -44,6 +45,7 @@ function(test_target)
             ${Matlab_MAT_LIBRARY}
             ${LIBCXX_LIBRARY}
             OpenMP::OpenMP_CXX
+            spdlog::spdlog
             )
 
     target_link_libraries(tdms tdms_lib)

--- a/tdms/src/argument_parser.cpp
+++ b/tdms/src/argument_parser.cpp
@@ -1,4 +1,5 @@
-#include "stdexcept"
+#include <stdexcept>
+#include <spdlog/spdlog.h>
 #include "argument_parser.h"
 
 using namespace std;
@@ -7,6 +8,7 @@ using namespace std;
 ArgumentParser::ArgumentParser() = default;
 
 ArgumentNamespace ArgumentParser::parse_args(int n_args, char *arg_ptrs[]) {
+  spdlog::debug("Parsing {} command line arguments", n_args);
 
   auto args = ArgumentNamespace(n_args, arg_ptrs);
 

--- a/tdms/src/argument_parser.cpp
+++ b/tdms/src/argument_parser.cpp
@@ -17,6 +17,10 @@ ArgumentNamespace ArgumentParser::parse_args(int n_args, char *arg_ptrs[]) {
     exit(0);
   }
 
+  if (args.have_flag("-q")){  // quiet operation
+    spdlog::set_level(spdlog::level::off);
+  }
+
   if (!args.have_correct_number_of_filenames()){
     fprintf(stderr,"Incorrect number of arguments. See below for help\n\n");
     print_help_message();
@@ -37,6 +41,7 @@ ArgumentNamespace ArgumentParser::parse_args(int n_args, char *arg_ptrs[]) {
             args.have_flag("-m"));
   }
 
+  spdlog::debug("Finished parsing arguments");
   return args;
 }
 
@@ -46,6 +51,7 @@ void ArgumentParser::print_help_message(){
                  "openandorder [options] infile gridfile outfile\n"
                  "Options:\n"
                  "-h:\tDisplay this help message\n"
+                 "-q:\tQuiet operation. Silence all logging\n"
                  "-m:\tMinimise output file size by not saving vertex and facet information\n\n");
 }
 

--- a/tdms/src/openandorder.cpp
+++ b/tdms/src/openandorder.cpp
@@ -5,6 +5,7 @@
  *                 the mexFunction and writing the output to the
  *                 specified output file.
  ******************************************************************/
+#include <spdlog/spdlog.h>
 #include "cstdio"
 #include "stdexcept"
 #include "utils.h"
@@ -21,6 +22,13 @@ using namespace std;
 
 
 int main(int nargs, char *argv[]){
+
+  // Set the logging level with a compile-time define for debugging
+  #if SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_DEBUG
+    spdlog::set_level(spdlog::level::debug);
+  #elif SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_INFO
+    spdlog::set_level(spdlog::level::info);
+  #endif
 
   /*
     There are two cases to consider, when the fdtdgrid matrix is specified in a separate mat file


### PR DESCRIPTION
This PR adds a logging library, specifically [spdlog](https://github.com/gabime/spdlog) to e.g. allow for debug logging to be turned on/off depending on the build type. I've tried this out by both brew installing spdlog (and defining `spdlog_DIR` for CMake to find it) and also letting `FetchContent_MakeAvailable` do it's thing and both seem to work well. To turn on debug logging:

```
cmake <other args> -DCMAKE_BUILD_TYPE=Debug
```

To silence all logging (excellent suggestion from @samcunliffe !) run the executable with

```bash
tdms input.mat output.mat -q
```

***

Also includes simple example usage in the argument parser, just for an outline. Seems like it's thread safe too:

```diff
--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -32,6 +32,9 @@
 #include "numerical_derivative.h"
 #include <time.h>
 
+#include <spdlog/spdlog.h>^M

 using namespace std;
 #include "globals.h"
 #include "matlabio.h"
@@ -6505,6 +6508,8 @@ void extractPhasorsVolume(double ***ExR, double ***ExI, double ***EyR, double **
     for(int k=k_l; k<= k_u; k++)
       for(int j=j_l; j<= j_u; j++)
        for(int i=i_l; i<= i_u; i++){
+          spdlog::debug("here in the loop {} {} {}", i, j, k);
```

```
...
[2022-09-06 14:14:05.108] [debug] here in the loop 12 0 12
[2022-09-06 14:14:05.108] [debug] here in the loop 13 0 12
...
```
