### PR TITLE
Fix to steady state mode

### DIFF
--- a/tdms/src/electric_field.cpp
+++ b/tdms/src/electric_field.cpp
@@ -10,7 +10,9 @@ void ElectricField::add_to_angular_norm(double f, int n, int Nt, SimulationParam
 }
 
 complex<double> ElectricField::phasor_norm(double f, int n, double omega, double dt, int Nt){
+  //fprintf(stderr,"omega=%e, dt=%e, n=%d\n", omega,dt,n); 
   return f
          * exp( fmod(omega*((double) (n+1))*dt, 2*dcpi) * I)
          * 1./((double) Nt);
+  
 }

--- a/tdms/src/electric_field.cpp
+++ b/tdms/src/electric_field.cpp
@@ -10,7 +10,6 @@ void ElectricField::add_to_angular_norm(double f, int n, int Nt, SimulationParam
 }
 
 complex<double> ElectricField::phasor_norm(double f, int n, double omega, double dt, int Nt){
-  //fprintf(stderr,"omega=%e, dt=%e, n=%d\n", omega,dt,n); 
   return f
          * exp( fmod(omega*((double) (n+1))*dt, 2*dcpi) * I)
          * 1./((double) Nt);

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -2508,6 +2508,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
     dt_old = dt[0];
     Nsteps_tmp = ceil(2.*dcpi/omega_an[0]/dt[0]*3);
     dt[0] = 2.*dcpi/omega_an[0]*3/Nsteps_tmp;
+    params.dt = dt[0];
   }
   
   //fprintf(stderr,"Pre 16\n");
