### PR TITLE
Samcunliffe array test class

### DIFF
--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,9 +286,9 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
-  static int n_layers = 4;
-  static int n_cols = 8;
-  static int n_rows = 16;
+  const static int n_layers = 4;
+  const static int n_cols = 8;
+  const static int n_rows = 16;
 
   void test_correct_construction() override;
   // set_ptr()

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,9 +286,9 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
-  const int n_layers = 4;
-  const int n_cols = 8;
-  const int n_rows = 16;
+  constexpr int n_layers = 4;
+  constexpr int n_cols = 8;
+  constexpr int n_rows = 16;
 
   void test_correct_construction() override;
   // set_ptr()

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -286,9 +286,9 @@ public:
 
 class XYZVectorsTest : public AbstractArrayTest {
 private:
-  constexpr int n_layers = 4;
-  constexpr int n_cols = 8;
-  constexpr int n_rows = 16;
+  static int n_layers = 4;
+  static int n_cols = 8;
+  static int n_rows = 16;
 
   void test_correct_construction() override;
   // set_ptr()


### PR DESCRIPTION
Fixes the MacOS requirement that `const static` be used in place of `const` for private class attributes that are used to declare arrays.