### PR TITLE
Obey the GIT_SSH option also for catch2.

### DIFF
--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -10,6 +10,12 @@ include(CTest)
 
 # Allow user to specify git access protocol (default to https)
 option(GIT_SSH "" OFF)
+if(GIT_SSH)
+    set(GITHUB_PREFIX git@github.com:)
+else()
+    set(GITHUB_PREFIX https://github.com/)
+endif()
+
 
 # Allow RPATH on mac
 set(CMAKE_MACOSX_RPATH TRUE)
@@ -69,12 +75,6 @@ endif()
 
 
 # spdlog ----------------------------------------------------------------------
-if(GIT_SSH)
-    set(GITHUB_PREFIX git@github.com:)
-else()
-    set(GITHUB_PREFIX https://github.com/)
-endif()
-
 find_package(spdlog NO_CMAKE_PACKAGE_REGISTRY QUIET)
 if(NOT spdlog_FOUND)
     include(FetchContent)

--- a/tdms/cmake/targets.cmake
+++ b/tdms/cmake/targets.cmake
@@ -25,7 +25,7 @@ function(test_target)
 
     FetchContent_Declare(
             Catch2
-            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+	    GIT_REPOSITORY ${GITHUB_PREFIX}catchorg/Catch2.git
             GIT_TAG        v3.0.1
     )
 

--- a/tdms/cmake/targets.cmake
+++ b/tdms/cmake/targets.cmake
@@ -25,7 +25,7 @@ function(test_target)
 
     FetchContent_Declare(
             Catch2
-	    GIT_REPOSITORY ${GITHUB_PREFIX}catchorg/Catch2.git
+            GIT_REPOSITORY ${GITHUB_PREFIX}catchorg/Catch2.git
             GIT_TAG        v3.0.1
     )
 


### PR DESCRIPTION
I missed this when testing #92. 

→ We also need to grab catch2 over ssh if the `GIT_SSH` option is set. 

This PR allows us to also build the tests on Myriad. Or if the user just prefers ssh.