@@ -5761,12 +5762,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
 
     if( exphasorssurface || exphasorsvolume || exdetintegral || (nvertices > 0) ){
       if(sourcemode==sm_steadystate){
-        E.add_to_angular_norm(fte, tind, Nsteps, params);
-        H.add_to_angular_norm(fth, tind, Nsteps, params);
+	if( (tind % Nsteps)==0 ){
+	  E.angular_norm = 0.0;
+	  H.angular_norm = 0.0;
+	}
+	
+        E.add_to_angular_norm(fte, tind % Nsteps, Nsteps, params);
+        H.add_to_angular_norm(fth, tind % Nsteps, Nsteps, params);
 
         for(int ifx=0;ifx<N_f_ex_vec;ifx++){
-          extractPhasorENorm(&E_norm[ifx], fte, tind, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
-          extractPhasorHNorm(&H_norm[ifx], fth, tind, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
+          extractPhasorENorm(&E_norm[ifx], fte, tind % Nsteps, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
+          extractPhasorHNorm(&H_norm[ifx], fth, tind % Nsteps, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
         }
       }
       else{
@@ -5978,7 +5984,6 @@ if(runmode == rm_complete && (nvertices>0) )
       }
     }
   }
-  
   //fprintf(stderr,"Pos 15\n");
   //noe set the output
   ndims   = 2;

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -5762,17 +5762,65 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]){
 
     if( exphasorssurface || exphasorsvolume || exdetintegral || (nvertices > 0) ){
       if(sourcemode==sm_steadystate){
+	/*
+	  Each time a new acquisition period of harmonic illumination begins, all complex amplitudes (volume, surface etc.) are set back to 0 since the discrete Fourier transforms used to acquire these complex amplitudes starts again. In particular, the returned complex amplitudes will have been acquired during a single acquisition period of harmonic illumination. Note that, as explained above, the acquisition period is actually three periods of the harmonic waves fundamental period. The complex amplitudes are reset to 0 using calls such as: 
+
+initialiseDouble3DArray(ExR, dims[0], dims[1], dims[2]);
+
+However, the normalisation factors are reset to 0 here.
+	 */
+	
 	if( (tind % Nsteps)==0 ){
 	  E.angular_norm = 0.0;
 	  H.angular_norm = 0.0;
+
+	  for(int ifx=0;ifx<N_f_ex_vec;ifx++){
+	    E_norm[ifx] = 0.;
+	    H_norm[ifx] = 0.;
+	  }
 	}
+
+	/*In the calls below, the following two lines of code are equivalent up to numerical precision:
+
+	  E.add_to_angular_norm(fte, tind, Nsteps, params);
+	  E.add_to_angular_norm(fte, tind % Nsteps, Nsteps, params);
+
+	  To understand why, first consult the lines of code above:
+
+	  Nsteps_tmp = ceil(2.*dcpi/omega_an[0]/dt[0]*3);
+	  dt[0] = 2.*dcpi/omega_an[0]*3/Nsteps_tmp;
+	  Nsteps = (int)lround(Nsteps_tmp);
+
+	  Where dt and Nsteps are set. The reason for the factor of 3 is that we will perform complex amplitude extraction over 3 fundamental periods of the monochromatic source. We can then make the following statement:
+
+	  T/dt*3=1/(f*dt)*3=Nsteps
+
+	  where T and f (omega=2*pi*f) are the period and frequency of the monochromatic source, respectively.
+
+	  Then consider the argument of the exponentional function on phasor_norm, called by add_to_angular_norm, where tind=n is used:
+
+	  i*omega*((double) (n+1))*dt (where fmod(.,2*dcpi) is ignored since this will not affect the result)
+
+	  The argument of this function simplifies to:
+
+	  i*omega*(tind+1)*dt=i*2*pi*f*(tind+1)*dt=i*2*pi*(tind+1)*3/Nsteps (using f*dt=3/Nsteps)
+
+	  Then, without loss of generallity, let tind = p*Nsteps + q, substituting into the above
+
+	  i*2*pi*(tind+1)*3/Nsteps = i*2*pi*(p*Nsteps + q)*3/Nsteps = i*2*pi*3*p + i*2*pi*q*3/Nsteps
+
+	  In which case exp(i*2*pi*3*p + i*2*pi*q*3/Nsteps) = exp(i*2*pi*q*3/Nsteps)
+
+	  If instead we use tind % Nsteps=n, we see that n=q, leading to the same exponential function as above. So the two cases are equivalent.
+	  
+	 */
 	
-        E.add_to_angular_norm(fte, tind % Nsteps, Nsteps, params);
-        H.add_to_angular_norm(fth, tind % Nsteps, Nsteps, params);
+        E.add_to_angular_norm(fte, tind, Nsteps, params);
+        H.add_to_angular_norm(fth, tind, Nsteps, params);
 
         for(int ifx=0;ifx<N_f_ex_vec;ifx++){
-          extractPhasorENorm(&E_norm[ifx], fte, tind % Nsteps, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
-          extractPhasorHNorm(&H_norm[ifx], fth, tind % Nsteps, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
+          extractPhasorENorm(&E_norm[ifx], fte, tind, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
+          extractPhasorHNorm(&H_norm[ifx], fth, tind, f_ex_vec[ifx]*2*dcpi, *dt, Nsteps);
         }
       }
       else{

--- a/tdms/tests/system/test_arc08.py
+++ b/tdms/tests/system/test_arc08.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-import pytest
 from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
 
 ZIP_PATH = Path(os.path.dirname(os.path.abspath(__file__)), "data", "arc_08.zip")
@@ -10,7 +9,6 @@ if not ZIP_PATH.exists():
     download_data("https://zenodo.org/record/7086087/files/arc_08.zip", to=ZIP_PATH)
 
 
-@pytest.mark.skip(reason="Currently failing for known reasons.")
 @work_in_zipped_dir(ZIP_PATH)
 def test_fs():
     """Ensure that the free space stady-state PSTD output matches the reference"""
@@ -23,7 +21,6 @@ def test_fs():
     ), "The free space, steady-state PSTD output doesn't match the reference."
 
 
-@pytest.mark.skip(reason="Currently failing for known reasons.")
 @work_in_zipped_dir(ZIP_PATH)
 def test_sph():
     """Ensure that the spherical steady-state PSTD output matches the reference."""


### PR DESCRIPTION
I updated the code so that steady state mode is now correct. I picked up a bug introduced during recent refactoring work, whereby there are now two variables storing dt, in particular:

params.dt
dt

both are used. This becomes a problem since in some instances dt can be changed within the code. After refactoring, params.dt was not updated, leading to incorrect behaviour. I will add this as an issue.