### PR TITLE
BLi vs Cubic interpolation comparisons

### DIFF
--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -33,7 +33,7 @@ namespace tdms_tests {
       return true;
     }
 
-    return std::abs(a - b) / std::max(std::abs(a), std::abs(b)) < tol;
+    return std::abs(a - b) / max_norm < tol;
   }
 
   /**
@@ -102,6 +102,11 @@ namespace tdms_tests {
     double norm_val = 0.;
     for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
     return std::sqrt(norm_val);
+  }
+
+  // returns the order of magnitude of the value x
+  inline int order_of_magnitude(double x) {
+    return floor(log10(x));
   }
 
   /**

--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -11,9 +11,9 @@
 
 namespace tdms_tests {
 
-inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
+  inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
 
-/**
+  /**
  * @brief Determines if two numerical values are close by relative comparison.
  *
  * Checks the truth value of the condition
@@ -24,19 +24,19 @@ inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
  * @param tol Relative comparison tolerance
  * @param close_to_zero_tol Cutoff value for the "close to zero" criterion
  */
-template<typename T>
-inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E-30) {
+  template<typename T>
+  inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E-30) {
 
-  auto max_norm = std::max(std::abs(a), std::abs(b));
+    auto max_norm = std::max(std::abs(a), std::abs(b));
 
-  if (max_norm < close_to_zero_tol) {// Prevent dividing by zero
-    return true;
+    if (max_norm < close_to_zero_tol) {// Prevent dividing by zero
+      return true;
+    }
+
+    return std::abs(a - b) / std::max(std::abs(a), std::abs(b)) < tol;
   }
 
-  return std::abs(a - b) / std::max(std::abs(a), std::abs(b)) < tol;
-}
-
-/**
+  /**
  * @brief Determines whether an error value is better than a benchmark, or sufficiently close to be insignificant.
  *
  * If the error to check is superior (IE, closer to zero in absolute value) than the benchmark, return true.
@@ -49,19 +49,47 @@ inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E
  * @return true to_check is a superior or equivalent error to to_beat
  * @return false to_check is an inferior error
  */
-template<typename T>
-inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
-                                double close_to_zero_tol = 1E-30) {
-  if (std::abs(to_check) < std::abs(to_beat)) {
-    // return true if the value to_check is better (closer to 0) than to_beat
-    return true;
-  } else {
-    // determine if the numerical values are close by relative comparison
-    return is_close(to_check, to_beat, tol, close_to_zero_tol);
+  template<typename T>
+  inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
+                                 double close_to_zero_tol = 1E-30) {
+    if (std::abs(to_check) < std::abs(to_beat)) {
+      // return true if the value to_check is better (closer to 0) than to_beat
+      return true;
+    } else {
+      // determine if the numerical values are close by relative comparison
+      return is_close(to_check, to_beat, tol, close_to_zero_tol);
+    }
   }
-}
 
-/**
+  /**
+ * @brief Compute the relative mean square difference of two arrays
+ *
+ * @param x,y Arrays to read from
+ * @param n_elements Number of elements in the arrays
+ * @param x_start,y_start Index to start reading the buffer from the x, y array respectively (default 0)
+ * @param close_to_zero_tol Tolerance for MSDs being zero (to avoid /0 errors)
+ * @return double The relative mean square difference of x and y
+ */
+  inline double relative_mean_square_difference(double *x, double *y, int n_elements,
+                                                int x_start = 0, int y_start = 0,
+                                                double close_to_zero_tol = TOLERANCE) {
+    double mean_sq_x = 0., mean_sq_y = 0., mean_sq_diff = 0.;
+    for (int i = 0; i < n_elements; i++) {
+      mean_sq_x += x[i + x_start] * x[i + x_start];
+      mean_sq_y += y[i + y_start] * y[i + y_start];
+      mean_sq_diff += (x[i + x_start] - y[i + y_start]) * (x[i + x_start] - y[i + y_start]);
+    }
+    mean_sq_x = mean_sq_x / (double) n_elements;
+    mean_sq_y = mean_sq_y / (double) n_elements;
+    if (mean_sq_x < close_to_zero_tol && mean_sq_y < close_to_zero_tol) {
+      return 0.;
+    } else {
+      mean_sq_diff = mean_sq_diff / (((double) n_elements) * std::max(mean_sq_x, mean_sq_y));
+      return mean_sq_diff;
+    }
+  }
+
+  /**
 * @brief Computes the Euclidean norm of the vector provided
 *
 * @param v Vector or array
@@ -69,14 +97,14 @@ inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
 * @param start (Inclusive) start of buffer to read vector from
 * @return double Euclidean norm
 */
