### PR TITLE
Test class for `array.h` classes

### DIFF
--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -135,6 +135,10 @@ protected:
    * @brief Tests the behaviour of the initialise method
    */
   virtual void test_initialise_method() { ran_a_test = false; }
+  /**
+   * @brief Tests any other methods that the class may have
+   */
+  virtual void test_other_methods() { ran_a_test = false; }
 
 public:
   AbstractArrayTest() = default;
@@ -179,6 +183,10 @@ public:
     SECTION("initialise() method") {
       logging_string += "initialise() method";
       test_initialise_method();
+    }
+    SECTION("Testing class-specific methods") {
+      logging_string += "class specific method";
+      test_other_methods();
     }
 
     // suppress output if no test was run

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -99,34 +99,35 @@ protected:
   /* Test functions to be overriden by each class.
   These methods are designed to be overriden by the subclasses specific to each arrays.h class.
 
-  The default behaviour of each test_ method is to return false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
-  If overriden, a test_ method should return true, to indicate to run_all_class_tests() that this test did attempt to run (and might have failed).
+  The default behaviour of each test_ method is to set ran_a_test to false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
+  If overriden, a test_ method should not alter ran_a_test
   */
 
+  bool ran_a_test = true;
   /**
   * @brief Tests the behaviour of construction when passed an empty MATLAB array
   */
-  virtual bool test_empty_construction() { return false; }
+  virtual void test_empty_construction() { ran_a_test = false; }
   /**
    * @brief Tests the behaviour of construction when passed an array of the incorrect dimensions
    */
-  virtual bool test_wrong_input_dimensions() { return false; }
+  virtual void test_wrong_input_dimensions() { ran_a_test = false; }
   /**
    * @brief Tests the behaviour of construction when passed an array of the incorrect type
    */
-  virtual bool test_wrong_input_type() { return false; }
+  virtual void test_wrong_input_type() { ran_a_test = false; }
   /**
    * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
    */
-  virtual bool test_incorrect_number_of_fields() { return false; }
+  virtual void test_incorrect_number_of_fields() { ran_a_test = false; }
   /**
    * @brief Tests the behaviour of construction methods when passing the expected inputs
    */
-  virtual bool test_correct_construction() { return false; }
+  virtual void test_correct_construction() { ran_a_test = false; }
   /**
    * @brief Tests the behaviour of the initialise method
    */
-  virtual bool test_initialise_method() { return false; }
+  virtual void test_initialise_method() { ran_a_test = false; }
 
 public:
   AbstractArrayTest() = default;
