### PR TITLE
Add FDTD test.

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -99,4 +99,3 @@ jobs:
         run: |
           export OMP_NUM_THREADS=1
           pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m fdtd_build_only
-          

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -93,3 +93,4 @@ jobs:
         run: |
           export OMP_NUM_THREADS=1
           pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m fdtd_build_only
+          

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -21,6 +21,10 @@ jobs:
         build_testing:
           - ON
           - OFF
+        # TODO: remove this once MATLAB dependency is removed and mexFunction is replaced
+        derivative_type:
+          - PS
+          - FD
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -55,7 +59,10 @@ jobs:
         env:
           CXXFLAGS: -Werror
         run: |
-          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING=${{ matrix.build_testing }}
+          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+           -DBUILD_TESTING=${{ matrix.build_testing }} \
+           -DDERIVATIVE_TYPE=${{ matrix.derivative_type }}
 
       - name: Build TDMS
         working-directory: ${{runner.workspace}}/build
@@ -70,9 +77,19 @@ jobs:
           export OMP_NUM_THREADS=1
           ctest -C ${{ matrix.build_type }} --output-on-failure --extra-verbose 
 
-      - name: Run TDMS system tests
+      # TODO: simplify this once MATLAB dependency is removed and mexFunction is replaced
+      - name: Run PSTD TDMS system tests
+        if: matrix.derivative_type == 'PS'
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
           export OMP_NUM_THREADS=1
-          py.test ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m "not fdtd_build_only"
+
+      - name: Run FDTD TDMS system tests
+        if: matrix.derivative_type == 'FD'
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          export OMP_NUM_THREADS=1
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m fdtd_build_only

--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -22,6 +22,10 @@ jobs:
         build_testing:
           - ON
           - OFF
+        # TODO: remove this once MATLAB dependency is removed and mexFunction is replaced
+        derivative_type:
+          - PS
+          - FD
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -58,7 +62,8 @@ jobs:
           cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON\
            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}\
            -DBUILD_TESTING=${{ matrix.build_testing }}\
-           -DOMP_ROOT=/usr/local/opt/llvm/ -DCXX_ROOT=/usr/local/opt/llvm
+           -DOMP_ROOT=/usr/local/opt/llvm/ -DCXX_ROOT=/usr/local/opt/llvm \
+           -DDERIVATIVE_TYPE=${{ matrix.derivative_type }}
 
       - name: Build TDMS
         working-directory: ${{runner.workspace}}/build
@@ -73,11 +78,21 @@ jobs:
           export OMP_NUM_THREADS=1
           ctest -C ${{ matrix.build_type }} --output-on-failure --extra-verbose
 
-      - name: Run TDMS system tests
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      # TODO: simplify this once MATLAB dependency is removed and mexFunction is replaced
+      - name: Run PSTD TDMS system tests
         # run system tests in mac only on pushes to main (they are a bit slow)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.derivative_type == 'PS' }}
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
           export OMP_NUM_THREADS=1