-template<typename T>
-inline double euclidean(T *v, int end, int start = 0) {
-  double norm_val = 0.;
-  for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
-  return std::sqrt(norm_val);
-}
+  template<typename T>
+  inline double euclidean(T *v, int end, int start = 0) {
+    double norm_val = 0.;
+    for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
+    return std::sqrt(norm_val);
+  }
 
-/**
+  /**
  * @brief Create a temporary directory for writing files.
  *
  * Creates a subdirectory (with randomised name) in the system tmp.  This can be
@@ -87,19 +115,19 @@ inline double euclidean(T *v, int end, int start = 0) {
  *
  * @return std::filesystem::path Path to the temporary directory.
  */
-inline std::filesystem::path create_tmp_dir() {
-  // random number setup
-  std::random_device device_seed;
-  std::mt19937 random_number_generator(device_seed());
+  inline std::filesystem::path create_tmp_dir() {
+    // random number setup
+    std::random_device device_seed;
+    std::mt19937 random_number_generator(device_seed());
 
-  // get system tmp directory (OS-dependent), add a uniquely named subdirectory
-  auto tmp = std::filesystem::temp_directory_path();
-  std::string subdir = "tdms_unit_tests_" + std::to_string(random_number_generator());
-  auto path = tmp / subdir;
+    // get system tmp directory (OS-dependent), add a uniquely named subdirectory
+    auto tmp = std::filesystem::temp_directory_path();
+    std::string subdir = "tdms_unit_tests_" + std::to_string(random_number_generator());
+    auto path = tmp / subdir;
 
-  // mkdir and return the path to the directory we've just created
-  std::filesystem::create_directory(path);
-  return path;
-}
+    // mkdir and return the path to the directory we've just created
+    std::filesystem::create_directory(path);
+    return path;
+  }
 
 }// namespace tdms_tests

--- a/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_BLi_vs_cubic_validation.m
+++ b/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_BLi_vs_cubic_validation.m
@@ -17,6 +17,7 @@ Results are printed out for each cell size to stdout.
 %}
 clear;
 close all;
+clc;
 
 % interp inputs
 r = 2;
@@ -111,7 +112,9 @@ function [out] = interp_cubic(v, pos)
 end
 
 function [out] = BLi_vs_cubic_fn(x)
-    out = sin(2*pi*x) ./ (10*(x.^2) + 1);
+    %out = sin(2*pi*x) ./ (10*(x.^2) + 1);
+    %out = sin(2*pi*x);
+    out = sin(2*pi*x) .* exp( -x.^2 );
 end
 
 % Relative mean square error

--- a/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_BLi_vs_cubic_validation.m
+++ b/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_BLi_vs_cubic_validation.m
@@ -8,7 +8,7 @@ test_BLi_vs_cubic_interpolation.cpp.
 
 The function we use is a Cauchy distribution multiplied by a sin wave;
 f(x) = sin(2\pi x) / (10x^2+1)
-over the range x\in[-2,2]
+over the range x\in[-4,4]
 
 Neither cubic nor BLi should be the superior interpolation method for all
 datapoint-separation  distances.
@@ -22,16 +22,19 @@ close all;
 r = 2;
 N = 4;
 % the spacing between datapoints, mimicing the Yee cell dimensions
-cell_Sizes = [1e-1, 5e-2, 1e-2, 5e-3, 1e-3, 5e-4];
-x_lower = -2.; % lower value of the range over which we shall test
-x_upper = 2.; % upper value of the range over which we shall test
+cell_Sizes = [7.5e-1, 6.25e-1, 5e-1, 3.75e-1, 2.5e-1, 1e-1, 5e-2, 1e-2, 5e-3, 1e-3, 5e-4];
+x_lower = -4.; % lower value of the range over which we shall test
+x_upper = 4.; % upper value of the range over which we shall test
 extent = x_upper - x_lower;
+% make interpolation plots
+make_plots = 0;
 
 % for each trial compute BLi and cubic errors
 fprintf("Cellsize | (MAX error) BLi :     Cubic       |");
 % fprintf(" (Norm error) BLi :     Cubic      |");
 fprintf("   (RMSD) BLi    :      Cubic     |");