@@ -142,37 +143,35 @@ public:
   void run_all_class_tests() {
     // String to print to the log
     std::string logging_string = get_class_name() + ": ";
-    // Skips over tests that do not need to be executed
-    bool test_executed;
 
     // run all tests
     SECTION("Empty construction") {
       logging_string += "Empty construction";
-      test_executed = test_empty_construction();
+      test_empty_construction();
     }
     SECTION("Incorrect dimension of input") {
       logging_string += "Incorrect dimension of input";
-      test_executed = test_wrong_input_dimensions();
+      test_wrong_input_dimensions();
     }
     SECTION("Incorrect type of input") {
       logging_string += "Incorrect type of input";
-      test_executed = test_wrong_input_type();
+      test_wrong_input_type();
     }
     SECTION("Incorrect number of fields") {
       logging_string += "Incorrect number of fields";
-      test_executed = test_incorrect_number_of_fields();
+      test_incorrect_number_of_fields();
     }
     SECTION("Correct construction") {
       logging_string += "Correct construction";
-      test_executed = test_correct_construction();
+      test_correct_construction();
     }
     SECTION("initialise() method") {
       logging_string += "initialise() method";
-      test_executed = test_initialise_method();
+      test_initialise_method();
     }
 
     // suppress output if no test was run
-    if (test_executed) {
+    if (ran_a_test) {
       // tear down is necessary if a test was run
       bool needed_to_destroy = destroy_matlab_input();
       if (needed_to_destroy) {

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -79,7 +79,6 @@ protected:
   }
   /**
    * @brief Creates the MATLAB empty struct (no fields, 0 size)
-   *
    */
   void create_empty_struct() {
     create_struct_array(0, 1, 0, {});
@@ -146,7 +145,7 @@ public:
   /**
    * @brief Returns the name of the class, for logging purposes
    */
-  virtual std::string get_class_name() { return ""; }
+  virtual std::string get_class_name() = 0;
 
   /**
    * @brief Runs all the unit tests associated to this class

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -124,6 +124,10 @@ protected:
    */
   virtual void test_incorrect_number_of_fields() { ran_a_test = false; }
   /**
+   * @brief Tests the behaviour of construction methods when passed a struct with an incorrect fieldname
+   */
+  virtual void test_incorrect_fieldname() { ran_a_test = false; }
+  /**
    * @brief Tests the behaviour of construction methods when passing the expected inputs
    */
   virtual void test_correct_construction() { ran_a_test = false; }
@@ -163,6 +167,10 @@ public:
     SECTION("Incorrect number of fields") {
       logging_string += "Incorrect number of fields";
       test_incorrect_number_of_fields();
+    }
+    SECTION("Incorrect fieldname") {
+      logging_string += "Incorrect fieldname";
+      test_incorrect_fieldname();
     }
     SECTION("Correct construction") {
       logging_string += "Correct construction";

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -1,0 +1,186 @@
+/**
+ * @file array_test_class.h
+ * @brief Defines the abstract class for testing objects defined in arrays.h
+ */
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <spdlog/spdlog.h>
+#include <string>
+
+#include "arrays.h"
+
+/**
+ * @brief Abstract container for the tests that classes in arrays.h will have to pass.
+ *
+ * Private methods are empty, and designed to be overridden in the derived class. However this also means that definitions for these tests can be left out of those subclasses, whilst not changing the run_all_tests() function.
+ *
+ */
+class AbstractArrayTest {
+protected:
+  int empty_dimensions[2] = {0, 1};   //< For initialising empty arrays
+  int I_tot = 4, J_tot = 8, K_tot = 4;//< For mimicing simulation grid dimensions
+  int n_rows = 4, n_cols = 8;         //< For mimicing matrix dimensions
+  int n_numeric_elements =
+          8;//< For standardising the number of elements we initialise MATLAB vectors with
+  int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
+  int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
+
+  // To point to the (top-level) matlab inputs the classes require. Top-level structure ensures mxDestroyArray clears all sub-arrays too
+  mxArray *matlab_input = nullptr;
+  // Flags if we have created an mxArray manually, so we are forced to destroy to free memory when done
+  bool matlab_input_assigned = false;
+
+  /**
+   * @brief Destroys the matlab_input array if it is assigned.
+   *
+   * @returns true If mxDestroyArray was called successfully
+   * @returns false matlab_input was not assigned, so no deletion was necessary
+   */
+  bool destroy_matlab_input() {
+    if (matlab_input_assigned) {
+      mxDestroyArray(matlab_input);
+      matlab_input_assigned = false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  /**
+   * @brief Creates a MATLAB structure array
+   *
+   * @param n_rows,n_cols Dimensions of the array. This is the number of identical structs in the array, not the size of a particular field
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_struct_array(int n_rows, int n_cols, int n_fields, const char *fields[]) {
+    matlab_input = mxCreateStructMatrix(n_rows, n_cols, n_fields, fields);
+    matlab_input_assigned = true;
+  }
+  /**
+   * @brief Creates a MATLAB structure array
+   *
+   * @param n_dimensions Number of dimensions of the array.
+   * @param dimensions Array or vector, containing the number of elements in each axis of the array
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_struct_array(int n_dimensions, int *dimensions, int n_fields, const char *fields[]) {
+    matlab_input = mxCreateStructArray(n_dimensions, (const mwSize *) dimensions, n_fields, fields);
+    matlab_input_assigned = true;
+  }
+  /**
+   * @brief Creates a 1-by-1 MATLAB structure array
+   *
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_1by1_struct(int n_fields, const char *fields[]) {
+    create_struct_array(1, 1, n_fields, fields);
+  }
+  void create_empty_struct(int n_fields, const char *fields[]) {
+    create_struct_array(0, 1, n_fields, fields);
+  }
+  /**
+   * @brief Creates a MATLAB numeric array
+   *
+   * @param n_dims Number of dimensions in the array
+   * @param dimensions Array/vector containing the number of elements in each dimension, sequentially
+   * @param data_type The MATLAB data type to populate the array with
+   * @param complex_flag Whether the data is real or complex
+   */
+  void create_numeric_array(int n_dims, int *dimensions, mxClassID data_type = mxDOUBLE_CLASS,
+                            mxComplexity complex_flag = mxREAL) {
+    matlab_input =
+            mxCreateNumericArray(n_dims, (const mwSize *) dimensions, data_type, complex_flag);
+    matlab_input_assigned = true;
+  }
+
+  /* Test functions to be overriden by each class.
+  These methods are designed to be overriden by the subclasses specific to each arrays.h class.
+
+  The default behaviour of each test_ method is to return false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
+  If overriden, a test_ method should return true, to indicate to run_all_class_tests() that this test did attempt to run (and might have failed).
+  */
+
+  /**
+  * @brief Tests the behaviour of construction when passed an empty MATLAB array
+  */
+  virtual bool test_empty_construction() { return false; }
+  /**
+   * @brief Tests the behaviour of construction when passed an array of the incorrect dimensions
+   */
+  virtual bool test_wrong_input_dimensions() { return false; }
+  /**
+   * @brief Tests the behaviour of construction when passed an array of the incorrect type
+   */
+  virtual bool test_wrong_input_type() { return false; }
+  /**
+   * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
+   */
+  virtual bool test_incorrect_number_of_fields() { return false; }
+  /**
+   * @brief Tests the behaviour of construction methods when passing the expected inputs
+   */
+  virtual bool test_correct_construction() { return false; }
+  /**
+   * @brief Tests the behaviour of the initialise method
+   */
+  virtual bool test_initialise_method() { return false; }
+
+public:
+  AbstractArrayTest() = default;
+
+  /**
+   * @brief Returns the name of the class, for logging purposes
+   */
+  virtual std::string get_class_name() { return ""; }
+
+  /**
+   * @brief Runs all the unit tests associated to this class
+   */
+  void run_all_class_tests() {
+    // String to print to the log
+    std::string logging_string = get_class_name() + ": ";
+    // Skips over tests that do not need to be executed
+    bool test_executed;
+
+    // run all tests
+    SECTION("Empty construction") {
+      logging_string += "Empty construction";
+      test_executed = test_empty_construction();
+    }
+    SECTION("Incorrect dimension of input") {
+      logging_string += "Incorrect dimension of input";
+      test_executed = test_wrong_input_dimensions();
+    }
+    SECTION("Incorrect type of input") {
+      logging_string += "Incorrect type of input";
+      test_executed = test_wrong_input_type();
+    }
+    SECTION("Incorrect number of fields") {
+      logging_string += "Incorrect number of fields";
+      test_executed = test_incorrect_number_of_fields();
+    }
+    SECTION("Correct construction") {
+      logging_string += "Correct construction";
+      test_executed = test_correct_construction();
+    }
+    SECTION("initialise() method") {
+      logging_string += "initialise() method";
+      test_executed = test_initialise_method();
+    }
+
+    // suppress output if no test was run
+    if (test_executed) {
+      // tear down is necessary if a test was run
+      bool needed_to_destroy = destroy_matlab_input();
+      if (needed_to_destroy) {
+        logging_string += " (matlab_input destroyed)";
+      } else {
+        logging_string += " (nothing to tear down)";
+      }
+      SPDLOG_INFO(logging_string);
+    }
+  }
+};

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -20,7 +20,6 @@ class AbstractArrayTest {
 protected:
   int empty_dimensions[2] = {0, 1};   //< For initialising empty arrays
   int I_tot = 4, J_tot = 8, K_tot = 4;//< For mimicing simulation grid dimensions
-  int n_rows = 4, n_cols = 8;         //< For mimicing matrix dimensions
   int n_numeric_elements =
           8;//< For standardising the number of elements we initialise MATLAB vectors with
   int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
@@ -78,8 +77,12 @@ protected:
   void create_1by1_struct(int n_fields, const char *fields[]) {
     create_struct_array(1, 1, n_fields, fields);
   }
-  void create_empty_struct(int n_fields, const char *fields[]) {
-    create_struct_array(0, 1, n_fields, fields);
+  /**
+   * @brief Creates the MATLAB empty struct (no fields, 0 size)
+   *
+   */
+  void create_empty_struct() {
+    create_struct_array(0, 1, 0, {});
   }
   /**
    * @brief Creates a MATLAB numeric array

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -124,6 +124,35 @@ private:
 public:
   std::string get_class_name() override { return "FieldSample"; }
 };
+
+class CMaterialTest : public AbstractArrayTest {
+private:
+  const int n_fields = 9;
+  const char *fieldnames[9] = {"Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz"};
+  const char *wrong_fieldnames[9] = {"Dax", "Cay", "Daz", "Cbx", "Dby", "Cbz", "Ccx", "Ccy", "Ccz"};
+
+  void test_incorrect_number_of_fields() override;
+  void test_incorrect_fieldname() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "CMaterial"; }
+};
+
+class DMaterialTest : public AbstractArrayTest {
+private:
+  const int n_fields = 6;
+  const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
+  const char *wrong_fieldnames[6] = {"Dax", "Cay", "Daz", "Cbx", "Dby", "Cbz"};
+
+  void test_incorrect_number_of_fields() override;
+  void test_incorrect_fieldname() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "DMaterial"; }
+};
+
 /*
 class : public AbstractArrayTest {
 private:
@@ -131,6 +160,7 @@ private:
   void test_wrong_input_dimensions() override;
   void test_wrong_input_type() override;
   void test_incorrect_number_of_fields() override;
+  void test_incorrect_fieldname() override;
   void test_correct_construction() override;
   void test_initialise_method() override;
 

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -62,7 +62,7 @@ public:
   std::string get_class_name() override { return "DispersiveMultilayer"; }
 };
 
-// DTilde test methods check the performance of initialise, as this is the de-facto constructor
+// Test methods check the performance of initialise, as this is the de-facto constructor
 class DTildeTest : public AbstractArrayTest {
 private:
   const int n_fields = 2;
@@ -92,6 +92,21 @@ public:
   std::string get_class_name() override { return "FieldSample"; }
 };
 
+// Test methods check the performance of initialise, as this is the de-facto constructor
+class FrequencyVectorsTest : public AbstractArrayTest {
+private:
+  const int n_fields = 2;
+  const char *fieldnames[2] = {"fx_vec", "fy_vec"};
+
+  void test_empty_construction() override;
+  void test_wrong_input_type() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
+  void test_initialise_method() override;
+
+public:
+  std::string get_class_name() override { return ""; }
+};
 /*
 class : public AbstractArrayTest {
 private:

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -20,6 +20,7 @@ class AbstractArrayTest {
 protected:
   int empty_dimensions[2] = {0, 1};            //< For initialising empty arrays
   int I_tot = 4, J_tot = 8, K_tot = 4;         //< For mimicing simulation grid dimensions
+  int n_rows = 4, n_cols = 8;//< For mimicing matrix dimensions
   int n_numeric_elements = 8; //< For standardising the number of elements we initialise MATLAB vectors with
   int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
   int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
@@ -56,6 +57,18 @@ protected:
     matlab_input_assigned = true;
   }
   /**
+   * @brief Creates a MATLAB structure array
+   *
+   * @param n_dimensions Number of dimensions of the array.
+   * @param dimensions Array or vector, containing the number of elements in each axis of the array
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_struct_array(int n_dimensions, int *dimensions, int n_fields, const char *fields[]) {
+    matlab_input = mxCreateStructArray(n_dimensions, (const mwSize *) dimensions, n_fields, fields);
+    matlab_input_assigned = true;
+  }
+  /**
    * @brief Creates a 1-by-1 MATLAB structure array
    *
    * @param n_fields Number of fields
@@ -63,6 +76,9 @@ protected:
    */
   void create_1by1_struct(int n_fields, const char *fields[]) {
     create_struct_array(1, 1, n_fields, fields);
+  }
+  void create_empty_struct(int n_fields, const char *fields[]) {
+    create_struct_array(0, 1, n_fields, fields);
   }
   /**
    * @brief Creates a MATLAB numeric array
@@ -102,6 +118,10 @@ protected:
    * @brief Tests the behaviour of construction methods when passing the expected inputs
    */
   virtual bool test_correct_construction() { return false;}
+  /**
+   * @brief Tests the behaviour of the initialise method
+   */
+  virtual bool test_initialise_method() { return false;}
 
 public:
   AbstractArrayTest() = default;
@@ -167,11 +187,29 @@ class DCollectionTest : public AbstractArrayTest {
   private:
     const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
 
-    std::string class_being_tested = "DCollection";
-
     bool test_incorrect_number_of_fields() override;
     bool test_correct_construction() override;
 
   public:
     std::string get_class_name() override { return "DCollection"; }
+};
+
+class ComplexAmplitudeSampleTest : public AbstractArrayTest {
+private:
+  const char *fieldnames[2] = {"vertices", "components"};
+
+  bool test_empty_construction() override;
+  bool test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "ComplexAmplitudeSample"; }
+};
+
+class DetectorSensitivityArraysTest : public AbstractArrayTest {
+private:
+  bool test_correct_construction() override;
+  bool test_initialise_method() override;
+
+public:
+  std::string get_class_name() override { return "DetectorSensitivityArray";}
 };

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -107,7 +107,7 @@ private:
   void test_initialise_method() override;
 
 public:
-  std::string get_class_name() override { return ""; }
+  std::string get_class_name() override { return "FrequencyVectors"; }
 };
 
 class IncidentFieldTest : public AbstractArrayTest {
@@ -122,7 +122,7 @@ private:
   void test_correct_construction() override;
 
 public:
-  std::string get_class_name() override { return "FieldSample"; }
+  std::string get_class_name() override { return "IncidentField"; }
 };
 
 class CMaterialTest : public AbstractArrayTest {
@@ -153,6 +153,61 @@ public:
   std::string get_class_name() override { return "DMaterial"; }
 };
 
+class MatrixTest : public AbstractArrayTest {
+private:
+  const int n_rows = 4, n_cols = 8;
+
+  void test_correct_construction() override;
+  // allocate() must be tested
+  void test_other_methods() override;
+
+public:
+  std::string get_class_name() override { return "Matrix"; }
+};
+
+class VerticesTest : public AbstractArrayTest {
+private:
+  const int n_fields = 1;
+  const char *fieldnames[1] = {"vertices"};
+
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "Vertices"; }
+};
+
+class GratingStructureTest : public AbstractArrayTest {
+private:
+  void test_empty_construction() override;
+  void test_wrong_input_dimensions() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "GratingStructure"; }
+};
+
+class PupilTest : public AbstractArrayTest {
+private:
+  const int n_rows = 4, n_cols = 8;
+
+  void test_empty_construction() override;
+  void test_wrong_input_dimensions() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "Pupil"; }
+};
+
+class EHVecTest : public AbstractArrayTest {
+private:
+  const int n_rows = 4, n_cols = 8;
+
+  void test_other_methods() override;
+
+public:
+  std::string get_class_name() override { return "EHVec"; }
+};
+
 /*
 class : public AbstractArrayTest {
 private:
@@ -163,8 +218,9 @@ private:
   void test_incorrect_fieldname() override;
   void test_correct_construction() override;
   void test_initialise_method() override;
+  void test_other_methods() override;
 
 public:
-  std::string get_class_name() override { return ""; }
+  std::string get_class_name() override { return "SETME"; }
 };
 */

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -10,8 +10,8 @@ class CCollectionTest : public AbstractArrayTest {
   private:
     const char *fieldnames[9] = { "Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz" };
 
-    bool test_incorrect_number_of_fields() override;
-    bool test_correct_construction() override;
+    void test_incorrect_number_of_fields() override;
+    void test_correct_construction() override;
 
   public:
     std::string get_class_name() override {return "CCollection";}
@@ -21,8 +21,8 @@ class DCollectionTest : public AbstractArrayTest {
   private:
     const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
 
-    bool test_incorrect_number_of_fields() override;
-    bool test_correct_construction() override;
+    void test_incorrect_number_of_fields() override;
+    void test_correct_construction() override;
 
   public:
     std::string get_class_name() override { return "DCollection"; }
@@ -32,8 +32,8 @@ class ComplexAmplitudeSampleTest : public AbstractArrayTest {
 private:
   const char *fieldnames[2] = {"vertices", "components"};
 
-  bool test_empty_construction() override;
-  bool test_correct_construction() override;
+  void test_empty_construction() override;
+  void test_correct_construction() override;
 
 public:
   std::string get_class_name() override { return "ComplexAmplitudeSample"; }
@@ -41,8 +41,8 @@ public:
 
 class DetectorSensitivityArraysTest : public AbstractArrayTest {
 private:
-  bool test_correct_construction() override;
-  bool test_initialise_method() override;
+  void test_correct_construction() override;
+  void test_initialise_method() override;
 
 public:
   std::string get_class_name() override { return "DetectorSensitivityArray";}
@@ -54,9 +54,9 @@ private:
   const char *fieldnames[9] = {"alpha",   "beta",    "gamma",   "kappa_x", "kappa_y",
                                "kappa_z", "sigma_x", "sigma_y", "sigma_z"};
 
-  bool test_empty_construction() override;
-  bool test_wrong_input_type() override;
-  bool test_correct_construction() override;
+  void test_empty_construction() override;
+  void test_wrong_input_type() override;
+  void test_correct_construction() override;
 
 public:
   std::string get_class_name() override { return "DispersiveMultilayerTest"; }
@@ -68,11 +68,11 @@ private:
   const int n_fields = 2;
   const char *fieldnames[2] = { "Dx_tilde", "Dy_tilde" };
 
-  bool test_empty_construction() override;
-  bool test_wrong_input_type() override;
-  bool test_incorrect_number_of_fields() override;
-  bool test_correct_construction() override;
-  bool test_initialise_method() override;
+  void test_empty_construction() override;
+  void test_wrong_input_type() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
+  void test_initialise_method() override;
 
 public:
   std::string get_class_name() override { return ""; }
@@ -81,12 +81,12 @@ public:
 /*
 class : public AbstractArrayTest {
 private:
-  bool test_empty_construction() override;
-  bool test_wrong_input_dimensions() override;
-  bool test_wrong_input_type() override;
-  bool test_incorrect_number_of_fields() override;
-  bool test_correct_construction() override;
-  bool test_initialise_method() override;
+  void test_empty_construction() override;
+  void test_wrong_input_dimensions() override;
+  void test_wrong_input_type() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
+  void test_initialise_method() override;
 
 public:
   std::string get_class_name() override { return ""; }

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,8 +286,6 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
-  const int n_layers = 4, n_cols = 8, n_rows = 16;
-
   void test_correct_construction() override;
   // set_ptr()
   void test_other_methods() override;

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -1,0 +1,32 @@
+/**
+ * @file array_test_class.h
+ * @brief Defines the test classes for the objects in arrays.h
+ */
+#pragma once
+
+/**
+ * @brief Abstract container for the tests that classes in arrays.h will have to pass.
+ *
+ * Private methods are empty, and designed to be overridden in the derived class. However this also means that definitions for these tests can be left out of those subclasses, whilst not changing the run_all_tests() function.
+ *
+ */
+class AbstractArrayTest {
+private:
+  int empty_dimensions[2] = {0, 1};            //< For initialising empty arrays
+  int I_tot = 4, J_tot = 8, K_tot = 4;         //< For mimicing simulation grid dimensions
+  int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
+  int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
+  // we could put some common values, EG empty_dimensions, I_tot, etc here as private values to save redefining everything
+
+  void test_empty_construction(){};//< Tests the behaviour of construction when passed an empty MATLAB array
+  void test_correct_construction(){};//< Tests the behaviour of construction methods when passing the expected inputs
+
+public:
+  AbstractArrayTest() = default;
+
+  // Runs all the class's private test methods sequentially
+  void run_all_class_tests() {
+    test_empty_construction();
+    test_correct_construction();
+  }
+};

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -23,7 +23,7 @@
 
 #include "abstract_array_test_class.h"
 
-        class CCollectionTest : public AbstractArrayTest {
+class CCollectionTest : public AbstractArrayTest {
   private:
     const char *fieldnames[9] = { "Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz" };
 

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -221,6 +221,40 @@ public:
   std::string get_class_name() override { return "Tensor3D"; }
 };
 
+class VectorTest : public AbstractArrayTest {
+private:
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "Vector"; }
+};
+
+class FieldComponentsVectorTest : public AbstractArrayTest {
+private:
+  const int n_fields = 1;
+  const char *fieldnames[1] = {"components"};
+
+  void test_correct_construction() override;
+  void test_initialise_method() override;
+
+public:
+  std::string get_class_name() override { return "FieldComponentsVector"; }
+};
+
+class FrequencyExtractVectorTest : public AbstractArrayTest {
+private:
+  const double omega_an = 1.;
+
+  void test_empty_construction() override;
+  void test_wrong_input_dimensions() override;
+  void test_correct_construction() override;
+  // max() method
+  void test_other_methods() override;
+
+public:
+  std::string get_class_name() override { return "FrequencyExtractVector"; }
+};
+
 /*
 class : public AbstractArrayTest {
 private:

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -202,10 +202,23 @@ class EHVecTest : public AbstractArrayTest {
 private:
   const int n_rows = 4, n_cols = 8;
 
+  // allocate() needs testing
   void test_other_methods() override;
 
 public:
   std::string get_class_name() override { return "EHVec"; }
+};
+
+class Tensor3DTest : public AbstractArrayTest {
+private:
+  const int n_layers = 4, n_cols = 8, n_rows = 16;
+
+  void test_correct_construction() override;
+  // allocate() (and) zero(), frobenius()
+  void test_other_methods() override;
+
+public:
+  std::string get_class_name() override { return "Tensor3D"; }
 };
 
 /*

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -4,6 +4,12 @@
  */
 #pragma once
 
+#include <catch2/catch_test_macros.hpp>
+#include <spdlog/spdlog.h>
+#include <string>
+
+#include "arrays.h"
+
 /**
  * @brief Abstract container for the tests that classes in arrays.h will have to pass.
  *
@@ -11,22 +17,161 @@
  *
  */
 class AbstractArrayTest {
-private:
+protected:
   int empty_dimensions[2] = {0, 1};            //< For initialising empty arrays
   int I_tot = 4, J_tot = 8, K_tot = 4;         //< For mimicing simulation grid dimensions
+  int n_numeric_elements = 8; //< For standardising the number of elements we initialise MATLAB vectors with
   int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
   int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
-  // we could put some common values, EG empty_dimensions, I_tot, etc here as private values to save redefining everything
 
-  void test_empty_construction(){};//< Tests the behaviour of construction when passed an empty MATLAB array
-  void test_correct_construction(){};//< Tests the behaviour of construction methods when passing the expected inputs
+  // To point to the (top-level) matlab inputs the classes require. Top-level structure ensures mxDestroyArray clears all sub-arrays too
+  mxArray *matlab_input = nullptr;
+  // Flags if we have created an mxArray manually, so we are forced to destroy to free memory when done
+  bool matlab_input_assigned = false;
+
+  /**
+   * @brief Destroys the matlab_input array if it is assigned.
+   *
+   * @returns true If mxDestroyArray was called successfully
+   * @returns false matlab_input was not assigned, so no deletion was necessary
+   */
+  bool destroy_matlab_input() {
+    if (matlab_input_assigned) {
+      mxDestroyArray(matlab_input);
+      matlab_input_assigned = false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+  /**
+   * @brief Creates a MATLAB structure array
+   *
+   * @param n_rows,n_cols Dimensions of the array. This is the number of identical structs in the array, not the size of a particular field
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_struct_array(int n_rows, int n_cols, int n_fields, const char *fields[]) {
+    matlab_input = mxCreateStructMatrix(n_rows, n_cols, n_fields, fields);
+    matlab_input_assigned = true;
+  }
+  /**
+   * @brief Creates a 1-by-1 MATLAB structure array
+   *
+   * @param n_fields Number of fields
+   * @param fields Names of the fields
+   */
+  void create_1by1_struct(int n_fields, const char *fields[]) {
+    create_struct_array(1, 1, n_fields, fields);
+  }
+  /**
+   * @brief Creates a MATLAB numeric array
+   *
+   * @param n_dims Number of dimensions in the array
+   * @param dimensions Array/vector containing the number of elements in each dimension, sequentially
+   * @param data_type The MATLAB data type to populate the array with
+   * @param complex_flag Whether the data is real or complex
+   */
+  void create_numeric_array(int n_dims, int *dimensions, mxClassID data_type = mxDOUBLE_CLASS,
+                            mxComplexity complex_flag = mxREAL) {
+    matlab_input =
+            mxCreateNumericArray(n_dims, (const mwSize *) dimensions, data_type, complex_flag);
+    matlab_input_assigned = true;
+  }
+
+  /* Test functions to be overriden by each class.
+  These methods are designed to be overriden by the subclasses specific to each arrays.h class.
+
+  The default behaviour of each test_ method is to return false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
+  If overriden, a test_ method should return true, to indicate to run_all_class_tests() that this test did attempt to run (and might have failed).
+  */
+
+  /**
+  * @brief Tests the behaviour of construction when passed an empty MATLAB array
+  */
+  virtual bool test_empty_construction() { return false;}
+  /**
+   * @brief Tests the behaviour of construction when passed an array of the incorrect dimensions
+   */
+  virtual bool test_wrong_input_dimensions() { return false;}
+  /**
+   * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
+   */
+  virtual bool test_incorrect_number_of_fields() { return false;}
+  /**
+   * @brief Tests the behaviour of construction methods when passing the expected inputs
+   */
+  virtual bool test_correct_construction() { return false;}
 
 public:
   AbstractArrayTest() = default;
 
-  // Runs all the class's private test methods sequentially
+  /**
+   * @brief Returns the name of the class, for logging purposes
+   */
+  virtual std::string get_class_name() { return "";}
+
+  /**
+   * @brief Runs all the unit tests associated to this class
+   */
   void run_all_class_tests() {
-    test_empty_construction();
-    test_correct_construction();
+    // String to print to the log
+    std::string logging_string = get_class_name() + ": ";
+    // Skips over tests that do not need to be executed
+    bool test_executed;
+
+    // run all tests
+    SECTION("Empty construction") {
+      logging_string += "Empty construction";
+      test_executed = test_empty_construction();
+    }
+    SECTION("Incorrect dimension of input") {
+      logging_string += "Incorrect dimension of input";
+      test_executed = test_wrong_input_dimensions();
+    }
+    SECTION("Incorrect number of fields") {
+      logging_string += "Incorrect number of fields";
+      test_executed = test_incorrect_number_of_fields();
+    }
+    SECTION("Correct construction") {
+      logging_string += "Correct construction";
+      test_executed = test_correct_construction();
+    }
+
+    // suppress output if no test was run
+    if (test_executed) {
+      // tear down is necessary if a test was run
+      bool needed_to_destroy = destroy_matlab_input();
+      if (needed_to_destroy) {
+        logging_string += " (matlab_input destroyed)";
+      } else {
+        logging_string += " (nothing to tear down)";
+      }
+      SPDLOG_INFO(logging_string);
+    }
   }
+};
+
+class CCollectionTest : public AbstractArrayTest {
+  private:
+    const char *fieldnames[9] = { "Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz" };
+
+    bool test_incorrect_number_of_fields() override;
+    bool test_correct_construction() override;
+
+  public:
+    std::string get_class_name() override {return "CCollection";}
+};
+
+class DCollectionTest : public AbstractArrayTest {
+  private:
+    const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
+
+    std::string class_being_tested = "DCollection";
+
+    bool test_incorrect_number_of_fields() override;
+    bool test_correct_construction() override;
+
+  public:
+    std::string get_class_name() override { return "DCollection"; }
 };

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -59,7 +59,7 @@ private:
   void test_correct_construction() override;
 
 public:
-  std::string get_class_name() override { return "DispersiveMultilayerTest"; }
+  std::string get_class_name() override { return "DispersiveMultilayer"; }
 };
 
 // DTilde test methods check the performance of initialise, as this is the de-facto constructor
@@ -75,7 +75,21 @@ private:
   void test_initialise_method() override;
 
 public:
-  std::string get_class_name() override { return ""; }
+  std::string get_class_name() override { return "DTilde"; }
+};
+
+class FieldSampleTest : public AbstractArrayTest {
+private:
+  const int n_fields = 4;
+  const char *fieldnames[4] = {"i", "j", "k", "n"};
+
+  void test_empty_construction() override;
+  void test_wrong_input_type() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "FieldSample"; }
 };
 
 /*

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -4,185 +4,7 @@
  */
 #pragma once
 
-#include <catch2/catch_test_macros.hpp>
-#include <spdlog/spdlog.h>
-#include <string>
-
-#include "arrays.h"
-
-/**
- * @brief Abstract container for the tests that classes in arrays.h will have to pass.
- *
- * Private methods are empty, and designed to be overridden in the derived class. However this also means that definitions for these tests can be left out of those subclasses, whilst not changing the run_all_tests() function.
- *
- */
-class AbstractArrayTest {
-protected:
-  int empty_dimensions[2] = {0, 1};            //< For initialising empty arrays
-  int I_tot = 4, J_tot = 8, K_tot = 4;         //< For mimicing simulation grid dimensions
-  int n_rows = 4, n_cols = 8;//< For mimicing matrix dimensions
-  int n_numeric_elements = 8; //< For standardising the number of elements we initialise MATLAB vectors with
-  int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
-  int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
-
-  // To point to the (top-level) matlab inputs the classes require. Top-level structure ensures mxDestroyArray clears all sub-arrays too
-  mxArray *matlab_input = nullptr;
-  // Flags if we have created an mxArray manually, so we are forced to destroy to free memory when done
-  bool matlab_input_assigned = false;
-
-  /**
-   * @brief Destroys the matlab_input array if it is assigned.
-   *
-   * @returns true If mxDestroyArray was called successfully
-   * @returns false matlab_input was not assigned, so no deletion was necessary
-   */
-  bool destroy_matlab_input() {
-    if (matlab_input_assigned) {
-      mxDestroyArray(matlab_input);
-      matlab_input_assigned = false;
-      return true;
-    } else {
-      return false;
-    }
-  }
-  /**
-   * @brief Creates a MATLAB structure array
-   *
-   * @param n_rows,n_cols Dimensions of the array. This is the number of identical structs in the array, not the size of a particular field
-   * @param n_fields Number of fields
-   * @param fields Names of the fields
-   */
-  void create_struct_array(int n_rows, int n_cols, int n_fields, const char *fields[]) {
-    matlab_input = mxCreateStructMatrix(n_rows, n_cols, n_fields, fields);
-    matlab_input_assigned = true;
-  }
-  /**
-   * @brief Creates a MATLAB structure array
-   *
-   * @param n_dimensions Number of dimensions of the array.
-   * @param dimensions Array or vector, containing the number of elements in each axis of the array
-   * @param n_fields Number of fields
-   * @param fields Names of the fields
-   */
-  void create_struct_array(int n_dimensions, int *dimensions, int n_fields, const char *fields[]) {
-    matlab_input = mxCreateStructArray(n_dimensions, (const mwSize *) dimensions, n_fields, fields);
-    matlab_input_assigned = true;
-  }
-  /**
-   * @brief Creates a 1-by-1 MATLAB structure array
-   *
-   * @param n_fields Number of fields
-   * @param fields Names of the fields
-   */
-  void create_1by1_struct(int n_fields, const char *fields[]) {
-    create_struct_array(1, 1, n_fields, fields);
-  }
-  void create_empty_struct(int n_fields, const char *fields[]) {
-    create_struct_array(0, 1, n_fields, fields);
-  }
-  /**
-   * @brief Creates a MATLAB numeric array
-   *
-   * @param n_dims Number of dimensions in the array
-   * @param dimensions Array/vector containing the number of elements in each dimension, sequentially
-   * @param data_type The MATLAB data type to populate the array with
-   * @param complex_flag Whether the data is real or complex
-   */
-  void create_numeric_array(int n_dims, int *dimensions, mxClassID data_type = mxDOUBLE_CLASS,
-                            mxComplexity complex_flag = mxREAL) {
-    matlab_input =
-            mxCreateNumericArray(n_dims, (const mwSize *) dimensions, data_type, complex_flag);
-    matlab_input_assigned = true;
-  }
-
-  /* Test functions to be overriden by each class.
-  These methods are designed to be overriden by the subclasses specific to each arrays.h class.
-
-  The default behaviour of each test_ method is to return false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
-  If overriden, a test_ method should return true, to indicate to run_all_class_tests() that this test did attempt to run (and might have failed).
-  */
-
-  /**
-  * @brief Tests the behaviour of construction when passed an empty MATLAB array
-  */
-  virtual bool test_empty_construction() { return false;}
-  /**
-   * @brief Tests the behaviour of construction when passed an array of the incorrect dimensions
-   */
-  virtual bool test_wrong_input_dimensions() { return false;}
-  /**
-   * @brief Tests the behaviour of construction when passed an array of the incorrect type
-   */
-  virtual bool test_wrong_input_type() { return false;}
-  /**
-   * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
-   */
-  virtual bool test_incorrect_number_of_fields() { return false;}
-  /**
-   * @brief Tests the behaviour of construction methods when passing the expected inputs
-   */
-  virtual bool test_correct_construction() { return false;}
-  /**
-   * @brief Tests the behaviour of the initialise method
-   */
-  virtual bool test_initialise_method() { return false;}
-
-public:
-  AbstractArrayTest() = default;
-
-  /**
-   * @brief Returns the name of the class, for logging purposes
-   */
-  virtual std::string get_class_name() { return "";}
-
-  /**
-   * @brief Runs all the unit tests associated to this class
-   */
-  void run_all_class_tests() {
-    // String to print to the log
-    std::string logging_string = get_class_name() + ": ";
-    // Skips over tests that do not need to be executed
-    bool test_executed;
-
-    // run all tests
-    SECTION("Empty construction") {
-      logging_string += "Empty construction";
-      test_executed = test_empty_construction();
-    }
-    SECTION("Incorrect dimension of input") {
-      logging_string += "Incorrect dimension of input";
-      test_executed = test_wrong_input_dimensions();
-    }
-    SECTION("Incorrect type of input") {
-      logging_string += "Incorrect type of input";
-      test_executed = test_wrong_input_type();
-    }
-    SECTION("Incorrect number of fields") {
-      logging_string += "Incorrect number of fields";
-      test_executed = test_incorrect_number_of_fields();
-    }
-    SECTION("Correct construction") {
-      logging_string += "Correct construction";
-      test_executed = test_correct_construction();
-    }
-    SECTION("initialise() method") {
-      logging_string += "initialise() method";
-      test_executed = test_initialise_method();
-    }
-
-    // suppress output if no test was run
-    if (test_executed) {
-      // tear down is necessary if a test was run
-      bool needed_to_destroy = destroy_matlab_input();
-      if (needed_to_destroy) {
-        logging_string += " (matlab_input destroyed)";
-      } else {
-        logging_string += " (nothing to tear down)";
-      }
-      SPDLOG_INFO(logging_string);
-    }
-  }
-};
+#include "abstract_array_test_class.h"
 
 class CCollectionTest : public AbstractArrayTest {
   private:
@@ -239,3 +61,34 @@ private:
 public:
   std::string get_class_name() override { return "DispersiveMultilayerTest"; }
 };
+
+// DTilde test methods check the performance of initialise, as this is the de-facto constructor
+class DTildeTest : public AbstractArrayTest {
+private:
+  const int n_fields = 2;
+  const char *fieldnames[2] = { "Dx_tilde", "Dy_tilde" };
+
+  bool test_empty_construction() override;
+  bool test_wrong_input_type() override;
+  bool test_incorrect_number_of_fields() override;
+  bool test_correct_construction() override;
+  bool test_initialise_method() override;
+
+public:
+  std::string get_class_name() override { return ""; }
+};
+
+/*
+class : public AbstractArrayTest {
+private:
+  bool test_empty_construction() override;
+  bool test_wrong_input_dimensions() override;
+  bool test_wrong_input_type() override;
+  bool test_incorrect_number_of_fields() override;
+  bool test_correct_construction() override;
+  bool test_initialise_method() override;
+
+public:
+  std::string get_class_name() override { return ""; }
+};
+*/

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -41,6 +41,8 @@ public:
 
 class DetectorSensitivityArraysTest : public AbstractArrayTest {
 private:
+  int n_rows = 4, n_cols = 8;
+
   void test_correct_construction() override;
   void test_initialise_method() override;
 
@@ -106,6 +108,21 @@ private:
 
 public:
   std::string get_class_name() override { return ""; }
+};
+
+class IncidentFieldTest : public AbstractArrayTest {
+private:
+  const int n_rows = 6, n_cols = 4, n_layers = 5;
+  const int n_fields = 2;
+  const char *fieldnames[2] = {"exi", "eyi"};
+
+  void test_empty_construction() override;
+  void test_wrong_input_type() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "FieldSample"; }
 };
 /*
 class : public AbstractArrayTest {

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -1,12 +1,29 @@
 /**
  * @file array_test_class.h
  * @brief Defines the test classes for the objects in arrays.h
- */
+ *
+ *
+ * TEMPLATE FOR MAKING A NEW TEST ARRAY CLASS
+ * class : public AbstractArrayTest {
+ * private:
+ *   void test_empty_construction() override;
+ *   void test_wrong_input_dimensions() override;
+ *   void test_wrong_input_type() override;
+ *   void test_incorrect_number_of_fields() override;
+ *   void test_incorrect_fieldname() override;
+ *   void test_correct_construction() override;
+ *   void test_initialise_method() override;
+ *   void test_other_methods() override;
+ *
+ * public:
+ *   std::string get_class_name() override { return "SETME"; }
+ * };
+*/
 #pragma once
 
 #include "abstract_array_test_class.h"
 
-class CCollectionTest : public AbstractArrayTest {
+        class CCollectionTest : public AbstractArrayTest {
   private:
     const char *fieldnames[9] = { "Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz" };
 
@@ -255,19 +272,26 @@ public:
   std::string get_class_name() override { return "FrequencyExtractVector"; }
 };
 
-/*
-class : public AbstractArrayTest {
+class XYZTensor3DTest : public AbstractArrayTest {
 private:
-  void test_empty_construction() override;
-  void test_wrong_input_dimensions() override;
-  void test_wrong_input_type() override;
-  void test_incorrect_number_of_fields() override;
-  void test_incorrect_fieldname() override;
+  const int n_layers = 4, n_cols = 8, n_rows = 16;
+
   void test_correct_construction() override;
-  void test_initialise_method() override;
+  // allocate()
   void test_other_methods() override;
 
 public:
-  std::string get_class_name() override { return "SETME"; }
+  std::string get_class_name() override { return "XYZTensor3D"; }
 };
-*/
+
+class XYZVectorsTest : public AbstractArrayTest {
+private:
+  const int n_layers = 4, n_cols = 8, n_rows = 16;
+
+  void test_correct_construction() override;
+  // set_ptr()
+  void test_other_methods() override;
+
+public:
+  std::string get_class_name() override { return "XYZVectors"; }
+};

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,6 +286,10 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
+  const int n_layers = 4;
+  const int n_cols = 8;
+  const int n_rows = 16;
+
   void test_correct_construction() override;
   // set_ptr()
   void test_other_methods() override;

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,9 +286,9 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
-  const int n_layers = 4;
-  const int n_cols = 8;
-  const int n_rows = 16;
+  const static int n_layers = 4;
+  const static int n_cols = 8;
+  const static int n_rows = 16;
 
   void test_correct_construction() override;
   // set_ptr()

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -111,6 +111,10 @@ protected:
    */
   virtual bool test_wrong_input_dimensions() { return false;}
   /**
+   * @brief Tests the behaviour of construction when passed an array of the incorrect type
+   */
+  virtual bool test_wrong_input_type() { return false;}
+  /**
    * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
    */
   virtual bool test_incorrect_number_of_fields() { return false;}
@@ -149,6 +153,10 @@ public:
       logging_string += "Incorrect dimension of input";
       test_executed = test_wrong_input_dimensions();
     }
+    SECTION("Incorrect type of input") {
+      logging_string += "Incorrect type of input";
+      test_executed = test_wrong_input_type();
+    }
     SECTION("Incorrect number of fields") {
       logging_string += "Incorrect number of fields";
       test_executed = test_incorrect_number_of_fields();
@@ -156,6 +164,10 @@ public:
     SECTION("Correct construction") {
       logging_string += "Correct construction";
       test_executed = test_correct_construction();
+    }
+    SECTION("initialise() method") {
+      logging_string += "initialise() method";
+      test_executed = test_initialise_method();
     }
 
     // suppress output if no test was run
@@ -212,4 +224,18 @@ private:
 
 public:
   std::string get_class_name() override { return "DetectorSensitivityArray";}
+};
+
+class DispersiveMultilayerTest : public AbstractArrayTest {
+private:
+  const int n_fields = 9;
+  const char *fieldnames[9] = {"alpha",   "beta",    "gamma",   "kappa_x", "kappa_y",
+                               "kappa_z", "sigma_x", "sigma_y", "sigma_z"};
+
+  bool test_empty_construction() override;
+  bool test_wrong_input_type() override;
+  bool test_correct_construction() override;
+
+public:
+  std::string get_class_name() override { return "DispersiveMultilayerTest"; }
 };

--- a/tdms/tests/unit/array_tests/test_CollectionBase.cpp
+++ b/tdms/tests/unit/array_tests/test_CollectionBase.cpp
@@ -7,73 +7,61 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 
-TEST_CASE("CCollection") {
+bool CCollectionTest::test_incorrect_number_of_fields() {
+  create_1by1_struct(3, fieldnames);
+  REQUIRE_THROWS_AS(CCollection(matlab_input), std::runtime_error);
+  return true;
+}
 
-  // setup - an empty mxArray and the names of the field components
-  mxArray *matlab_input;
-  const int n_numeric_elements = 8;
-  const char *fieldnames[] = {"Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz"};
-
-  // we need to provide a struct array with either 6 or 9 fields
-  // incorrect number of fields should throw an error
-  SECTION("Incorrect number of fields") {
-    matlab_input = mxCreateStructMatrix(1, 1, 3, fieldnames);
-    REQUIRE_THROWS_AS(CCollection(matlab_input), std::runtime_error);
-  }
-
-  // now create an array with the correct fieldnames
-  SECTION("Expected input (6 fields)") {
-    matlab_input = mxCreateStructMatrix(1, 1, 6, fieldnames);
-    mxArray *elements6[6];
+bool CCollectionTest::test_correct_construction() {
+  SECTION("(6 inputs)") {
+    create_1by1_struct(6, fieldnames);
+    mxArray *field_arrays[6];
     for (int i = 0; i < 6; i++) {
-      elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
-      mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
+      field_arrays[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+      mxSetField(matlab_input, 0, fieldnames[i], field_arrays[i]);
     }
     CCollection cc6(matlab_input);
     REQUIRE(!cc6.is_disp_ml);
     REQUIRE(!cc6.is_multilayer);
   }
-  SECTION("Expected input (9 fields)") {
-    matlab_input = mxCreateStructMatrix(1, 1, 9, fieldnames);
-    mxArray *elements9[9];
+  SECTION("(9 inputs)") {
+    create_1by1_struct(9, fieldnames);
+    mxArray *field_arrays[9];
     for (int i = 0; i < 9; i++) {
-      elements9[i] = mxCreateNumericMatrix(2, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
-      mxSetField(matlab_input, 0, fieldnames[i], elements9[i]);
+      field_arrays[i] = mxCreateNumericMatrix(2, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+      mxSetField(matlab_input, 0, fieldnames[i], field_arrays[i]);
     }
     CCollection cc9(matlab_input);
     REQUIRE(cc9.is_disp_ml);
     REQUIRE(cc9.is_multilayer);
   }
+  return true;
+}
 
-  // tear down
-  mxDestroyArray(matlab_input);
+bool DCollectionTest::test_incorrect_number_of_fields() {
+  create_1by1_struct(3, fieldnames);
+  REQUIRE_THROWS_AS(DCollection(matlab_input), std::runtime_error);
+  return true;
+}
+
+bool DCollectionTest::test_correct_construction() {
+  create_1by1_struct(6, fieldnames);
+  mxArray *elements6[6];
+  for (int i = 0; i < 6; i++) {
+    elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
+  }
+  REQUIRE_NOTHROW(DCollection(matlab_input));
+  return true;
+}
+
+TEST_CASE("CCollection") {
+  CCollectionTest().run_all_class_tests();
 }
 
 TEST_CASE("DCollection") {
-
-  mxArray *matlab_input;
-  const char *fieldnames[] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
-  const int n_numeric_elements = 8;
-
-  // we need to provide a struct array with either 6 or 9 fields
-  // incorrect number of fields should throw an error
-  SECTION("Incorrect number of fields") {
-    matlab_input = mxCreateStructMatrix(1, 1, 3, fieldnames);
-    REQUIRE_THROWS_AS(CCollection(matlab_input), std::runtime_error);
-  }
-
-  // now create an array with the correct fieldnames
-  SECTION("Expected input") {
-    matlab_input = mxCreateStructMatrix(1, 1, 6, fieldnames);
-    mxArray *elements6[6];
-    for (int i = 0; i < 6; i++) {
-      elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
-      mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
-    }
-    REQUIRE_NOTHROW(DCollection(matlab_input));
-  }
-
-  // tear down - cleanup MATLAB memory
-  mxDestroyArray(matlab_input);
+  DCollectionTest().run_all_class_tests();
 };

--- a/tdms/tests/unit/array_tests/test_CollectionBase.cpp
+++ b/tdms/tests/unit/array_tests/test_CollectionBase.cpp
@@ -9,13 +9,12 @@
 #include "array_test_class.h"
 #include "arrays.h"
 
-bool CCollectionTest::test_incorrect_number_of_fields() {
+void CCollectionTest::test_incorrect_number_of_fields() {
   create_1by1_struct(3, fieldnames);
   REQUIRE_THROWS_AS(CCollection(matlab_input), std::runtime_error);
-  return true;
 }
 
-bool CCollectionTest::test_correct_construction() {
+void CCollectionTest::test_correct_construction() {
   SECTION("(6 inputs)") {
     create_1by1_struct(6, fieldnames);
     mxArray *field_arrays[6];
@@ -38,16 +37,14 @@ bool CCollectionTest::test_correct_construction() {
     REQUIRE(cc9.is_disp_ml);
     REQUIRE(cc9.is_multilayer);
   }
-  return true;
 }
 
-bool DCollectionTest::test_incorrect_number_of_fields() {
+void DCollectionTest::test_incorrect_number_of_fields() {
   create_1by1_struct(3, fieldnames);
   REQUIRE_THROWS_AS(DCollection(matlab_input), std::runtime_error);
-  return true;
 }
 
-bool DCollectionTest::test_correct_construction() {
+void DCollectionTest::test_correct_construction() {
   create_1by1_struct(6, fieldnames);
   mxArray *elements6[6];
   for (int i = 0; i < 6; i++) {
@@ -55,7 +52,6 @@ bool DCollectionTest::test_correct_construction() {
     mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
   }
   REQUIRE_NOTHROW(DCollection(matlab_input));
-  return true;
 }
 
 TEST_CASE("CCollection") { CCollectionTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_CollectionBase.cpp
+++ b/tdms/tests/unit/array_tests/test_CollectionBase.cpp
@@ -6,8 +6,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 
 bool CCollectionTest::test_incorrect_number_of_fields() {
   create_1by1_struct(3, fieldnames);
@@ -58,10 +58,6 @@ bool DCollectionTest::test_correct_construction() {
   return true;
 }
 
-TEST_CASE("CCollection") {
-  CCollectionTest().run_all_class_tests();
-}
+TEST_CASE("CCollection") { CCollectionTest().run_all_class_tests(); }
 
-TEST_CASE("DCollection") {
-  DCollectionTest().run_all_class_tests();
-};
+TEST_CASE("DCollection") { DCollectionTest().run_all_class_tests(); };

--- a/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
+++ b/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 
 void ComplexAmplitudeSampleTest::test_empty_construction() {
-  create_empty_struct(2, fieldnames);
+  create_empty_struct();
   CHECK_NOTHROW(ComplexAmplitudeSample(matlab_input));
   ComplexAmplitudeSample empty_test(matlab_input);
   // n_vertices should return 0, since Vector has not been set so should default initialise to 0-vertex matrix

--- a/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
+++ b/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-bool ComplexAmplitudeSampleTest::test_empty_construction() {
+void ComplexAmplitudeSampleTest::test_empty_construction() {
   create_empty_struct(2, fieldnames);
   CHECK_NOTHROW(ComplexAmplitudeSample(matlab_input));
   ComplexAmplitudeSample empty_test(matlab_input);
@@ -21,10 +21,9 @@ bool ComplexAmplitudeSampleTest::test_empty_construction() {
   CHECK(empty_test.n_vertices() == 0);
   CHECK(!empty_test.vertices.has_elements());
   CHECK(!empty_test.components.has_elements());
-  return true;
 }
 
-bool ComplexAmplitudeSampleTest::test_correct_construction() {
+void ComplexAmplitudeSampleTest::test_correct_construction() {
   create_struct_array(2, dimensions_2d, 2, fieldnames);
   // each entry is a numeric array, setup for vertices and components
   // array for "vertices" field
@@ -36,7 +35,6 @@ bool ComplexAmplitudeSampleTest::test_correct_construction() {
   mxSetField(matlab_input, 0, fieldnames[1], components_vector);
   // create an instance using this struct
   REQUIRE_NOTHROW(ComplexAmplitudeSample(matlab_input));
-  return true;
 }
 
 TEST_CASE("ComplexAmplitudeSample") { ComplexAmplitudeSampleTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
+++ b/tdms/tests/unit/array_tests/test_ComplexAmplitudeSample.cpp
@@ -6,49 +6,37 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
+#include "array_test_class.h"
 #include "arrays.h"
 #include "globals.h"
 
 using namespace std;
 
-TEST_CASE("ComplexAmplitudeSample") {
-
-  mxArray *matlab_input;
-  int dimensions[2] = {1, 1};
-  const int n_fields = 2;
-  const char *fieldnames[n_fields] = {"vertices", "components"};
-
-  // Constructor should just exit if recieving an empty struct
-  SECTION("Empty input") {
-    dimensions[0] = 0;
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, n_fields, fieldnames);
-    CHECK_NOTHROW(ComplexAmplitudeSample(matlab_input));
-    ComplexAmplitudeSample empty_test(matlab_input);
-    // n_vertices should return 0, since Vector has not been set so should default initialise to 0-vertex matrix
-    // similarly, vector & components should be flagged as having no elements
-    CHECK(empty_test.n_vertices() == 0);
-    CHECK(!empty_test.vertices.has_elements());
-    CHECK(!empty_test.components.has_elements());
-  }
-
-  // For successful construction, we need to build a MATLAB struct with 2 fields
-  // these are the fieldnames that are expected
-  SECTION("Expected input") {
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, n_fields, fieldnames);
-    // each entry is a numeric array, setup for vertices and components
-    // copy code from Vertices and FieldComponentsVector once those tests have been added
-    const int n_elements = 8;
-    // array for "vertices" field
-    mxArray *vertices_array = mxCreateNumericMatrix(n_elements, 3, mxINT32_CLASS, mxREAL);
-    // array for "components" field
-    mxArray *components_vector = mxCreateNumericMatrix(1, n_elements, mxINT16_CLASS, mxREAL);
-    // add fields to struct that will be passed to CAS constructor function
-    mxSetField(matlab_input, 0, fieldnames[0], vertices_array);
-    mxSetField(matlab_input, 0, fieldnames[1], components_vector);
-    // create an instance using this struct
-    REQUIRE_NOTHROW(ComplexAmplitudeSample(matlab_input));
-  }
-
-  // tear down
-  mxDestroyArray(matlab_input);
+bool ComplexAmplitudeSampleTest::test_empty_construction() {
+  create_empty_struct(2, fieldnames);
+  CHECK_NOTHROW(ComplexAmplitudeSample(matlab_input));
+  ComplexAmplitudeSample empty_test(matlab_input);
+  // n_vertices should return 0, since Vector has not been set so should default initialise to 0-vertex matrix
+  // similarly, vector & components should be flagged as having no elements
+  CHECK(empty_test.n_vertices() == 0);
+  CHECK(!empty_test.vertices.has_elements());
+  CHECK(!empty_test.components.has_elements());
+  return true;
 }
+
+bool ComplexAmplitudeSampleTest::test_correct_construction() {
+  create_struct_array(2, dimensions_2d, 2, fieldnames);
+  // each entry is a numeric array, setup for vertices and components
+  // array for "vertices" field
+  mxArray *vertices_array = mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
+  // array for "components" field
+  mxArray *components_vector = mxCreateNumericMatrix(1, n_numeric_elements, mxINT16_CLASS, mxREAL);
+  // add fields to struct that will be passed to CAS constructor function
+  mxSetField(matlab_input, 0, fieldnames[0], vertices_array);
+  mxSetField(matlab_input, 0, fieldnames[1], components_vector);
+  // create an instance using this struct
+  REQUIRE_NOTHROW(ComplexAmplitudeSample(matlab_input));
+  return true;
+}
+
+TEST_CASE("ComplexAmplitudeSample") { ComplexAmplitudeSampleTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -11,16 +11,15 @@
 
 using namespace std;
 
-bool DTildeTest::test_correct_construction() {
+void DTildeTest::test_correct_construction() {
   // check no information is contained in the DTilde object when declared with default constructor
   DTilde dt;
   bool no_information_stored =
           (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
   REQUIRE(no_information_stored);
-  return true;
 }
 
-bool DTildeTest::test_empty_construction() {
+void DTildeTest::test_empty_construction() {
   DTilde dt;
   bool no_information_stored;
   // initialise() method should exit without assignment
@@ -31,20 +30,18 @@ bool DTildeTest::test_empty_construction() {
   no_information_stored =
           (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
   REQUIRE(no_information_stored);
-  return true;
 }
 
-bool DTildeTest::test_wrong_input_type() {
+void DTildeTest::test_wrong_input_type() {
   DTilde dt;
   // initialise() will throw error if we attempt to provide a non-empty, non-struct array
   dimensions_2d[0] = 2;
   dimensions_2d[1] = 3;
   create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
   REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
-  return true;
 }
 
-bool DTildeTest::test_incorrect_number_of_fields() {
+void DTildeTest::test_incorrect_number_of_fields() {
   DTilde dt;
   // assignment will throw error if we attempt to provide a struct array that doesn't have two fields
   SECTION("Struct with too many fields") {
@@ -57,10 +54,9 @@ bool DTildeTest::test_incorrect_number_of_fields() {
     create_struct_array(2, dimensions_2d, 3, too_few_names);
     REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
-  return true;
 }
 
-bool DTildeTest::test_initialise_method() {
+void DTildeTest::test_initialise_method() {
   DTilde dt;
   // otherwise, we need to provide a struct with two fields, Dx_tilde and Dy_tilde
   // these fields must contain (n_det_modes, n_rows, n_cols) arrays of doubles/complex
@@ -81,7 +77,6 @@ bool DTildeTest::test_initialise_method() {
   bool information_stored = (dt.num_det_modes() == target_n_det_modes) && (dt.x.has_elements()) &&
                             (dt.y.has_elements());
   CHECK(information_stored);
-  return true;
 }
 
 TEST_CASE("DTilde") {

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -23,7 +23,7 @@ void DTildeTest::test_empty_construction() {
   DTilde dt;
   bool no_information_stored;
   // initialise() method should exit without assignment
-  create_empty_struct(0, {});
+  create_empty_struct();
   // attempt assignment (2nd and 3rd args don't matter)
   dt.initialise(matlab_input, 0, 0);
   // should still be unassigned vectors

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -7,86 +7,83 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 
 using namespace std;
 
-TEST_CASE("DTilde") {
+bool DTildeTest::test_correct_construction() {
+  // check no information is contained in the DTilde object when declared with default constructor
+  DTilde dt;
+  bool no_information_stored =
+          (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
+  REQUIRE(no_information_stored);
+  return true;
+}
 
+bool DTildeTest::test_empty_construction() {
   DTilde dt;
   bool no_information_stored;
-  int dimensions[2];
-  mxArray *test_input;
+  // initialise() method should exit without assignment
+  create_empty_struct(0, {});
+  // attempt assignment (2nd and 3rd args don't matter)
+  dt.initialise(matlab_input, 0, 0);
+  // should still be unassigned vectors
+  no_information_stored =
+          (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
+  REQUIRE(no_information_stored);
+  return true;
+}
 
-  // check no information is contained in the DTilde object
-  SECTION("No information stored on declaration") {
-    no_information_stored =
-            (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
-    REQUIRE(no_information_stored);
-  }
+bool DTildeTest::test_wrong_input_type() {
+  DTilde dt;
+  // initialise() will throw error if we attempt to provide a non-empty, non-struct array
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = 3;
+  create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
+  REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
+  return true;
+}
 
-  // initialise() method should exit without assignment if we pass in a pointer to an empty array
-  // create empty array
-  SECTION("Empty array input") {
-    dimensions[0] = 0;
-    dimensions[1] = 1;
-    test_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    // attempt assignment (2nd and 3rd args don't matter)
-    dt.initialise(test_input, 0, 0);
-    // should still be unassigned vectors
-    no_information_stored =
-            (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
-    REQUIRE(no_information_stored);
-  }
-
-  // assignment will throw error if we attempt to provide a non-empty, non-struct array
-  SECTION("Non-struct input") {
-    dimensions[0] = 2;
-    dimensions[1] = 3;
-    test_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    CHECK_THROWS_AS(dt.initialise(test_input, 0, 0), runtime_error);
-  }
-
+bool DTildeTest::test_incorrect_number_of_fields() {
+  DTilde dt;
   // assignment will throw error if we attempt to provide a struct array that doesn't have two fields
   SECTION("Struct with too many fields") {
-    dimensions[0] = 1;
-    dimensions[1] = 1;
     const char *too_mny_names[3] = {"field1", "field2", "field3"};
-    test_input = mxCreateStructArray(2, (const mwSize *) dimensions, 3, too_mny_names);
-    CHECK_THROWS_AS(dt.initialise(test_input, 0, 0), runtime_error);
+    create_struct_array(2, dimensions_2d, 3, too_mny_names);
+    REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
   SECTION("Struct with too few fields") {
-    dimensions[0] = 1;
-    dimensions[1] = 1;
     const char *too_few_names[1] = {"field1"};
-    test_input = mxCreateStructArray(2, (const mwSize *) dimensions, 1, too_few_names);
-    CHECK_THROWS_AS(dt.initialise(test_input, 0, 0), runtime_error);
+    create_struct_array(2, dimensions_2d, 3, too_few_names);
+    REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
+  return true;
+}
 
+bool DTildeTest::test_initialise_method() {
+  DTilde dt;
   // otherwise, we need to provide a struct with two fields, Dx_tilde and Dy_tilde
   // these fields must contain (n_det_modes, n_rows, n_cols) arrays of doubles/complex
-  SECTION("Correct input") {
-    const char *fieldnames[] = {"Dx_tilde", "Dy_tilde"};
-    dimensions[0] = 1;
-    dimensions[1] = 1;
-    const int target_n_det_modes = 5, n_rows = 6, n_cols = 4;
-    const int field_array_dimensions[3] = {target_n_det_modes, n_rows, n_cols};
-    // create the struct
-    test_input = mxCreateStructArray(2, (const mwSize *) dimensions, 2, fieldnames);
-    // create the data for the fields of our struct
-    mxArray *field_array_ptrs[2];
-    for (int i = 0; i < 2; i++) {
-      field_array_ptrs[i] =
-              mxCreateNumericArray(3, (const mwSize *) field_array_dimensions, mxDOUBLE_CLASS, mxCOMPLEX);
-      mxSetField(test_input, 0, fieldnames[i], field_array_ptrs[i]);
-    }
-    // attempt to create a vector from this struct
-    REQUIRE_NOTHROW(dt.initialise(test_input, n_rows, n_cols));
-    // check that we actually assigned values to the Vectors under the hood
-    bool information_stored = (dt.num_det_modes() == target_n_det_modes) && (dt.x.has_elements()) &&
-                              (dt.y.has_elements());
-    CHECK(information_stored);
+  const int target_n_det_modes = 5, n_rows = 6, n_cols = 4;
+  const int field_array_dimensions[3] = {target_n_det_modes, n_rows, n_cols};
+  // create the struct
+  create_struct_array(2, dimensions_2d, n_fields, fieldnames);
+  // create the data for the fields of our struct
+  mxArray *field_array_ptrs[n_fields];
+  for (int i = 0; i < n_fields; i++) {
+    field_array_ptrs[i] = mxCreateNumericArray(3, (const mwSize *) field_array_dimensions,
+                                               mxDOUBLE_CLASS, mxCOMPLEX);
+    mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
+  // attempt to create a vector from this struct
+  REQUIRE_NOTHROW(dt.initialise(matlab_input, n_rows, n_cols));
+  // check that we actually assigned values to the Vectors under the hood
+  bool information_stored = (dt.num_det_modes() == target_n_det_modes) && (dt.x.has_elements()) &&
+                            (dt.y.has_elements());
+  CHECK(information_stored);
+  return true;
+}
 
-  // tear down
-  mxDestroyArray(test_input);
+TEST_CASE("DTilde") {
+  DTildeTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
+++ b/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
@@ -4,28 +4,29 @@
  * @brief Unit tests for the DetectorSensitivityArrays class and its subclasses
  */
 #include <catch2/catch_test_macros.hpp>
-#include <spdlog/spdlog.h>
 #include <fftw3.h>
+#include <spdlog/spdlog.h>
 
 #include <cmath>
 
+#include "array_test_class.h"
 #include "arrays.h"
 #include "globals.h"
 
 using namespace std;
 using namespace tdms_math_constants;
 
-TEST_CASE("DetectorSensitivityArrays") {
-
-  mxArray *matlab_input;
+bool DetectorSensitivityArraysTest::test_correct_construction() {
   DetectorSensitivityArrays dsa;
-  const int n_rows = 8, n_cols = 4;
-
   // default constructor should set everything to nullptrs
   // destructor uses fftw destroy, which handles nullptrs itself
-  bool all_are_nullptrs = (dsa.cm==nullptr) && (dsa.plan==nullptr) && (dsa.v==nullptr);
+  bool all_are_nullptrs = (dsa.cm == nullptr) && (dsa.plan == nullptr) && (dsa.v == nullptr);
   REQUIRE(all_are_nullptrs);
+  return true;
+}
 
+bool DetectorSensitivityArraysTest::test_initialise_method() {
+  DetectorSensitivityArrays dsa;
   // now let's construct a non-trival object
   dsa.initialise(n_rows, n_cols);
   // we should be able to assign complex doubles to the elements of cm now
@@ -40,4 +41,7 @@ TEST_CASE("DetectorSensitivityArrays") {
   // we can call the fftw_plan execution, which should place the 2D FFT into dsa.v
   // simply checking executation is sufficient, as fftw should cover whether the FFT is actually meaningful in what it puts out
   REQUIRE_NOTHROW(fftw_execute(dsa.plan));
+  return true;
 }
+
+TEST_CASE("DetectorSensitivityArrays") { DetectorSensitivityArraysTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
+++ b/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
@@ -16,16 +16,15 @@
 using namespace std;
 using namespace tdms_math_constants;
 
-bool DetectorSensitivityArraysTest::test_correct_construction() {
+void DetectorSensitivityArraysTest::test_correct_construction() {
   DetectorSensitivityArrays dsa;
   // default constructor should set everything to nullptrs
   // destructor uses fftw destroy, which handles nullptrs itself
   bool all_are_nullptrs = (dsa.cm == nullptr) && (dsa.plan == nullptr) && (dsa.v == nullptr);
   REQUIRE(all_are_nullptrs);
-  return true;
 }
 
-bool DetectorSensitivityArraysTest::test_initialise_method() {
+void DetectorSensitivityArraysTest::test_initialise_method() {
   DetectorSensitivityArrays dsa;
   // now let's construct a non-trival object
   dsa.initialise(n_rows, n_cols);
@@ -41,7 +40,6 @@ bool DetectorSensitivityArraysTest::test_initialise_method() {
   // we can call the fftw_plan execution, which should place the 2D FFT into dsa.v
   // simply checking executation is sufficient, as fftw should cover whether the FFT is actually meaningful in what it puts out
   REQUIRE_NOTHROW(fftw_execute(dsa.plan));
-  return true;
 }
 
 TEST_CASE("DetectorSensitivityArrays") { DetectorSensitivityArraysTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -15,20 +15,20 @@ using namespace std;
 using Catch::Approx;
 using tdms_tests::TOLERANCE;
 
-bool DispersiveMultilayerTest::test_empty_construction() {
+void DispersiveMultilayerTest::test_empty_construction() {
   // Constructor should error if recieving a struct with no fields
   create_1by1_struct(0, {});
   REQUIRE_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
-  return true;
 }
-bool DispersiveMultilayerTest::test_wrong_input_type() {
+
+void DispersiveMultilayerTest::test_wrong_input_type() {
   // Constructor should throw runtime_error at not recieving struct
   dimensions_2d[0] = 2; dimensions_2d[1] = 3;
   create_numeric_array(2, dimensions_2d, mxUINT16_CLASS);
   REQUIRE_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
-  return true;
 }
-bool DispersiveMultilayerTest::test_correct_construction() {
+
+void DispersiveMultilayerTest::test_correct_construction() {
   create_1by1_struct(n_fields, fieldnames);
   // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
   const int array_size[2] = {1, n_numeric_elements};
@@ -55,7 +55,6 @@ bool DispersiveMultilayerTest::test_correct_construction() {
     CHECK(dml.sigma.y[i] == Approx(i).epsilon(TOLERANCE));
     CHECK(dml.sigma.z[i] == Approx(i).epsilon(TOLERANCE));
   }
-  return true;
 }
 
 TEST_CASE("DispersiveMultiLayer") {

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -8,69 +8,56 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 #include "unit_test_utils.h"
 
 using namespace std;
 using Catch::Approx;
 using tdms_tests::TOLERANCE;
 
-TEST_CASE("DispersiveMultiLayer") {
-
-  mxArray *matlab_input;
+bool DispersiveMultilayerTest::test_empty_construction() {
+  // Constructor should error if recieving a struct with no fields
+  create_1by1_struct(0, {});
+  REQUIRE_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
+  return true;
+}
+bool DispersiveMultilayerTest::test_wrong_input_type() {
   // Constructor should throw runtime_error at not recieving struct
-  // create a MATLAB pointer to something that isn't an array
-  SECTION("Non-struct input") {
-    int n_elements[2] = {2, 3};
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) n_elements, mxUINT8_CLASS, mxREAL);
-    CHECK_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
+  dimensions_2d[0] = 2; dimensions_2d[1] = 3;
+  create_numeric_array(2, dimensions_2d, mxUINT16_CLASS);
+  REQUIRE_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
+  return true;
+}
+bool DispersiveMultilayerTest::test_correct_construction() {
+  create_1by1_struct(n_fields, fieldnames);
+  // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
+  const int array_size[2] = {1, n_numeric_elements};
+  mxArray *field_array_ptrs[n_fields];
+  for (int i = 0; i < n_fields; i++) {
+    field_array_ptrs[i] =
+            mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
+    mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
+    for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) i; }
+    mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
-
-  // Constructor should error if recieving an empty struct
-  // create a MATLAB pointer to an empty struct
-  SECTION("Empty struct input") {
-    const char* empty_fields[] = {};
-    const int empty_dimensions[2] = {1,1};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) empty_dimensions, 0, empty_fields);
-    CHECK_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
+  // we should now be able to create a DispersiveMultiLayer object
+  REQUIRE_NOTHROW(DispersiveMultiLayer(matlab_input));
+  DispersiveMultiLayer dml(matlab_input);
+  // now check that the data has been correctly assigned
+  for (int i = 0; i < n_numeric_elements; i++) {
+    CHECK(dml.alpha[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.beta[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.gamma[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.kappa.x[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.kappa.y[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.kappa.z[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.sigma.x[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.sigma.y[i] == Approx(i).epsilon(TOLERANCE));
+    CHECK(dml.sigma.z[i] == Approx(i).epsilon(TOLERANCE));
   }
+  return true;
+}
 
-  // For successful construction, we need to build a MATLAB struct with 9 fields
-  // these are the fieldnames that are expected
-  SECTION("Successful construction") {
-    const int n_fields = 9;
-    const char *fieldnames[n_fields] = {"alpha", "beta", "gamma", "kappa_x", "kappa_y",
-                                        "kappa_z", "sigma_x", "sigma_y", "sigma_z"};
-    const int n_field_elements = 5;
-    // build our struct
-    const int dimensions[2] = {1, 1};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, n_fields, fieldnames);
-    // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
-    const int array_size[2] = {1, n_field_elements};
-    mxArray *field_array_ptrs[n_fields];
-    for (int i = 0; i < n_fields; i++) {
-      field_array_ptrs[i] =
-              mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
-      mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
-      for (int i = 0; i < 5; i++) { where_to_place_data[i] = (double) i; }
-      mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
-    }
-    // we should now be able to create a DispersiveMultiLayer object
-    REQUIRE_NOTHROW(DispersiveMultiLayer(matlab_input));
-    DispersiveMultiLayer dml(matlab_input);
-    // now check that the data has been correctly assigned
-    for (int i = 0; i < 5; i++) {
-      CHECK(dml.alpha[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.beta[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.gamma[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.kappa.x[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.kappa.y[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.kappa.z[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.sigma.x[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.sigma.y[i] == Approx(i).epsilon(TOLERANCE));
-      CHECK(dml.sigma.z[i] == Approx(i).epsilon(TOLERANCE));
-    }
-  }
-
-  // tear down
-  mxDestroyArray(matlab_input);
+TEST_CASE("DispersiveMultiLayer") {
+  DispersiveMultilayerTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_FieldSample.cpp
+++ b/tdms/tests/unit/array_tests/test_FieldSample.cpp
@@ -15,7 +15,7 @@ using tdms_tests::TOLERANCE;
 
 void FieldSampleTest::test_empty_construction() {
   // should exit with default values
-  create_empty_struct(n_fields, fieldnames);
+  create_empty_struct();
   // attempt construction
   FieldSample empty_fs(matlab_input);
   // should still be unassigned vectors

--- a/tdms/tests/unit/array_tests/test_FieldSample.cpp
+++ b/tdms/tests/unit/array_tests/test_FieldSample.cpp
@@ -7,55 +7,47 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 #include "unit_test_utils.h"
 
 using namespace std;
 using tdms_tests::TOLERANCE;
 
-TEST_CASE("FieldSample") {
+void FieldSampleTest::test_empty_construction() {
+  // should exit with default values
+  create_empty_struct(n_fields, fieldnames);
+  // attempt construction
+  FieldSample empty_fs(matlab_input);
+  // should still be unassigned vectors
+  bool no_vectors_set = (!empty_fs.i.has_elements()) && (!empty_fs.j.has_elements()) &&
+                        (!empty_fs.k.has_elements()) && (!empty_fs.n.has_elements());
+  REQUIRE(no_vectors_set);
+}
 
-  mxArray *matlab_input;
-  int dimensions[2] = {1, 1};
-  const char *fieldnames[] = {"i", "j", "k", "n"};
+void FieldSampleTest::test_wrong_input_type() {
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = 3;
+  create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
+  CHECK_THROWS_AS(FieldSample(matlab_input), runtime_error);
+}
 
-  // attempting to construct with an empty array should exit with default values
-  SECTION("Empty array input") {
-    dimensions[0] = 0;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    // attempt assignment (2nd and 3rd args don't matter)
-    FieldSample empty_fs(matlab_input);
-    // should still be unassigned vectors
-    bool no_vectors_set = (!empty_fs.i.has_elements()) && (!empty_fs.j.has_elements()) &&
-                          (!empty_fs.k.has_elements()) && (!empty_fs.n.has_elements());
-    REQUIRE(no_vectors_set);
-  }
-
-  // construction fails if provided a non-empty, non-struct array
-  SECTION("Non-struct input") {
-    dimensions[0] = 2;
-    dimensions[1] = 3;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    CHECK_THROWS_AS(FieldSample(matlab_input), runtime_error);
-  }
-
-  // construction fails if provided a struct array that doesn't have 4 fields
+void FieldSampleTest::test_incorrect_number_of_fields() {
   SECTION("Struct with too many fields") {
     const char *too_many_names[5] = {"field1", "field2", "field3", "field4", "field5"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 5, too_many_names);
+    create_1by1_struct(5, too_many_names);
     CHECK_THROWS_AS(FieldSample(matlab_input), runtime_error);
   }
   SECTION("Struct with too few fields") {
-    const char *too_few_names[1] = {"field1"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 1, too_few_names);
+    create_1by1_struct(n_fields - 1, fieldnames);
     CHECK_THROWS_AS(FieldSample(matlab_input), runtime_error);
   }
+}
 
-  // expecting a struct with fields i, j, k, and n
+void FieldSampleTest::test_correct_construction() {
   SECTION("Expected input (populated)") {
-    const int number_of_vector_elements = 8;
-    const int vector_dimensions[2] = {1, number_of_vector_elements};
+    const int vector_dimensions[2] = {1, n_numeric_elements};
     // create the struct
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 4, fieldnames);
+    create_1by1_struct(n_fields, fieldnames);
     // create vectors to place in the fields of the struct
     mxArray *i_vector =
             mxCreateNumericArray(2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
@@ -72,8 +64,8 @@ TEST_CASE("FieldSample") {
     mxDouble *place_n_data = mxGetPr(n_vector);//< 1, 1/2, 1/3, ...
     for (int i = 0; i < 4; i++) {
       place_i_data[i] = i;
-      place_j_data[i] = number_of_vector_elements - (i + 1);
-      place_k_data[i] = i % (number_of_vector_elements / 2);
+      place_j_data[i] = n_numeric_elements - (i + 1);
+      place_k_data[i] = i % (n_numeric_elements / 2);
       place_n_data[i] = 1. / (double) (i + 1);
     }
     // set the vectors to be the field values
@@ -86,12 +78,12 @@ TEST_CASE("FieldSample") {
     FieldSample fs(matlab_input);
     // check that the tensor attribute is the correct size
     const mwSize *dimensions = mxGetDimensions(fs.mx);
-    for (int i = 0; i < 4; i++) { CHECK(dimensions[i] == number_of_vector_elements); }
+    for (int i = 0; i < 4; i++) { CHECK(dimensions[i] == n_numeric_elements); }
     // check that we did indeed copy the data across
     for (int i = 0; i < 4; i++) {
       CHECK(abs(fs.i[i] - i) < TOLERANCE);
-      CHECK(abs(fs.j[i] - (number_of_vector_elements - (i + 1))) < TOLERANCE);
-      CHECK(abs(fs.k[i] - (i % (number_of_vector_elements / 2))) < TOLERANCE);
+      CHECK(abs(fs.j[i] - (n_numeric_elements - (i + 1))) < TOLERANCE);
+      CHECK(abs(fs.k[i] - (i % (n_numeric_elements / 2))) < TOLERANCE);
       CHECK(abs(fs.n[i] - 1. / (double) (i + 1)) < TOLERANCE);
     }
   }
@@ -100,16 +92,16 @@ TEST_CASE("FieldSample") {
   SECTION("Expected inputs (empty vectors)") {
     const int empty_vector_dimensions[2] = {1, 0};
     // create the struct
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 4, fieldnames);
+    create_1by1_struct(n_fields, fieldnames);
     // create vectors to place in the fields of the struct
-    mxArray *empty_i_vector =
-            mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *empty_j_vector =
-            mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *empty_k_vector =
-            mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *empty_n_vector =
-            mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions, mxDOUBLE_CLASS, mxREAL);
+    mxArray *empty_i_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
+                                                   mxINT32_CLASS, mxREAL);
+    mxArray *empty_j_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
+                                                   mxINT32_CLASS, mxREAL);
+    mxArray *empty_k_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
+                                                   mxINT32_CLASS, mxREAL);
+    mxArray *empty_n_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
+                                                   mxDOUBLE_CLASS, mxREAL);
     mxSetField(matlab_input, 0, fieldnames[0], empty_i_vector);
     mxSetField(matlab_input, 0, fieldnames[1], empty_j_vector);
     mxSetField(matlab_input, 0, fieldnames[2], empty_k_vector);
@@ -123,7 +115,8 @@ TEST_CASE("FieldSample") {
     const mwSize *empty_tensor_dimensions = mxGetDimensions(fs_from_empty_vectors.mx);
     for (int i = 0; i < 4; i++) { CHECK(empty_tensor_dimensions[i] == 0); }
   }
+}
 
-  // cleanup
-  mxDestroyArray(matlab_input);
+TEST_CASE("FieldSample") {
+  FieldSampleTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_FrequencyVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_FrequencyVectors.cpp
@@ -7,89 +7,90 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 #include "unit_test_utils.h"
 
 using namespace std;
 using tdms_tests::TOLERANCE;
 
-TEST_CASE("FrequencyVectors") {
-
-  // there is no custom constructor for this class
+void FrequencyVectorsTest::test_empty_construction() {
+  // initialise() method should exit without assignment if we pass in a pointer to an empty array (regardless of whether this is a struct or not)
   FrequencyVectors fv;
-  mxArray *matlab_input;
-  int dimensions[2] = {1, 1};
-  // members should start unassigned
+  dimensions_2d[0] = 0;
+  create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
+  // attempt assignment
+  fv.initialise(matlab_input);
+  // should still be unassigned vectors
   bool not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
   REQUIRE(not_assigned);
+}
 
-  // initialise() method should exit without assignment if we pass in a pointer to an empty array
-  // create empty array
-  SECTION("Empty array input") {
-    dimensions[0] = 0;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    // attempt assignment
-    fv.initialise(matlab_input);
-    // should still be unassigned vectors
-    not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
-    REQUIRE(not_assigned);
-  }
+void FrequencyVectorsTest::test_wrong_input_type() {
+  FrequencyVectors fv;
+  // throw error if we attempt to provide a non-empty, non-struct array
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = 3;
+  create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
+  REQUIRE_THROWS_AS(fv.initialise(matlab_input), runtime_error);
+}
 
-  // assignment will throw error if we attempt to provide a non-empty, non-struct array
-  SECTION("Non-struct input") {
-    dimensions[0] = 2;
-    dimensions[1] = 3;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    CHECK_THROWS_AS(fv.initialise(matlab_input), runtime_error);
-  }
-
+void FrequencyVectorsTest::test_incorrect_number_of_fields() {
   // assignment will throw error if we attempt to provide a struct array that doesn't have two fields
+  FrequencyVectors fv;
   SECTION("Struct with too many inputs") {
     const char *too_many_names[3] = {"field1", "field2", "field3"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 3, too_many_names);
+    create_1by1_struct(3, too_many_names);
     CHECK_THROWS_AS(fv.initialise(matlab_input), runtime_error);
   }
   SECTION("Struct with too few inputs") {
-    const char *too_few_names[1] = {"field1"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 1, too_few_names);
+    create_1by1_struct(n_fields - 1, fieldnames);
     CHECK_THROWS_AS(fv.initialise(matlab_input), runtime_error);
   }
+}
 
-  // otherwise, we need to provide a struct, whose fields are vectors that can be assigned to
-  // setup for our struct
-  SECTION("Expected input") {
-    const char *fieldnames[] = {"fx_vec", "fy_vec"};
-    const int n_field_array_elements = 10;
-    const int field_array_dimensions[2] = {1, n_field_array_elements};
-    // create the struct
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 2, fieldnames);
-    // create the data for the fields of our struct
-    mxArray *field_array_ptrs[2];
-    for (int i = 0; i < 2; i++) {
-      field_array_ptrs[i] =
-              mxCreateNumericArray(2, (const mwSize *) field_array_dimensions, mxDOUBLE_CLASS, mxREAL);
-      mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
-      // 0th field, fx_vec[i], will be 1/(i+1)
-      // 1st field, fy_vec[i], will be -1/(i+1)
-      for (int j = 0; j < n_field_array_elements; j++) {
-        where_to_place_data[j] = pow(-1., (double) i) / ((double) (j + 1));
-      }
-      mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
+void FrequencyVectorsTest::test_correct_construction() {
+  FrequencyVectors fv;
+  // members should start unassigned
+  bool not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
+  REQUIRE(not_assigned);
+}
+
+void FrequencyVectorsTest::test_initialise_method() {
+  FrequencyVectors fv;
+  const int field_array_dimensions[2] = {1, n_numeric_elements};
+  // create the struct
+  create_1by1_struct(n_fields, fieldnames);
+  // create the data for the fields of our struct
+  mxArray *field_array_ptrs[2];
+  for (int i = 0; i < 2; i++) {
+    field_array_ptrs[i] = mxCreateNumericArray(2, (const mwSize *) field_array_dimensions,
+                                               mxDOUBLE_CLASS, mxREAL);
+    mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
+    // 0th field, fx_vec[i], will be 1/(i+1)
+    // 1st field, fy_vec[i], will be -1/(i+1)
+    for (int j = 0; j < n_numeric_elements; j++) {
+      where_to_place_data[j] = pow(-1., (double) i) / ((double) (j + 1));
     }
-    // attempt to create a vector from this struct
-    REQUIRE_NOTHROW(fv.initialise(matlab_input));
-    // check that we actually assigned values to the Vectors under the hood
-    not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
-    bool expected_size =
-            (fv.x.size() == n_field_array_elements && fv.y.size() == n_field_array_elements);
-    bool assigned_and_correct_size = ((!not_assigned) && expected_size);
-    REQUIRE(assigned_and_correct_size);
-    // and the values themselves are what we expect
-    for (int i = 0; i < n_field_array_elements; i++) {
-      CHECK(abs(fv.x[i] - 1. / ((double) (i + 1))) < TOLERANCE);
-      CHECK(abs(fv.y[i] + 1. / ((double) (i + 1))) < TOLERANCE);
-    }
+    mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
+  // attempt to create a vector from this struct
+  REQUIRE_NOTHROW(fv.initialise(matlab_input));
+  // check that we actually assigned values to the Vectors under the hood
+  bool not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
+  bool expected_size =
+          (fv.x.size() == n_numeric_elements && fv.y.size() == n_numeric_elements);
+  bool assigned_and_correct_size = ((!not_assigned) && expected_size);
+  REQUIRE(assigned_and_correct_size);
+  // and the values themselves are what we expect
+  bool values_are_correct = true;
+  for (int i = 0; i < n_numeric_elements; i++) {
+    values_are_correct = values_are_correct &&
+                         (abs(fv.x[i] - 1. / ((double) (i + 1))) < TOLERANCE) &&
+                         (abs(fv.y[i] + 1. / ((double) (i + 1))) < TOLERANCE);
+  }
+  REQUIRE(values_are_correct);
+}
 
-  // tear down
-  mxDestroyArray(matlab_input);
+TEST_CASE("FrequencyVectors") {
+  FrequencyVectorsTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_IncidentField.cpp
+++ b/tdms/tests/unit/array_tests/test_IncidentField.cpp
@@ -7,84 +7,79 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 #include "unit_test_utils.h"
 
 using namespace std;
 using tdms_tests::TOLERANCE;
 
-TEST_CASE("IncidentField") {
-
-  mxArray *matlab_input;
-  int dimensions[2] = {1, 1};
-
+void IncidentFieldTest::test_empty_construction() {
   // construction should fail if given an empty array
-  SECTION("Empty array input") {
-    dimensions[0] = 0;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    // attempt construction (2nd and 3rd args don't matter)
-    REQUIRE_THROWS_AS(IncidentField(matlab_input), runtime_error);
-  }
+  dimensions_2d[0] = 0;
+  create_empty_struct();
+  // attempt construction (2nd and 3rd args don't matter)
+  REQUIRE_THROWS_AS(IncidentField(matlab_input), runtime_error);
+}
 
-  // construction fails if provided a non-empty, non-struct array
-  SECTION("Non-struct input") {
-    dimensions[0] = 2; dimensions[1] = 3;
-    matlab_input = mxCreateNumericArray(2, (const mwSize *) dimensions, mxUINT8_CLASS, mxREAL);
-    CHECK_THROWS_AS(IncidentField(matlab_input), runtime_error);
-  }
+void IncidentFieldTest::test_wrong_input_type() {
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = 3;
+  create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
+  CHECK_THROWS_AS(IncidentField(matlab_input), runtime_error);
+}
 
-  // construction fails if provided a struct array that doesn't have two fields
+void IncidentFieldTest::test_incorrect_number_of_fields() {
   SECTION("Struct with too many fields") {
     const char *too_many_names[3] = {"field1", "field2", "field3"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 3, too_many_names);
+    create_1by1_struct(3, too_many_names);
     CHECK_THROWS_AS(IncidentField(matlab_input), runtime_error);
   }
   SECTION("Struct with too few fields") {
-    const char *too_few_names[1] = {"field1"};
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 1, too_few_names);
+    create_1by1_struct(n_fields - 1, fieldnames);
     CHECK_THROWS_AS(IncidentField(matlab_input), runtime_error);
   }
-
-  // otherwise, we need to provide a struct with two fields, Dx_tilde and Dy_tilde
-  // these fields must contain (n_det_modes, n_rows, n_cols) arrays of doubles/complex
-  SECTION("Expected input") {
-    const char *fieldnames[] = {"exi", "eyi"};
-    const int n_rows = 6, n_cols = 4, n_layers = 5;
-    const int field_array_dimensions[3] = {n_rows, n_cols, n_layers};
-    // create the struct
-    matlab_input = mxCreateStructArray(2, (const mwSize *) dimensions, 2, fieldnames);
-    // create the data for the fields of our struct
-    mxArray *field_array_ptrs[2];
-    for (int i = 0; i < 2; i++) {
-      field_array_ptrs[i] =
-              mxCreateNumericArray(3, (const mwSize *) field_array_dimensions, mxDOUBLE_CLASS, mxREAL);
-      mxDouble *place_data = mxGetPr(field_array_ptrs[i]);
-      for (int ii = 0; ii < n_rows; ii++) {
-        for (int jj = 0; jj < n_cols; jj++) {
-          for (int kk = 0; kk < n_layers; kk++) {
-            *(place_data + kk * n_cols * n_rows + jj * n_rows + ii) =
-                    1. / ((double) (kk + jj + ii + 1));
-          }
-        }
-      }
-      mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
-    }
-    // attempt to create a vector from this struct
-    IncidentField i_field(matlab_input);
-    // check that we actually assigned values to the Vectors under the hood
-    bool information_stored = (i_field.x.has_elements()) && (i_field.y.has_elements());
-    REQUIRE(information_stored);
+}
+void IncidentFieldTest::test_correct_construction() {
+  dimensions_3d[0] = n_rows;
+  dimensions_3d[1] = n_cols;
+  dimensions_3d[2] = n_layers;
+  // create the struct
+  create_1by1_struct(n_fields, fieldnames);
+  // create the data for the fields of our struct
+  mxArray *field_array_ptrs[2];
+  for (int i = 0; i < 2; i++) {
+    field_array_ptrs[i] = mxCreateNumericArray(3, (const mwSize *) dimensions_3d,
+                                               mxDOUBLE_CLASS, mxREAL);
+    mxDouble *place_data = mxGetPr(field_array_ptrs[i]);
     for (int ii = 0; ii < n_rows; ii++) {
       for (int jj = 0; jj < n_cols; jj++) {
         for (int kk = 0; kk < n_layers; kk++) {
-          bool element_set_correctly =
-                  (abs(i_field.x[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE) &&
-                  (abs(i_field.y[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE);
-          CHECK(element_set_correctly);
+          *(place_data + kk * n_cols * n_rows + jj * n_rows + ii) =
+                  1. / ((double) (kk + jj + ii + 1));
         }
       }
     }
+    mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
+  // attempt to create a vector from this struct
+  IncidentField i_field(matlab_input);
+  // check that we actually assigned values to the Vectors under the hood
+  bool information_stored = (i_field.x.has_elements()) && (i_field.y.has_elements());
+  REQUIRE(information_stored);
+  bool elements_set_correctly = true;
+  for (int ii = 0; ii < n_rows; ii++) {
+    for (int jj = 0; jj < n_cols; jj++) {
+      for (int kk = 0; kk < n_layers; kk++) {
+        elements_set_correctly =
+                elements_set_correctly &&
+                (abs(i_field.x[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE) &&
+                (abs(i_field.y[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE);
+      }
+    }
+  }
+  REQUIRE(elements_set_correctly);
+}
 
-  // cleanup
-  mxDestroyArray(matlab_input);
+TEST_CASE("IncidentField") {
+  IncidentFieldTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_Material.cpp
+++ b/tdms/tests/unit/array_tests/test_Material.cpp
@@ -7,69 +7,69 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
+
+void CMaterialTest::test_incorrect_number_of_fields() {
+  SECTION("Too few fields") {
+    create_1by1_struct(n_fields - 1, fieldnames);
+    REQUIRE_THROWS_AS(CMaterial(matlab_input), std::runtime_error);
+  }
+  SECTION("Too many fields") {
+    const char *too_many_fields[] = {"Cax", "Cay", "Caz", "Cbx", "Cby",
+                                     "Cbz", "Ccx", "Ccy", "Ccz", "extra"};
+    create_1by1_struct(n_fields + 1, too_many_fields);
+    REQUIRE_THROWS_AS(CMaterial(matlab_input), std::runtime_error);
+  }
+}
+
+void CMaterialTest::test_incorrect_fieldname() {
+  create_1by1_struct(n_fields, wrong_fieldnames);
+  REQUIRE_THROWS_AS(CMaterial(matlab_input), std::runtime_error);
+}
+
+void CMaterialTest::test_correct_construction() {
+  create_1by1_struct(n_fields, fieldnames);
+  mxArray *elements[n_fields];
+  for (int i = 0; i < n_fields; i++) {
+    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    mxSetField(matlab_input, 0, fieldnames[i], elements[i]);
+  }
+  // construction should succeed
+  CMaterial cm(matlab_input);
+}
+
+void DMaterialTest::test_incorrect_number_of_fields() {
+  SECTION("Too few fields") {
+    create_1by1_struct(n_fields - 1, fieldnames);
+    REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
+  }
+  SECTION("Too many fields") {
+    const char *too_many_fields[] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz", "extra"};
+    create_1by1_struct(n_fields + 1, too_many_fields);
+    REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
+  }
+}
+
+void DMaterialTest::test_incorrect_fieldname() {
+  create_1by1_struct(n_fields, wrong_fieldnames);
+  REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
+}
+
+void DMaterialTest::test_correct_construction() {
+  create_1by1_struct(n_fields, fieldnames);
+  mxArray *elements[n_fields];
+  for (int i = 0; i < n_fields; i++) {
+    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    mxSetField(matlab_input, 0, fieldnames[i], elements[i]);
+  }
+  // construction should succeed
+  DMaterial dm(matlab_input);
+}
 
 TEST_CASE("CMaterial") {
-
-  mxArray *matlab_input;
-  // the constructor expects a struct of 9 fields
-  const int n_fields = 9;
-  const char *fieldnames[n_fields] = {"Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz"};
-  const int n_numeric_elements = 8;
-
-  SECTION("Bad fieldname") {
-    const char *wrong_fieldnames[] = {"Cax", "Cay", "BAD", "Cbx", "Cby",
-                                      "Cbz", "Ccx", "Ccy", "Ccz"};
-    matlab_input = mxCreateStructMatrix(1, 1, 9, wrong_fieldnames);
-    REQUIRE_THROWS_AS(CMaterial(matlab_input), std::runtime_error);
-  }
-  SECTION("Wrong number of fields") {
-    matlab_input = mxCreateStructMatrix(1, 1, n_fields - 1, fieldnames);
-    REQUIRE_THROWS_AS(CMaterial(matlab_input), std::runtime_error);
-  }
-
-  // try and construct something meaningful
-  SECTION("Expected input") {
-    matlab_input = mxCreateStructMatrix(1, 1, 9, fieldnames);
-    mxArray *elements9[9];
-    for (int i = 0; i < 9; i++) {
-      elements9[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
-      mxSetField(matlab_input, 0, fieldnames[i], elements9[i]);
-    }
-    // construction should succeed
-    CMaterial cm(matlab_input);
-  }
-
-  mxDestroyArray(matlab_input);
+  CMaterialTest().run_all_class_tests();
 }
 
 TEST_CASE("DMaterial") {
-
-  mxArray *matlab_input;
-  // the constructor expects a struct of 6 fields
-  const int n_fields = 6;
-  const char *fieldnames[n_fields] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
-  const int n_numeric_elements = 8;
-
-  SECTION("Bad fieldname") {
-    const char *wrong_fieldnames[] = {"Cax", "Day", "Daz", "Dbx", "Cby", "Dbz"};
-    matlab_input = mxCreateStructMatrix(1, 1, 6, wrong_fieldnames);
-    REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
-  }
-  SECTION("Wrong number of fields") {
-    matlab_input = mxCreateStructMatrix(1, 1, n_fields - 1, fieldnames);
-    REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
-  }
-
-  SECTION("Expected input") {
-    matlab_input = mxCreateStructMatrix(1, 1, 6, fieldnames);
-    mxArray *elements6[6];
-    for (int i = 0; i < 6; i++) {
-      elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
-      mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
-    }
-    // construction should succeed
-    DMaterial dm(matlab_input);
-  }
-
-  mxDestroyArray(matlab_input);
+  DMaterialTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -7,29 +7,18 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
+#include "unit_test_utils.h"
 
-TEST_CASE("Matrix") {
+using tdms_tests::is_close;
 
-  // mock-up dimensions
-  int n_rows = 4, n_cols = 8;
-
+void MatrixTest::test_correct_construction() {
   // create a Matrix via the default constructor
   SECTION("Default constructor") {
     Matrix<int> M_int;
     // although created, the matrix should not have any elements, and should be flagged as such
     REQUIRE(!M_int.has_elements());
-    // we need to use allocate to provide space for elements
-    M_int.allocate(n_rows, n_cols);
-    REQUIRE(M_int.has_elements());
-
-    // should be able to assign to these values without seg faults now
-    for (int i = 0; i < n_rows; i++) {
-      for (int j = 0; j < n_cols; j++) {
-        CHECK_NOTHROW(M_int[i][j] = 0);
-      }
-    }
   }
-
   // create a Matrix using the overloaded constructor, and fill it with 1s
   SECTION("Overloaded constructor") {
     Matrix<double> M_double(n_rows, n_cols);
@@ -38,64 +27,64 @@ TEST_CASE("Matrix") {
 
     // should be able to assign to these values without seg faults now
     for (int i = 0; i < n_rows; i++) {
-      for (int j = 0; j < n_cols; j++) {
-        CHECK_NOTHROW(M_double[i][j] = 1.);
-      }
+      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_double[i][j] = 1.); }
     }
   }
 }
 
-TEST_CASE("Vertices") {
+void MatrixTest::test_other_methods() {
+  SECTION("allocate()") {
+    Matrix<int> M_int;
+    // we need to use allocate to provide space for elements
+    M_int.allocate(n_rows, n_cols);
+    REQUIRE(M_int.has_elements());
 
+    // should be able to assign to these values without seg faults now
+    for (int i = 0; i < n_rows; i++) {
+      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_int[i][j] = 0); }
+    }
+  }
+}
+
+void VerticesTest::test_correct_construction() {
   // initialise the struct, it needs the fieldname "vertices"
-  const int n_fields = 1;
-  const int n_vertex_elements = 8;
-  const char *fieldnames[n_fields] = {"vertices"};
-  mxArray *struct_pointer = mxCreateStructMatrix(1, 1, n_fields, fieldnames);
-  mxArray *vertices_array = mxCreateNumericMatrix(n_vertex_elements, 3, mxINT32_CLASS, mxREAL);
-  mxSetField(struct_pointer, 0, fieldnames[0], vertices_array);
+  create_1by1_struct(n_fields, fieldnames);
+  mxArray *vertices_array = mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
+  mxSetField(matlab_input, 0, fieldnames[0], vertices_array);
   // create object
   Vertices v;
   // initialise
-  v.initialise(struct_pointer);
+  v.initialise(matlab_input);
   // we should have n_vertex_elements number of vertices stored
-  REQUIRE(v.n_vertices() == n_vertex_elements);
+  REQUIRE(v.n_vertices() == n_numeric_elements);
   // what's more, we should have decremented all the elements of v from 0 to -1
-  for (int i = 0; i < n_vertex_elements; i++) {
-   for (int j = 0; j < 3; j++) {
-     CHECK(v[j][i] == -1);
-   }
+  for (int i = 0; i < n_numeric_elements; i++) {
+    for (int j = 0; j < 3; j++) { CHECK(v[j][i] == -1); }
   }
-
-  // tear down - destroy MATLAB object
-  mxDestroyArray(struct_pointer);
 }
 
-TEST_CASE("GratingStructure") {
+void GratingStructureTest::test_empty_construction() {
+  dimensions_2d[0] = 0;
+  dimensions_2d[1] = I_tot;
+  create_numeric_array(2, dimensions_2d, mxINT32_CLASS);
+  // note: "new" used here since we need to delete gs to then safely delete matlab_input AFTERWARDS
+  // we cannot delete matlab_array before gs
+  GratingStructure *gs;
+  REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, I_tot));
+  REQUIRE(!gs->has_elements());
+  // tear down
+  delete gs;
+}
 
-  // non-empty input must be a pointer to a 2D matlab array (of ints, although non-interleaved API does not grant us the luxury of enforcing this),
-  // dimensions must be 2 by I_tot+1
-  const int I_tot = 4;
-  mxArray *matlab_input;
-
-  // empty pointer input doesn't throw an error, but also doesn't initialise anything meaningful
-  SECTION("Empty input") {
-    matlab_input = mxCreateNumericMatrix(0, 4, mxINT32_CLASS, mxREAL);
-    GratingStructure *gs;
-    REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, 4));
-    REQUIRE(!gs->has_elements());
-    // memory cleanup
-    delete gs;
-  }
-
-  // try sending in a 3D array instead
+void GratingStructureTest::test_wrong_input_dimensions() {
   SECTION("Wrong number of dimensions (3D)") {
-    int dimensions_3d[3] = {2, I_tot + 1, 3};
-    matlab_input = mxCreateNumericArray(3, (mwSize *) dimensions_3d, mxINT32_CLASS, mxREAL);
+    dimensions_3d[0] = 2;
+    dimensions_3d[1] = I_tot;
+    dimensions_3d[2] = 3;
+    create_numeric_array(3, dimensions_3d, mxINT32_CLASS);
     REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot), std::runtime_error);
   }
   SECTION("Wrong dimension size") {
-    int dimensions_2d[2];
     SECTION("(axis 0)") {
       dimensions_2d[0] = 3;
       dimensions_2d[1] = I_tot + 1;
@@ -104,85 +93,107 @@ TEST_CASE("GratingStructure") {
       dimensions_2d[0] = 2;
       dimensions_2d[1] = I_tot;
     }
-    matlab_input = mxCreateNumericArray(2, (mwSize *) dimensions_2d, mxINT32_CLASS, mxREAL);
+    create_numeric_array(2, dimensions_2d, mxINT32_CLASS);
     REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot), std::runtime_error);
   }
-
-  // now try sending in something that's actually useful
-  SECTION("Expected input") {
-    int dimensions_2d[2] = {2, I_tot + 1};
-    matlab_input = mxCreateNumericMatrix(dimensions_2d[0], dimensions_2d[1], mxINT32_CLASS, mxREAL);
-    GratingStructure *gs;
-    REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, I_tot));
-    REQUIRE(gs->has_elements());
-    // tear down
-    delete gs;
-  }
-
-  mxDestroyArray(matlab_input);
 }
 
-TEST_CASE("Pupil") {
+void GratingStructureTest::test_correct_construction() {
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = I_tot + 1;
+  create_numeric_array(2, dimensions_2d, mxINT32_CLASS, mxREAL);
+  // note: "new" used here since we need to delete gs to then safely delete matlab_input AFTERWARDS
+  // we cannot delete matlab_array before gs
+  GratingStructure *gs;
+  REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, I_tot));
+  REQUIRE(gs->has_elements());
+  // tear down
+  delete gs;
+}
 
-  // only default constructor exists, which doesn't even assign memory
+void PupilTest::test_empty_construction() {
   Pupil p;
-  REQUIRE(!p.has_elements());
-  mxArray *matlab_input;
-  // we'll use these as the target dimensions
-  const int n_rows = 4, n_cols = 8;
-
+  dimensions_2d[0] = 0;
+  dimensions_2d[1] = n_cols;
+  create_numeric_array(2, dimensions_2d);
   // passing in an empty array to initialise() doesn't error, but also doesn't assign
   // additionally, the rows and columns arguments aren't even used, so can be garbage
-  SECTION("Empty input") {
-    matlab_input = mxCreateNumericMatrix(0, n_cols, mxDOUBLE_CLASS, mxREAL);
-    p.initialise(matlab_input, 1, 1);
-    REQUIRE(!p.has_elements());// shouldn't have assigned any memory or pointers
-  }
+  p.initialise(matlab_input, 1, 1);
+  REQUIRE(!p.has_elements());// shouldn't have assigned any memory or pointers
+}
 
-  // wrong dimensions or wrong number of dimensions will cause an error, and also not assign
+void PupilTest::test_wrong_input_dimensions() {
+  Pupil p;
   SECTION("Wrong number of dimensions (3D)") {
-    const int dimensions_3d[3] = {n_rows, n_cols, 2};
-    matlab_input = mxCreateNumericArray(3, (mwSize *) dimensions_3d, mxDOUBLE_CLASS, mxREAL);
+    dimensions_3d[0] = n_rows;
+    dimensions_3d[1] = n_cols;
+    dimensions_3d[2] = 2;
+    create_numeric_array(3, dimensions_3d);
     REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols), std::runtime_error);
-    CHECK(!p.has_elements());
+    REQUIRE(!p.has_elements());
   }
   SECTION("Wrong dimension size") {
-    matlab_input = mxCreateNumericMatrix(2 * n_rows, n_cols + 1, mxDOUBLE_CLASS, mxREAL);
+    dimensions_2d[0] = 2 * n_rows;
+    dimensions_2d[1] = n_cols + 1;
+    create_numeric_array(2, dimensions_2d);
     REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols), std::runtime_error);
-    CHECK(!p.has_elements());
+    REQUIRE(!p.has_elements());
   }
+}
 
-  // correct size should successfully assign memory
-  SECTION("Expected input") {
-    matlab_input = mxCreateNumericMatrix(n_rows, n_cols, mxDOUBLE_CLASS, mxREAL);
+void PupilTest::test_correct_construction() {
+  Pupil p;
+  SECTION("Default constructor") {
+    REQUIRE(!p.has_elements());
+  }
+  SECTION("Overloaded constructor") {
+    dimensions_2d[0] = n_rows;
+    dimensions_2d[1] = n_cols;
+    create_numeric_array(2, dimensions_2d);
     REQUIRE_NOTHROW(p.initialise(matlab_input, n_rows, n_cols));
     REQUIRE(p.has_elements());
   }
-
-  mxDestroyArray(matlab_input);
 }
 
-TEST_CASE("EHVec") {
-
-  // because we're storing fftw_complex variables, this class has a custom destructor but nothing else
-  // as such, we should just be able to initialise it using allocate as per
-  const int n_rows = 4, n_cols = 8;
+void EHVecTest::test_other_methods() {
   const int REAL = 0, IMAG = 1;
   EHVec eh;
-  CHECK(!eh.has_elements());
 
   // allocate memory
   eh.allocate(n_rows, n_cols);
-  CHECK(eh.has_elements());
+  REQUIRE(eh.has_elements());
 
   // check that we an assign fftw_complexes to the elements
-  eh[0][0][REAL] = 1.; eh[0][0][IMAG] = 0.;
-  eh[0][1][REAL] = 0.; eh[0][1][IMAG] = 1.;
-  fftw_complex fftw_unit {1.,0.};
-  fftw_complex fftw_imag_unit {0.,1.};
+  eh[0][0][REAL] = 1.;
+  eh[0][0][IMAG] = 0.;
+  eh[0][1][REAL] = 0.;
+  eh[0][1][IMAG] = 1.;
+  fftw_complex fftw_unit{1., 0.};
+  fftw_complex fftw_imag_unit{0., 1.};
 
-  CHECK(eh[0][0][REAL] == fftw_unit[REAL]);
-  CHECK(eh[0][0][IMAG] == fftw_unit[IMAG]);
-  CHECK(eh[0][1][REAL] == fftw_imag_unit[REAL]);
-  CHECK(eh[0][1][IMAG] == fftw_imag_unit[IMAG]);
+  bool elements_set_correctly = is_close(eh[0][0][REAL], fftw_unit[REAL]) &&
+                                is_close(eh[0][0][IMAG], fftw_unit[IMAG]) &&
+                                is_close(eh[0][1][REAL], fftw_imag_unit[REAL]) &&
+                                is_close(eh[0][1][IMAG], fftw_imag_unit[IMAG]);
+  REQUIRE(elements_set_correctly);
+}
+
+TEST_CASE("Matrix") {
+  MatrixTest().run_all_class_tests();
+}
+
+TEST_CASE("Vertices") {
+  VerticesTest().run_all_class_tests();
+}
+
+TEST_CASE("GratingStructure") {
+  GratingStructureTest().run_all_class_tests();
+}
+
+TEST_CASE("Pupil") {
+  PupilTest().run_all_class_tests();
+}
+
+TEST_CASE("EHVec") {
+  EHVecTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_Vector.cpp
+++ b/tdms/tests/unit/array_tests/test_Vector.cpp
@@ -7,129 +7,139 @@
 #include <spdlog/spdlog.h>
 
 #include "arrays.h"
+#include "array_test_class.h"
 #include "globals.h"
 #include "unit_test_utils.h"
 
 using namespace tdms_math_constants;
 using tdms_tests::TOLERANCE;
+using tdms_tests::is_close;
 
-TEST_CASE("Vector") {
-
+void VectorTest::test_correct_construction() {
   // default constructor should not assign any elements or pointers
-  Vector<double> v_double;
-  REQUIRE(!v_double.has_elements());
-  REQUIRE(v_double.size() == 0);
-
-  // create a MATLAB array to cast to
-  const int n_elements = 8;
-  const int dims[2] = {1, n_elements};
-  mxArray *array = mxCreateNumericArray(2, (const mwSize *) dims, mxDOUBLE_CLASS, mxREAL);
-  mxDouble *where_to_place_data = mxGetPr(array);
-  // data is just the integers starting from 0
-  for (int i = 0; i < n_elements; i++) { where_to_place_data[i] = (double) i; }
-
-  // assign this MATLAB array to a vector
-  Vector<double> v_from_matlab(array);
-  bool has_elements_and_right_size =
-          (v_from_matlab.has_elements() && v_from_matlab.size() == n_elements);
-  REQUIRE(has_elements_and_right_size);
-  // check that the data is the _right_ data too
-  for (int i = 0; i < n_elements; i++) { CHECK(v_from_matlab[i] == i); }
-
-  // cleanup our MATLAB array
-  mxDestroyArray(array);
+  SECTION("Default constructor") {
+    Vector<double> v_double;
+    REQUIRE(!v_double.has_elements());
+    REQUIRE(v_double.size() == 0);
+  }
+  SECTION("Overloaded constructor") {
+    dimensions_2d[1] = n_numeric_elements;
+    create_numeric_array(2, dimensions_2d);
+    mxDouble *where_to_place_data = mxGetPr(matlab_input);
+    // data is just the integers starting from 0
+    for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) i; }
+    // assign this MATLAB array to a vector
+    Vector<double> v_from_matlab(matlab_input);
+    bool has_elements_and_right_size =
+            (v_from_matlab.has_elements() && v_from_matlab.size() == n_numeric_elements);
+    REQUIRE(has_elements_and_right_size);
+    // check that the data is the _right_ data too
+    bool correct_data_accessed = true;
+    for (int i = 0; i < n_numeric_elements; i++) {
+      correct_data_accessed = correct_data_accessed && is_close(v_from_matlab[i], (double) i);
+    }
+    REQUIRE(correct_data_accessed);
+  }
 }
 
-TEST_CASE("FieldComponentsVector") {
-
+void FieldComponentsVectorTest::test_correct_construction() {
   // FieldComponentsVector can be initialised with the default constructor, then have initialise() called to assign values from a pre-existing MATLAB array
   FieldComponentsVector fcv;
   bool fcv_ready = ((!fcv.has_elements()) && (fcv.size() == 0));
   REQUIRE(fcv_ready);
+}
 
-  const int n_vector_elements = 8;
-  const char *fieldnames[1] = {"components"};
-  mxArray *matlab_input;
-
+void FieldComponentsVectorTest::test_initialise_method() {
+  FieldComponentsVector fcv;
   // create a MATLAB struct with a "components" field to cast to
   // the constructor shouldn't care whether or not the components field contains an n*1 or 1*n vector either
   // struct with horizontal vector
-  SECTION("Expected input") {
-    matlab_input = mxCreateStructMatrix(1, 1, 1, fieldnames);
-    mxArray *vector_array;
-    SECTION("(horz)") {
-      vector_array = mxCreateNumericMatrix(1, n_vector_elements, mxINT16_CLASS, mxREAL);
-    }
-    SECTION("(vert)") {
-      vector_array = mxCreateNumericMatrix(n_vector_elements, 1, mxINT16_CLASS, mxREAL);
-    }
-    mxSetField(matlab_input, 0, fieldnames[0], vector_array);
-    // initialise
-    REQUIRE_NOTHROW(fcv.initialise(matlab_input));
-    // number of elements should be n_vector_elements
-    REQUIRE(fcv.size() == n_vector_elements);
+  create_1by1_struct(n_fields, fieldnames);
+  mxArray *vector_array;
+  SECTION("(horz)") {
+    vector_array = mxCreateNumericMatrix(1, n_numeric_elements, mxINT16_CLASS, mxREAL);
   }
+  SECTION("(vert)") {
+    vector_array = mxCreateNumericMatrix(n_numeric_elements, 1, mxINT16_CLASS, mxREAL);
+  }
+  mxSetField(matlab_input, 0, fieldnames[0], vector_array);
+  // initialise
+  REQUIRE_NOTHROW(fcv.initialise(matlab_input));
+  // number of elements should be n_vector_elements
+  REQUIRE(fcv.size() == n_numeric_elements);
+}
 
-  // destroy what we created
-  mxDestroyArray(matlab_input);
+void FrequencyExtractVectorTest::test_empty_construction() {
+  // if passed in an empty pointer, creates a length-1 array with a single, predetermined element
+  dimensions_2d[0] = 0;
+  dimensions_2d[1] = n_numeric_elements;
+  create_numeric_array(2, dimensions_2d);
+  FrequencyExtractVector fev_empty(matlab_input, omega_an);
+  CHECK(fev_empty.has_elements());
+  CHECK(fev_empty.size() == 1);
+  CHECK(fev_empty[0] == omega_an / 2. / DCPI);
+}
+
+void FrequencyExtractVectorTest::test_wrong_input_dimensions() {
+  SECTION("(2D array)") {
+    dimensions_2d[0] = 2;
+    dimensions_2d[1] = 4;
+    create_numeric_array(2, dimensions_2d);
+  }
+  SECTION("(3D array)") {
+    dimensions_3d[0] = 1;
+    dimensions_3d[1] = n_numeric_elements;
+    dimensions_3d[2] = 3;
+    create_numeric_array(3, dimensions_3d);
+  }
+  REQUIRE_THROWS_AS(FrequencyExtractVector(matlab_input, omega_an), std::runtime_error);
+}
+
+void FrequencyExtractVectorTest::test_correct_construction() {
+  SECTION("(horz)") {
+    dimensions_2d[1] = n_numeric_elements;
+  }
+  SECTION("(vert)") {
+    dimensions_2d[0] = n_numeric_elements;
+  }
+  create_numeric_array(2, dimensions_2d);
+  FrequencyExtractVector fev(matlab_input, omega_an);
+  CHECK(fev.size() == n_numeric_elements);
+}
+
+void FrequencyExtractVectorTest::test_other_methods() {
+  SECTION("max()") {
+    dimensions_2d[1] = n_numeric_elements;
+    create_numeric_array(2, dimensions_2d);
+    double *data_placement = (double *) mxGetPr(matlab_input);
+    int target_max_index;
+    SECTION("Find element n_numeric_elements-1") {
+      for (int i = 0; i < n_numeric_elements; i++) {
+        data_placement[i] = ((double) i / (double) (n_numeric_elements - 1)) * omega_an * DCPI;
+      }
+      target_max_index = n_numeric_elements - 1;
+    }
+    SECTION("Find element 0") {
+      for (int i = 0; i < n_numeric_elements; i++) {
+        data_placement[i] = ((double) (n_numeric_elements - i) / (double) (n_numeric_elements - 1)) * omega_an * DCPI;
+      }
+      target_max_index = 0;
+    }
+    // create array
+    FrequencyExtractVector fev(matlab_input, omega_an);
+    // check max identifies the correct value in fev
+    REQUIRE(is_close(fev.max(), fev[target_max_index]));
+  }
+}
+
+TEST_CASE("Vector") {
+  VectorTest().run_all_class_tests();
+}
+
+TEST_CASE("FieldComponentsVector") {
+  FieldComponentsVectorTest().run_all_class_tests();
 }
 
 TEST_CASE("FrequencyExtractVector") {
-
-  const double omega_an = 1;
-  const int n_elements = 8;
-  mxArray *matlab_input;
-
-  // if passed in an empty pointer, creates a length-1 array with a single, predetermined element
-  SECTION("Empty input") {
-    matlab_input = mxCreateNumericMatrix(0, n_elements, mxDOUBLE_CLASS, mxREAL);
-    FrequencyExtractVector fev_empty(matlab_input, omega_an);
-    CHECK(fev_empty.has_elements());
-    CHECK(fev_empty.size() == 1);
-    CHECK(fev_empty[0] == omega_an / 2. / DCPI);
-  }
-
-  // catch wrong-dimension inputs
-  SECTION("Wrong number of dimensions") {
-    SECTION("(2D array)") {
-      matlab_input = mxCreateNumericMatrix(2, 4, mxDOUBLE_CLASS, mxREAL);
-      REQUIRE_THROWS_AS(FrequencyExtractVector(matlab_input, omega_an), std::runtime_error);
-    }
-    SECTION("(3D array)") {
-      int dims_3d[3] = {1, n_elements, 3};
-      matlab_input = mxCreateNumericArray(3, (mwSize *) dims_3d, mxDOUBLE_CLASS, mxREAL);
-      REQUIRE_THROWS_AS(FrequencyExtractVector(matlab_input, omega_an), std::runtime_error);
-    }
-  }
-
-  // otherwise, it shouldn't matter whether we pass in a vertical or horizontal array in
-  SECTION("Expected input") {
-    SECTION("(horz)") {
-      matlab_input = mxCreateNumericMatrix(1, n_elements, mxDOUBLE_CLASS, mxREAL);
-      double *horz_data_placement = (double *) mxGetPr(matlab_input);
-      for (int i = 0; i < n_elements; i++) {
-        horz_data_placement[i] = ((double) i / (double) (n_elements - 1)) * omega_an * DCPI;
-      }
-        FrequencyExtractVector fev_horz(matlab_input, omega_an);
-        CHECK(fev_horz.size() == n_elements);
-        CHECK(abs(fev_horz.max() - fev_horz[n_elements - 1]) < TOLERANCE);
-    }
-    SECTION("(vert)") {
-      matlab_input = mxCreateNumericMatrix(n_elements, 1, mxDOUBLE_CLASS, mxREAL);
-      // insert some data into the arrays
-      double *vert_data_placement = (double *) mxGetPr(matlab_input);
-      for (int i = 0; i < n_elements; i++) {
-        vert_data_placement[i] =
-                ((double) (n_elements - i) / (double) (n_elements - 1)) * omega_an * DCPI;
-      }
-      // create the arrays
-      FrequencyExtractVector fev_vert(matlab_input, omega_an);
-      CHECK(fev_vert.size() == n_elements);
-      // max should return the element at index n_elements-1 for horz and 0 for vert
-      CHECK(abs(fev_vert.max() - fev_vert[0]) < TOLERANCE);
-    }
-  }
-
-  // cleanup memory
-  mxDestroyArray(matlab_input);
+  FrequencyExtractVectorTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_XYZVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZVectors.cpp
@@ -15,6 +15,9 @@
 using std::accumulate;
 using tdms_tests::is_close;
 
+// MacOS doesn't allow these to be a const int attribute of the base class, so here they are
+const int n_layers = 4, n_cols = 8, n_rows = 16;
+
 void XYZVectorsTest::test_correct_construction() {
   XYZVectors v;
   // check that, although this has been declared, its members still point to nullptrs

--- a/tdms/tests/unit/array_tests/test_XYZVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZVectors.cpp
@@ -15,9 +15,6 @@
 using std::accumulate;
 using tdms_tests::is_close;
 
-// MacOS doesn't allow these to be a const int attribute of the base class, so here they are
-const int n_layers = 4, n_cols = 8, n_rows = 16;
-
 void XYZVectorsTest::test_correct_construction() {
   XYZVectors v;
   // check that, although this has been declared, its members still point to nullptrs


### PR DESCRIPTION
Closes #165 | Hence also closes #136 |

# TLDR;

- (~200 lines) Most important introduction (`AbstractArrayTest` class): [LINK](https://github.com/UCL/TDMS/blob/wgraham-array_test_class/tdms/tests/include/abstract_array_test_class.h)
- (~300 lines) A (very boring) long list of test class declarations: [LINK](https://github.com/UCL/TDMS/blob/wgraham-array_test_class/tdms/tests/include/array_test_class.h)
- Everything else is a refactor

---

## `AbstractArrayTest` class

Introduces the `AbstractArrayTest` class, using the template described [here](https://github.com/UCL/TDMS/pull/159#pullrequestreview-1178788597).

This class contains a number of virtual methods, which are designed to be overwritten by the subclasses that correspond to the individual arrays in `arrays.h`. Commonly executed tasks, like creation of MATLAB inputs, have been given explicit `test_{name}`s to save on code repetition. Additionally, the `matlab_input_assigned` variable exists to keep track of whether there is allocated MATLAB memory to clean up, which is picked up at the end of each test.

The only non-virtual method is `run_all_class_tests()`, which does what you think. This method calls all of the `test_` methods that have been overwritten in the subclasses. _(Actually, it technically calls the non-overwritten function method, which in turn just flags the test to be skipped with no checks performed)._ This function also makes use of the `matlab_input_assigned` variable to avoid memory leaks, by forcing `MATLAB` memory to be freed if it has been assigned.

### Sublcasses for each test

Subclasses are created for each custom class defined in `arrays.h`. Subclasses have the `test_` methods overridden to their specific needs, and with `test_` methods that are not overwritten being (effectively) skipped.

The PR's large diff is mostly because of the refactor this requires plus standardising several variable names across multiple classes.