-          py.test ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m "not fdtd_build_only"
+
+      - name: Run FDTD TDMS system tests
+        # run system tests in mac only on pushes to main (they are a bit slow)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.derivative_type == 'FD' }}
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          export OMP_NUM_THREADS=1
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/ -s -x  -m fdtd_build_only

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -87,23 +87,17 @@ jobs:
         run: |
           cp Release/* .
 
-      # TODO: simplify this once MATLAB dependency is removed and mexFunction is replaced
-      - name: Run PSTD TDMS system tests
-        if: matrix.derivative_type == 'PS'
+      - name: Run CLI test
+        # For Windows, we skip the main system tests and just test the CLI
+        # note that if we decide to turn these back on, we need to split into
+        # two test steps and guard each one based on
+        # if: matrix.derivative_type == 'PS'
+        # or 'FD', and filter the pytest labels accordingly
+        # pytest <blah> -m fdtd_build_only
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
           export OMP_NUM_THREADS=1
           export PATH=$(dirname "$(which MATLAB)")/win64/:$PATH
           export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
-          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x -m "not fdtd_build_only"
-
-      - name: Run FDTD TDMS system tests
-        if: matrix.derivative_type == 'FD'
-        working-directory: ${{runner.workspace}}/build
-        shell: bash
-        run: |
-          export OMP_NUM_THREADS=1
-          export PATH=$(dirname "$(which MATLAB)")/win64/:$PATH
-          export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
-          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x -m fdtd_build_only
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x 

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -20,6 +20,10 @@ jobs:
           - Release
         build_testing:
           - OFF
+        # TODO: remove this once MATLAB dependency is removed and mexFunction is replaced
+        derivative_type:
+          - PS
+          - FD
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -59,7 +63,10 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING=${{ matrix.build_testing }}
+          cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+           -DBUILD_TESTING=${{ matrix.build_testing }} \
+           -DDERIVATIVE_TYPE=${{ matrix.derivative_type }}
 
       - name: Build TDMS
         working-directory: ${{runner.workspace}}/build
@@ -74,11 +81,23 @@ jobs:
         run: |
           cp Release/* .
 
-      - name: Run TDMS system tests
+      # TODO: simplify this once MATLAB dependency is removed and mexFunction is replaced
+      - name: Run PSTD TDMS system tests
+        if: matrix.derivative_type == 'PS'
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
           export OMP_NUM_THREADS=1
           export PATH=$(dirname "$(which MATLAB)")/win64/:$PATH
           export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
-          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x -m "not fdtd_build_only"
+
+      - name: Run PSTD TDMS system tests
+        if: matrix.derivative_type == 'FD'
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          export OMP_NUM_THREADS=1
+          export PATH=$(dirname "$(which MATLAB)")/win64/:$PATH
+          export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x -m fdtd_build_only

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -92,7 +92,7 @@ jobs:
           export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
           pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x -m "not fdtd_build_only"
 
-      - name: Run PSTD TDMS system tests
+      - name: Run FDTD TDMS system tests
         if: matrix.derivative_type == 'FD'
         working-directory: ${{runner.workspace}}/build
         shell: bash

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -100,4 +100,4 @@ jobs:
           export OMP_NUM_THREADS=1
           export PATH=$(dirname "$(which MATLAB)")/win64/:$PATH
           export PATH=/c/Miniconda/envs/test/Library/bin/:$PATH
-          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x 
+          pytest ${GITHUB_WORKSPACE}/tdms/tests/system/test_cli.py -s -x

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -80,10 +80,12 @@ cmake .. \
 # -DMatlab_ROOT_DIR=/usr/local/MATLAB/R2019b/ \
 # -DFFTW_ROOT=/usr/local/fftw3/ \
 # -DCMAKE_INSTALL_PREFIX=$HOME/.local/
+# -DDERIVATIVE_TYPE=FD
 make install
 ```
 You may need to help CMake find MATLAB/fftw etc.
 
+- There are two methods to choose from: pseudospectral time domain (PSTD) or finite-difference time domain (FDTD) derivatives. **This choice must be made at compile time**, to comply with MATLAB. The default is PSTD. You can select FDTD with `-DDERIVATIVE_TYPE=FD`.
 - By default, build testing is turned off. You can turn it on with `-DBUILD_TESTING=ON`.
 - Also by default, debug printout is off. Turn on with `-DCMAKE_BUILD_TYPE=Debug` or manually at some specific place in the code with:
 ```{.cpp}
@@ -100,7 +102,6 @@ spdlog::debug("Send help");
 
 ### Compiling on UCL's Myriad cluster
 <details>
-  
   > **Warning**
   > These instructions are a bit experimental. Please use with care (and report anything that's wrong here)!
 
@@ -135,7 +136,6 @@ spdlog::debug("Send help");
   CApath: none
   ```
   it's because the MATLAB module is interfering with the SSL certificates (and we clone over https by default). This issue is known and reported. As a workaround, we've added the build option `-DGIT_SSH=ON` to switch to `git clone` over ssh instead.
-  
 </details>
 
 
@@ -198,5 +198,14 @@ A good example of running the `tdms` executable for a given input and expected o
 You need to [compile](#compiling) `tdms`, then the system tests can be run, e.g. from the build directory:
 
 ```{.sh}
-pytest ../tests/system/
+pytest ../tests/system/ -m "not fdtd_build_only"
+```
+
+A slight complication - which we hope to simplify - it is possible to build in two different configurations for two different methods: pseudospectral time domain (PSTD) or finite-difference time domain (FDTD) derivatives.
+We therefore [mark](https://docs.pytest.org/en/stable/example/markers.html) some of the system tests `fdtd_build_only`.
+
+To test the FDTD build: [recompile](#compiling) with `-DDERIVATIVE_TYPE=FD` and run:
+
+```{.sh}
+pytest ../tests/system/ -m fdtd_build_only
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    fdtd_build_only: marks tests as only to be run in an FDTD build (deselect with '-m "not fdtd_build_only"')
+

--- a/tdms/tests/system/test_fdtd.py
+++ b/tdms/tests/system/test_fdtd.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+
+import pytest
+from utils import HDF5File, download_data, run_tdms, work_in_zipped_dir
+
+ZIP_PATH = Path(
+    os.path.dirname(os.path.abspath(__file__)), "data", "arc_example_fdtd.zip"
+)
+
+if not ZIP_PATH.exists():
+    download_data(
+        "https://zenodo.org/record/7148198/files/arc_example_fdtd.zip", to=ZIP_PATH
+    )
+
+
+@pytest.mark.fdtd_build_only
+@work_in_zipped_dir(ZIP_PATH)
+def test_fs():
+    """
+    Ensure that the free space FDTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+
+    Note: At the moment (due to MATLAB) this test only works if tdms is compiled with
+    """
+
+    # misleading filename here
+    run_tdms("arc_example_fdtd/in_pstd_fs.mat", "fdtd_fs_output.mat")
+
+    reference = HDF5File("arc_example_fdtd/out_fdtd_fs.mat")
+    assert HDF5File("fdtd_fs_output.mat").matches(reference)
+
+
+@pytest.mark.fdtd_build_only
+@work_in_zipped_dir(ZIP_PATH)
+def test_cyl():
+    """
+    Ensure that the cylinder FDTD output matches the reference. Checks
+    that the output .mat file (with a HDF5 format) contains tensors with
+    relative mean square values within numerical precision of the reference.
+    """
+
+    # misleading filename here
+    run_tdms("arc_example_fdtd/in_pstd_cyl.mat", "fdtd_cyl_output.mat")
+
+    reference = HDF5File("arc_example_fdtd/out_fdtd_cyl.mat")
+    assert HDF5File("fdtd_cyl_output.mat").matches(reference)

--- a/tdms/tests/system/utils.py
+++ b/tdms/tests/system/utils.py
@@ -82,7 +82,7 @@ class HDF5File(dict):
         arrays
         """
 
-        for key, value in self.traverse(self):
+        for key, value in self.items():
 
             if key not in other:
                 return False  # Key did not match


### PR DESCRIPTION
Adds an example FDTD test (current functionality). Not necessarily meaningful, but a run of the example scripts with FD compile flag. This at least tests against regression.

Also runs the unit tests with the FD flag in the CI for BUILD_TESTING builds. And update the documentation.

***
### Dependencies

- #121 
- #119 