-fprintf(" %%pts BLi better\n");
+fprintf(" %%pts BLi better |\n");
+fprintf("|:-:|:-:|:-:|:-:|\n");
 for trial=1:numel(cell_Sizes)
     cellSize = cell_Sizes(trial);
     n_datapts = ceil(extent/cellSize); % number of Yee cells
@@ -71,24 +74,26 @@ for trial=1:numel(cell_Sizes)
     BLi_was_better = ones(size(BLi_err));
     BLi_was_better( abs(cub_err) < abs(BLi_err) ) = 0.;
 
-    fprintf("%.1e  |", cellSize);
+    fprintf("%.2e  |", cellSize);
     fprintf("  %.8e : %.8e  |", BLi_err_max, cub_err_max);
 %    fprintf("  %.8e  : %.8e |", BLi_err_norm, cub_err_norm);
     fprintf("  %.8e : %.8e |", BLi_rmsd, cub_rmsd);
-    fprintf(" %.2f%% \n", 100. * sum(BLi_was_better) / (n_datapts-1));
+    fprintf(" %.2f%% |\n", 100. * sum(BLi_was_better) / (n_datapts-1));
 
-    figure; hold on;
-    title(strcat("Interp values: ",num2str(cellSize)));
-    plot(cell_centres, BLi_interp);
-    plot(cell_centres, cubic_interp);
-    plot(cell_centres, exact_vals);
-    legend("BLi", "Cubic", "Exact");
+    if make_plots
+        figure; hold on;
+        title(strcat("Interp values: ",num2str(cellSize)));
+        plot(cell_centres, BLi_interp);
+        plot(cell_centres, cubic_interp);
+        plot(cell_centres, exact_vals);
+        legend("BLi", "Cubic", "Exact");
 
-    figure; hold on;
-    title(strcat("Pt-wise errors: ",num2str(cellSize)));
-    plot(cell_centres, BLi_err);
-    plot(cell_centres, cub_err);
-    legend("BLi", "Cubic");
+        figure; hold on;
+        title(strcat("Pt-wise errors: ",num2str(cellSize)));
+        plot(cell_centres, BLi_err);
+        plot(cell_centres, cub_err);
+        legend("BLi", "Cubic");
+    end
 
 end
 

--- a/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
+++ b/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
@@ -17,15 +17,7 @@
 
 using namespace std;
 using tdms_math_constants::DCPI;
-using tdms_tests::is_close_or_better;
-using tdms_tests::relative_mean_square_difference;
-
-// Computes the 2-norm of the vector v from buffer start to buffer end
-inline double norm(double *v, int end, int start = 0) {
-  double norm_val = 0.;
-  for (int i = start; i <= end; i++) { norm_val += v[i] * v[i]; }
-  return sqrt(norm_val);
-}
+using namespace tdms_tests;
 
 // function to interpolate
 inline double f_BLi_vs_Cubic(double x) { return sin(2. * DCPI * x) / ((10. * x * x) + 1.); }
@@ -156,8 +148,8 @@ TEST_CASE("Benchmark: BLi against cubic interpolation") {
     logging_string << "\n";
 
     // assert error is better or close
-    CHECK(is_close_or_better(BLi_RMSD[trial], MATLAB_BLi_RMSD[trial]));
-    CHECK(is_close_or_better(cub_RMSD[trial], MATLAB_cub_RMSD[trial]));
+    CHECK(is_close_or_better(BLi_RMSD[trial], MATLAB_BLi_RMSD[trial], 1e-8));
+    CHECK(is_close_or_better(cub_RMSD[trial], MATLAB_cub_RMSD[trial], 1e-6));
   }
 
   SPDLOG_INFO(logging_string.str());

--- a/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
+++ b/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
@@ -3,34 +3,32 @@
  * @author William Graham (ccaegra@ucl.ac.uk)
  * @brief Tests the performance of band-limited interpolation against cubic interpolation
  */
-#include "interpolation_methods.h"
-
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
+#include <sstream>
 
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
+#include "globals.h"
+#include "interpolation_methods.h"
+#include "unit_test_utils.h"
+
 using namespace std;
