### PR TITLE
Two more system tests.

### DIFF
--- a/doc/developers.md
+++ b/doc/developers.md
@@ -59,7 +59,7 @@ For Python code (e.g. in the [tests](#system-tests)) we use [black](https://blac
 To apply automatic code styling to staged changes in git we recommend [`pre-commit`](https://pre-commit.com/).
 If you don't have it already:
 ```{.sh}
-pip3 install pre-commit
+python -m pip install pre-commit
 ```
 
 Then from the root repository directory you can add the pre-commit hooks with
@@ -103,7 +103,9 @@ The main FDTD algorithm code is in iterator.cpp <!-- won't be linked as an undoc
 We have two [levels of tests](https://en.wikipedia.org/wiki/Software_testing#Testing_levels): unit tests, and full system tests.
 
 ### Unit 
-The unit tests use [catch2](https://github.com/catchorg/Catch2/blob/devel/docs/Readme.md#top) macros. See [tests/unit](https://github.com/UCL/TDMS/blob/main/tdms/tests/unit) for good examples in the actual test code, but as a rough sketch you need:
+The unit tests use [catch2](https://github.com/catchorg/Catch2/blob/devel/docs/Readme.md#top) macros. See [tests/unit](https://github.com/UCL/TDMS/blob/main/tdms/tests/unit) for good examples in the actual test code.
+
+To write a new test, as a rough sketch you need:
 
 ```{.cpp}
 #include <catch2/catch_test_macros.hpp>
@@ -115,7 +117,7 @@ TEST_CASE("Write a meaningful test case name") {
     CHECK(<something>)
 }
 ```
-To run the unit tests, [compile](#compiling) with `-DBUILD_TESTING=ON` and then run `ctest` from the build directory or execute the test executable `./tdms_tests`.
+To run the unit tests, [compile](#compiling) with `-DBUILD_TESTING=ON`. Then run `ctest` from the build directory or execute the test executable `./tdms_tests`.
 
 It's good practice, and reassuring for your pull-request reviewers, if new C++ functionality is at covered by unit tests.
 
@@ -126,17 +128,17 @@ We use [pytest](https://docs.pytest.org) and our example data is provided as zip
 
 There are a few [python packages you will need](https://github.com/UCL/TDMS/blob/main/tdms/tests/requirements.txt) before running the tests so run:
 ```{.sh}
-pip3 install -r tdms/tests/requirements.txt
+python -m pip install -r tdms/tests/requirements.txt
 ```
 if you don't already have them.
 
 When you run the tests for the first time, the example data will be downloaded to `tdms/tests/system/data` (which is [ignored by git](https://github.com/UCL/TDMS/blob/main/.gitignore)).
-Subsequent runs of the test will not redownload unless you manually delete the zip file.
+Subsequent runs of the test will not re-download unless you manually delete the zip file.
 
 A good example of running the `tdms` executable for a given input and expected output is [test_arc01.py](https://github.com/UCL/TDMS/blob/main/tdms/tests/system/test_arc01.py)
 
 You need to [compile](#compiling) `tdms`, then the system tests can be run, e.g. from the build directory:
 
 ```{.sh}
-py.test ../tests/system/
+pytest ../tests/system/
 ```

--- a/tdms/tests/system/test_arc09.py
+++ b/tdms/tests/system/test_arc09.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
+
+ZIP_PATH = Path(os.path.dirname(os.path.abspath(__file__)), "data", "arc_09.zip")
+
+if not ZIP_PATH.exists():
+    download_data("https://zenodo.org/record/7097063/files/arc_09.zip", to=ZIP_PATH)
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_fs():
+    """
+    Ensure that the free space PSTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+    """
+
+    run_tdms("arc_09/in/pstd_fs.mat", "pstd_fs_output.mat")
+
+    reference = HDF5File("arc_09/out/pstd_fs.mat")
+    assert HDF5File("pstd_fs_output.mat").matches(
+        reference
+    ), "The free space PSTD output with exdetintegral doesn't match the reference."
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_sc():
+    """
+    Ensure that the (FIXME ask Peter - SC) PSTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+    """
+
+    run_tdms("arc_09/in/pstd_sc.mat", "pstd_sc_output.mat")
+
+    reference = HDF5File("arc_09/out/pstd_sc.mat")
+    assert HDF5File("pstd_sc_output.mat").matches(
+        reference
+    ), "The sc PSTD output with exdetintegral doesn't match the reference."

--- a/tdms/tests/system/test_arc10.py
+++ b/tdms/tests/system/test_arc10.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+
+from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
+
+ZIP_PATH = Path(os.path.dirname(os.path.abspath(__file__)), "data", "arc_10.zip")
+
+if not ZIP_PATH.exists():
+    download_data("https://zenodo.org/record/7096040/files/arc_10.zip", to=ZIP_PATH)
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_fs():
+    """
+    Ensure that the free space PSTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+    """
+
+    run_tdms("arc_10/in/pstd_fs.mat", "pstd_fs_output.mat")
+
+    reference = HDF5File("arc_10/out/pstd_fs.mat")
+    assert HDF5File("pstd_fs_output.mat").matches(
+        reference
+    ), "The free space PSTD output with exi present doesn't match the reference."
+
+
+@work_in_zipped_dir(ZIP_PATH)
+def test_cyl():
+    """
+    Ensure that the cylinder PSTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+    """
+
+    run_tdms("arc_10/in/pstd_cyl.mat", "pstd_cyl_output.mat")
+
+    reference = HDF5File("arc_10/out/pstd_cyl.mat")
+    assert HDF5File("pstd_cyl_output.mat").matches(
+        reference
+    ), "The spherical PSTD output with exi present doesn't match the reference."

--- a/tdms/tests/system/utils.py
+++ b/tdms/tests/system/utils.py
@@ -36,7 +36,20 @@ class HDF5File(dict):
         super().__init__()
 
         with h5py.File(filepath, "r") as file:
-            self.update({k: self.to_numpy_array(v) for k, v in file.items()})
+            self.update({k: self.to_numpy_array(v) for k, v in self.traverse(file)})
+
+    def traverse(self, file_or_group, prefix=""):
+        """
+        Traverse the hdf5 file, when a group is encountered also traverse the
+        group (get all datasets).
+        """
+        for key in file_or_group.keys():
+            item = file_or_group[key]
+            path = f"{prefix}/{key}" if prefix else key
+            if isinstance(item, h5py.Dataset):
+                yield (path, item)
+            elif isinstance(item, h5py.Group):
+                yield from self.traverse(item, path)
 
     def to_numpy_array(self, dataset: h5py.Dataset) -> np.ndarray:
         """Convert a hdf5 dataset into a numpy array"""
@@ -67,7 +80,7 @@ class HDF5File(dict):
         arrays
         """
 
-        for key, value in self.items():
+        for key, value in self.traverse(self):
 
             if key not in other:
                 return False  # Key did not match

--- a/tdms/tests/system/utils.py
+++ b/tdms/tests/system/utils.py
@@ -8,7 +8,7 @@ from functools import wraps
 from pathlib import Path
 from platform import system
 from subprocess import PIPE, Popen
-from typing import Generator, Union
+from typing import Generator, Tuple, Union
 from urllib import request
 from zipfile import ZipFile
 
@@ -40,7 +40,7 @@ class HDF5File(dict):
 
     def traverse(
         self, file_or_group: Union[h5py.File, h5py.Group], prefix: str = ""
-    ) -> Generator[tuple[str, h5py.Dataset], None, None]:
+    ) -> Generator[Tuple[str, h5py.Dataset], None, None]:
         """
         Traverse the hdf5 file, when a group is encountered also traverse the
         group (get all datasets).

--- a/tdms/tests/system/utils.py
+++ b/tdms/tests/system/utils.py
@@ -8,7 +8,7 @@ from functools import wraps
 from pathlib import Path
 from platform import system
 from subprocess import PIPE, Popen
-from typing import Union
+from typing import Generator, Union
 from urllib import request
 from zipfile import ZipFile
 
@@ -38,7 +38,9 @@ class HDF5File(dict):
         with h5py.File(filepath, "r") as file:
             self.update({k: self.to_numpy_array(v) for k, v in self.traverse(file)})
 
-    def traverse(self, file_or_group, prefix=""):
+    def traverse(
+        self, file_or_group: Union[h5py.File, h5py.Group], prefix: str = ""
+    ) -> Generator[tuple[str, h5py.Dataset], None, None]:
         """
         Traverse the hdf5 file, when a group is encountered also traverse the
         group (get all datasets).


### PR DESCRIPTION
This PR is adds two more test cases provided by @prmunro (thanks!) and another 2/4 of #30: a test w/ exi present and a test w/ exdetintegral.

The first is very fast:
```
py.test tdms/tests/system/test_arc10.py  73.70s user 10.40s system 563% cpu 14.916 total
```

The second a little slower (but not the slowest):
```
py.test tdms/tests/system/test_arc09.py  704.33s user 40.89s system 681% cpu 1:49.37 total
py.test tdms/tests/system/test_arc03.py  1171.14s user 66.51s system 527% cpu 3:54.44 total
```
And notably I had to tweak the HDF5File class to cope with groups.