### PR TITLE
Adding steady state tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 **cmake-build**
 tdms/tests/system/data
 **-eps-converted-to.pdf
+html/

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -55,10 +55,21 @@ firefox html/index.html # or your web browser of choice
 You should be able to find and read what you've changed.
 Don't worry about doxygen for the source files (although obviously please do write helpful comments there).
 
-For Python code (e.g. in the tests) we use [black](https://black.readthedocs.io/en/stable/) to enforce the code style.
-To apply automatic code styling to staged changes in git use [`pre-commit`](https://pre-commit.com/).
+For Python code (e.g. in the [tests](#system-tests)) we use [black](https://black.readthedocs.io/en/stable/) to enforce the code style.
+To apply automatic code styling to staged changes in git we recommend [`pre-commit`](https://pre-commit.com/).
+If you don't have it already:
+```{.sh}
+pip3 install pre-commit
+```
 
-### Compiling and debugging
+Then from the root repository directory you can add the pre-commit hooks with
+```{.sh}
+ls .git/hooks
+pre-commit install
+ls .git/hooks
+```
+
+### Compiling and debugging {#compiling}
 
 Once you've checked the code out, compile with:
 ```{.sh}
@@ -86,3 +97,46 @@ spdlog::debug("Send help");
 
 The C++ `main` function is in openandorder.cpp <!-- words with a dot in them are assumed to be files so this will hyperlink to openandorder.cpp iff *that* file is also documented. --> however this only really does file I/O and setup.
 The main FDTD algorithm code is in iterator.cpp <!-- won't be linked as an undocumented file doesn't exist for doxygen... this is fine, we can link to the real file in github.--> and classes included therein.
+
+## Testing
+
+We have two [levels of tests](https://en.wikipedia.org/wiki/Software_testing#Testing_levels): unit tests, and full system tests.
+
+### Unit 
+The unit tests use [catch2](https://github.com/catchorg/Catch2/blob/devel/docs/Readme.md#top) macros. See [tests/unit](https://github.com/UCL/TDMS/blob/main/tdms/tests/unit) for good examples in the actual test code, but as a rough sketch you need:
+
+```{.cpp}
+#include <catch2/catch_test_macros.hpp>
+#include "things_to_be_tested.h"
+
+TEST_CASE("Write a meaningful test case name") {
+    // set up function calls or whatever
+    REQUIRE_THROW(<something>)
+    CHECK(<something>)
+}
+```
+To run the unit tests, [compile](#compiling) with `-DBUILD_TESTING=ON` and then run `ctest` from the build directory or execute the test executable `./tdms_tests`.
+
+It's good practice, and reassuring for your pull-request reviewers, if new C++ functionality is at covered by unit tests.
+
+### System {#system-tests}
+
+The full system tests are written in Python 3, and call the `tdms` executable for known inputs and compare to expected outputs.
+We use [pytest](https://docs.pytest.org) and our example data is provided as zip files on [zenodo](https://zenodo.org/). 
+
+There are a few [python packages you will need](https://github.com/UCL/TDMS/blob/main/tdms/tests/requirements.txt) before running the tests so run:
+```{.sh}
+pip3 install -r tdms/tests/requirements.txt
+```
+if you don't already have them.
+
+When you run the tests for the first time, the example data will be downloaded to `tdms/tests/system/data` (which is [ignored by git](https://github.com/UCL/TDMS/blob/main/.gitignore)).
+Subsequent runs of the test will not redownload unless you manually delete the zip file.
+
+A good example of running the `tdms` executable for a given input and expected output is [test_arc01.py](https://github.com/UCL/TDMS/blob/main/tdms/tests/system/test_arc01.py)
+
+You need to [compile](#compiling) `tdms`, then the system tests can be run, e.g. from the build directory:
+
+```{.sh}
+py.test ../tests/system/
+```

--- a/tdms/tests/README.md
+++ b/tdms/tests/README.md
@@ -1,8 +1,0 @@
-# TDMS tests
-
-Once TDMS has been compiled and installed the system tests can be run with
-
-```bash
-pip install -r requirements.txt
-py.test system/
-```

--- a/tdms/tests/system/test_arc08.py
+++ b/tdms/tests/system/test_arc08.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+
+from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
+
+ZIP_PATH = Path(os.path.dirname(os.path.abspath(__file__)), "data", "arc_08.zip")
+
+if not ZIP_PATH.exists():
+    download_data("https://zenodo.org/record/7086087/files/arc_08.zip", to=ZIP_PATH)
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_fs():
+    """Ensure that the free space stady-state PSTD output matches the reference"""
+
+    run_tdms("arc_08/pstd_fs_steady_input_fast.mat", "pstd_fs_steady_output_fast.mat")
+
+    reference = HDF5File("arc_08/pstd_fs_steady_reference_output_fast.mat")
+    assert HDF5File("pstd_fs_steady_output_fast.mat").matches(
+        reference
+    ), "The free space, steady-state PSTD output doesn't match the reference."
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_sph():
+    """Ensure that the spherical steady-state PSTD output matches the reference."""
+
+    run_tdms("arc_08/pstd_sph_steady_input_fast.mat", "pstd_sph_steady_output_fast.mat")
+
+    reference = HDF5File("arc_08/pstd_sph_steady_reference_output_fast.mat")
+    assert HDF5File("pstd_sph_steady_output_fast.mat").matches(
+        reference
+    ), "The spherical steady-state PSTD output doesn't match the reference."

--- a/tdms/tests/system/test_arc08.py
+++ b/tdms/tests/system/test_arc08.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import pytest
 from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
 
 ZIP_PATH = Path(os.path.dirname(os.path.abspath(__file__)), "data", "arc_08.zip")
@@ -9,6 +10,7 @@ if not ZIP_PATH.exists():
     download_data("https://zenodo.org/record/7086087/files/arc_08.zip", to=ZIP_PATH)
 
 
+@pytest.mark.skip(reason="Currently failing for known reasons.")
 @work_in_zipped_dir(ZIP_PATH)
 def test_fs():
     """Ensure that the free space stady-state PSTD output matches the reference"""
@@ -21,6 +23,7 @@ def test_fs():
     ), "The free space, steady-state PSTD output doesn't match the reference."
 
 
+@pytest.mark.skip(reason="Currently failing for known reasons.")
 @work_in_zipped_dir(ZIP_PATH)
 def test_sph():
     """Ensure that the spherical steady-state PSTD output matches the reference."""


### PR DESCRIPTION
Adding system tests of the steady state mode. This is 1/4 of #30. Peter kindly provided a [fast version](https://github.com/UCL/TDMS/issues/30#issuecomment-1249187562) (physically meaningless, but can be used for testing).

Note that the test will *fail* until #94 is merged.

@dstansby, @giordano, @prmunro you're very welcome to join the review and/or comment if you have time to do so.

Since I'm tweaking the documentation, language/clarity and section logic comments are also very welcome. No comment is too picky or too minor.