+using tdms_math_constants::DCPI;
+using tdms_tests::is_close_or_better;
+using tdms_tests::relative_mean_square_difference;
 
 // Computes the 2-norm of the vector v from buffer start to buffer end
 inline double norm(double *v, int end, int start = 0) {
-    double norm_val = 0.;
-    for (int i = start; i <= end; i++) {
-        norm_val += v[i] * v[i];
-    }
-    return sqrt(norm_val);
+  double norm_val = 0.;
+  for (int i = start; i <= end; i++) { norm_val += v[i] * v[i]; }
+  return sqrt(norm_val);
 }
 
 // function to interpolate
-inline double f_BLi_vs_Cubic(double x) {
-    return 1. / ((10. * x * x) + 1.);
-}
-
-// computes order of magnitude of a double
-int orderOfMagnitude(double x) {
-    return floor(log10(x));
-}
+inline double f_BLi_vs_Cubic(double x) { return sin(2. * DCPI * x) / ((10. * x * x) + 1.); }
 
 /**
  * @brief We will check that BLi gives a better approximation than cubic interpolation.
@@ -38,107 +36,129 @@ int orderOfMagnitude(double x) {
  * The metric we will use is the norm of the error-vector.
  * As the cell-size becomes larger (across the same domain), BLi should begin to perform better than cubic interpolation.
  *
- * For the following cell sizes, over the range -2 to 2, and for the function f(x) = 1/(10x^2+1), MATLAB predicts the following errors:
- * Cell size    | BLi err           | Cubic err
- *  0.25        | 1.25953429e-02    | 3.28105674e-02
- *  0.1         | 7.10587711e-04    | 5.49601748e-03
- *  0.05        | 7.80325615e-04    | 5.53430587e-04
- *  0.01        | 1.97562511e-03    | 2.06917814e-06
+ * For the following cell sizes, over the range -2 to 2, and for the function f(x) = sin(2\pi x)/(10x^2+1), MATLAB predicts the following errors:
+ * Cellsize | (MAX error) BLi :     Cubic       |   (RMSD) BLi    :      Cubic     | %pts BLi better
+ * 1.0e-01  |  1.48931677e-03 : 9.96898136e-03  |  2.66761900e-06 : 1.71214373e-04 | 82.05%
+ * 5.0e-02  |  8.02870428e-05 : 9.35367215e-04  |  2.31881524e-08 : 8.61216185e-07 | 77.22%
+ * 1.0e-02  |  1.75965585e-04 : 1.61196447e-06  |  6.79644463e-08 : 2.41007234e-12 | 0.00%
+ * 5.0e-03  |  1.88927787e-04 : 1.00885869e-07  |  7.68604981e-08 : 9.44110925e-15 | 0.25%
+ * 1.0e-03  |  1.93280583e-04 : 1.61583136e-10  |  7.99275135e-08 : 2.41912139e-20 | 0.00%
+ * 5.0e-04  |  1.93418193e-04 : 1.00993103e-11  |  8.00251513e-08 : 9.44996450e-23 | 0.00%
  * Values computed via the benchmark_test_BLi_vs_cubic.m script.
  *
  * We will test the following:
- * - The norm-error of BLi is lesser/greater than cubic in each case
- * - The order of the magnitude (of BOTH) errors is the same as that obtained from MATLAB (for validation reasons)
+ * - The RMSD error is_close_or_better than that obtained from MATLAB for both BLi and cubic
  */
