### PR TITLE
Node.js 12 warnings.

### DIFF
--- a/.github/workflows/macos_tests.yml
+++ b/.github/workflows/macos_tests.yml
@@ -51,7 +51,7 @@ jobs:
           brew link --force libomp
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
Continues #182.

Sorry for the trivial PR noise. I should have noticed this last night, but I was too happy that I had fixed the build.

`actions/setup-python@v2` uses some old Node.js and kicks out [warnings on the build](https://github.com/UCL/TDMS/actions/runs/3456729198). Updating to `v4` updates everything and clears the warnings. Completely transparent change for us.