-TEST_CASE("Benchmark: BLi is better than cubic interpolation") {
-    SPDLOG_INFO("===== Benchmarking BLi against cubic interpolation =====");
-    // number of cell sizes to test at
-    const int n_trials = 4;
-    // Yee cell sizes to test across
-    double cell_sizes[n_trials] = {0.25, 0.1, 0.05, 0.01};
-    // Flags for whether or not we expect BLi to perform better
-    bool BLi_is_better[n_trials] = {true, true, false, false};
-    // MATLAB errors for BLi
-    double MATLAB_BLi_errs[n_trials] = {1.25953429e-02, 7.10587711e-04, 7.80325615e-04,
-                                        1.97562511e-03};
-    // MATLAB errors for cubic interp
-    double MATLAB_cub_errs[n_trials] = {3.28105674e-02, 5.49601748e-03, 5.53430587e-04,
-                                        2.06917814e-06};
-    // coordinate of the LHS of the first Yee cell
-    double x_lower = -2.;
-    // spatial extent of the domain will be [x_lower, x_lower+extent]
-    double extent = 4.;
-    // norm errors recorded across runs
-    double BLi_norm_errs[n_trials], cub_norm_errs[n_trials];
+TEST_CASE("Benchmark: BLi against cubic interpolation") {
+  // number of cell sizes to test at
+  const int n_trials = 6;
+  // Yee cell sizes to test across
+  double cell_sizes[n_trials] = {1e-1, 5e-2, 1e-2, 5e-3, 1e-3, 5e-4};
+  // Flags for whether or not we expect BLi have superior RMSD
+  bool BLi_is_better[n_trials] = {true, true, false, false, false, false};
+  // MATLAB errors for BLi
+  double MATLAB_BLi_RMSD[n_trials] = {2.66761900e-06, 2.31881524e-08, 6.79644463e-08,
+                                      7.68604981e-08, 7.99275135e-08, 8.00251513e-08};
+  // MATLAB errors for cubic interp
+  double MATLAB_cub_RMSD[n_trials] = {1.71214373e-04, 8.61216185e-07, 2.41007234e-12,
+                                      9.44110925e-15, 2.41912139e-20, 9.44996450e-23};
+  // coordinate of the LHS of the first Yee cell
+  double x_lower = -2.;
+  // spatial extent of the domain will be [x_lower, x_lower+extent]
+  double extent = 4.;
+  // norm errors recorded across runs
+  double BLi_RMSD[n_trials], cub_RMSD[n_trials];
 
-    for (int trial = 0; trial < n_trials; trial++) {
-        // Yee cell "size" to use
-        double cellSize = cell_sizes[trial];
-        // the number of datapoints that we have, the number of "cells" we have is one less than this
-        int n_datapts = round(extent / cellSize);
-        CHECK(n_datapts > 8); // BLi cannot run otherwise
+  // to record log so it prints out a bit nicer to the screen
+  stringstream logging_string;
+  logging_string << scientific << setprecision(8);
+  logging_string << "\nBenchmarking BLi against Cubic interpolation\n";
+  logging_string << "   BLi RMSD      (benchmark)    |   Cubic RMSD     (benchmark)    | Correct "
+                    "scheme better? \n";
 
-        // the centres of the Yee cells
-        double cell_centres[n_datapts - 1];
-        // the exact field values at the Yee cell centres
-        double exact_field_values[n_datapts - 1];
-        // the spatial coordinates of the samples of our field
-        double field_positions[n_datapts];
-        // the field values at the sample positions
-        double field_samples[n_datapts];
-        for (int i = 0; i < n_datapts; i++) {
-          if (i != n_datapts - 1) { cell_centres[i] = x_lower + (((double) i) + 0.5) * cellSize; }
-          field_positions[i] = x_lower + ((double) i) * cellSize;
+  for (int trial = 0; trial < n_trials; trial++) {
+    // Yee cell "size" to use
+    double cellSize = cell_sizes[trial];
+    // the number of datapoints that we have, the number of "cells" we have is one less than this
+    int n_datapts = round(extent / cellSize);
+    CHECK(n_datapts > 8);// BLi cannot run otherwise
 
-          exact_field_values[i] = f_BLi_vs_Cubic(cell_centres[i]);
-          field_samples[i] = f_BLi_vs_Cubic(field_positions[i]);
-        }
+    // the centres of the Yee cells
+    double cell_centres[n_datapts - 1];
+    // the exact field values at the Yee cell centres
+    double exact_field_values[n_datapts - 1];
+    // the spatial coordinates of the samples of our field
+    double field_positions[n_datapts];
+    // the field values at the sample positions
+    double field_samples[n_datapts];
+    for (int i = 0; i < n_datapts; i++) {
+      if (i != n_datapts - 1) { cell_centres[i] = x_lower + (((double) i) + 0.5) * cellSize; }
+      field_positions[i] = x_lower + ((double) i) * cellSize;
 
-        // the interpolated field values via BLi
-        double BLi_interp[n_datapts - 1];
-        // the interpolated field values via cubic interp
-        double cub_interp[n_datapts - 1];
-
-        // pointwise-interpolation error in BLi
-        double BLi_err[n_datapts - 1];
-        // pointwise-interpolation error in cubic
-        double cub_err[n_datapts - 1];
-
-        // perform interpolation - this is manual since best_interp_scheme will always want to do BLi
-        // cubic interpolation only changes at the first and last cells
-        cub_interp[0] = CBFst.interpolate(field_samples);
-        for (int i = 1; i < n_datapts - 2; i++) {
-            cub_interp[i] = CBMid.interpolate(field_samples, i + 1 - CBMid.number_of_datapoints_to_left);
-        }
-        cub_interp[n_datapts - 2] = CBLst.interpolate(field_samples, n_datapts - 1 - CBLst.number_of_datapoints_to_left);
-
-        // BLi interpolation
-        for (int i = 0; i < n_datapts - 1; i++) {
-            // we checked earlier that BLi should always be available, so this is always a BLi scheme
-            InterpolationScheme use_scheme = best_scheme(n_datapts - 1, i);
-            // to be on the safe side, check that we have a BLi scheme. BLi schemes are always strictly better than CUBIC_INTERP_MIDDLE, and not equal or worse.
-            CHECK(use_scheme.is_better_than(CUBIC_INTERP_MIDDLE));
-            // interpolate using the cell data we have provided
-            // i + 1 - use_scheme.number_of_datapoints_to_left is the index of field_samples to read as the point v[0] in the schemes
-            BLi_interp[i] = use_scheme.interpolate(field_samples, i + 1 - use_scheme.number_of_datapoints_to_left);
-        }
-
-        // compare to exact values - again ignore cell 0 for the time being
-        for (int i = 0; i < n_datapts - 1; i++) {
-            BLi_err[i] = abs(BLi_interp[i] - exact_field_values[i]);
-            cub_err[i] = abs(cub_interp[i] - exact_field_values[i]);
-        }
-        // compute square-norm error
-        BLi_norm_errs[trial] = norm(BLi_err, n_datapts - 2);
-        cub_norm_errs[trial] = norm(cub_err, n_datapts - 2);
-
-        // value-testing commences: the better method should be superior, and the worse method should be worse.
-        // assert this is the case for each cellSize we used.
-        CHECK((BLi_norm_errs[trial] <= cub_norm_errs[trial]) == BLi_is_better[trial]);
-        SPDLOG_INFO("BLi err: {0:.8e} | Cubic err : {1:.8e} | Expected BLi to be better: {2:d}", BLi_norm_errs[trial], cub_norm_errs[trial], BLi_is_better[trial]);
-
-        // in all cases, assert that the order of magnitude of error is what we expect, if we had used MATLAB
-        CHECK(orderOfMagnitude(BLi_norm_errs[trial]) == orderOfMagnitude(MATLAB_BLi_errs[trial]));
-        CHECK(orderOfMagnitude(cub_norm_errs[trial]) == orderOfMagnitude(MATLAB_cub_errs[trial]));
+      exact_field_values[i] = f_BLi_vs_Cubic(cell_centres[i]);
+      field_samples[i] = f_BLi_vs_Cubic(field_positions[i]);
     }
+
+    // the interpolated field values via BLi
+    double BLi_interp[n_datapts - 1];
+    // the interpolated field values via cubic interp
+    double cub_interp[n_datapts - 1];
+
+    // pointwise-interpolation error in BLi
+    double BLi_err[n_datapts - 1];
+    // pointwise-interpolation error in cubic
+    double cub_err[n_datapts - 1];
+
+    // perform interpolation - this is manual since best_interp_scheme will always want to do BLi
+    // cubic interpolation only changes at the first and last cells
+    cub_interp[0] = CBFst.interpolate(field_samples);
+    for (int i = 1; i < n_datapts - 2; i++) {
+      cub_interp[i] = CBMid.interpolate(field_samples, i + 1 - CBMid.number_of_datapoints_to_left);
+    }
+    cub_interp[n_datapts - 2] =
+            CBLst.interpolate(field_samples, n_datapts - 1 - CBLst.number_of_datapoints_to_left);
+
+    // BLi interpolation
+    bool check_using_BLi = true;
+    for (int i = 0; i < n_datapts - 1; i++) {
+      // we checked earlier that BLi should always be available, so this is always a BLi scheme
+      InterpolationScheme use_scheme = best_scheme(n_datapts - 1, i);
+      // to be on the safe side, check that we have a BLi scheme. BLi schemes are always strictly better than CUBIC_INTERP_MIDDLE, and not equal or worse.
+      check_using_BLi = check_using_BLi && use_scheme.is_better_than(CUBIC_INTERP_MIDDLE);
+      // interpolate using the cell data we have provided
+      // i + 1 - use_scheme.number_of_datapoints_to_left is the index of field_samples to read as the point v[0] in the schemes
+      BLi_interp[i] = use_scheme.interpolate(field_samples,
+                                             i + 1 - use_scheme.number_of_datapoints_to_left);
+    }
+    // require that we used BLi for all of these interpolations
+    REQUIRE(check_using_BLi);
+
+    // compute RMSD
+    BLi_RMSD[trial] =
+            relative_mean_square_difference(BLi_interp, exact_field_values, n_datapts - 1);
+    cub_RMSD[trial] =
+            relative_mean_square_difference(cub_interp, exact_field_values, n_datapts - 1);
+
+    // value-testing commences: the better method should be superior, and the worse method should be worse.
+    // assert this is the case for each cellSize we used.
+    bool expected_scheme_is_better = ((BLi_RMSD[trial] <= cub_RMSD[trial]) == BLi_is_better[trial]);
+    CHECK(expected_scheme_is_better);
+
+    // update the log
+    //SPDLOG_INFO("BLi RMSD: {0:.8e} | Cubic RMSD : {1:.8e} | Expected BLi to be better: {2:d}", BLi_RMSD[trial], cub_RMSD[trial], BLi_is_better[trial]);
+    logging_string << BLi_RMSD[trial] << " (" << MATLAB_BLi_RMSD[trial] << ") | ";
+    logging_string << cub_RMSD[trial] << " (" << MATLAB_cub_RMSD[trial] << ") | ";
+    if (expected_scheme_is_better) {
+      logging_string << "Yes";
+    } else {
+      logging_string << "No";
+    }
+    logging_string << "\n";
+
+    // assert error is better or close
+    CHECK(is_close_or_better(BLi_RMSD[trial], MATLAB_BLi_RMSD[trial]));
+    CHECK(is_close_or_better(cub_RMSD[trial], MATLAB_cub_RMSD[trial]));
+  }
+
+  SPDLOG_INFO(logging_string.str());
 }


### PR DESCRIPTION
Some investigations following the discussion on 29/11/2022. @prmunro 

We were interested in the affect of reducing the inter-spatial distance between field values, and the corresponding effect on the quality of the interpolation.

This experiment compares the interpolation quality of the function $$f:\mathbb{R}\rightarrow[-1,1], \quad \frac{\sin(2\pi x)}{10x^2+1},$$ over the range $[-2,2]$ for shrinking inter-sample spacing (mimicking decreasing Yee cell size).

What's particularly interesting is that, for the functional form that we try, it appears that the Band-Limited approximation reaches a plateau regarding how "good" it's performance is - even appearing to get worse in terms of relative mean square difference (RMSD) from the exact values! 

By contrast, cubic interpolation seems to get better with each successive reduction in inter-spatial distance. To the point where for inter-spatial distancing of the order $10^{-2}$, it's already performing superiorly to Band-Limited interpolation. This behaviour is consistent with MATLAB's behaviour too.

The file `tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_BLi_vs_cubic_validation.m` can be used to replicate the interpolation and the results below.

 Cellsize | (MAX pt-wise error) BLi :     Cubic       |   (RMSD) BLi    :      Cubic     | %pts BLi better |
| :-: | :-: | :-: | :-: |
 1.0e-01  |  1.48931677e-03 : 9.96898136e-03  |  2.66761900e-06 : 1.71214373e-04 | 82.05% |
 5.0e-02  |  8.02870428e-05 : 9.35367215e-04  |  2.31881524e-08 : 8.61216185e-07 | 77.22% |
 1.0e-02  |  1.75965585e-04 : 1.61196447e-06  |  6.79644463e-08 : 2.41007234e-12 | 0.00% |
 5.0e-03  |  1.88927787e-04 : 1.00885869e-07  |  7.68604981e-08 : 9.44110925e-15 | 0.25% |
 1.0e-03  |  1.93280583e-04 : 1.61583136e-10  |  7.99275135e-08 : 2.41912139e-20 | 0.00% |
 5.0e-04  |  1.93418193e-04 : 1.00993103e-11  |  8.00251513e-08 : 9.44996450e-23 | 0.00% |