### PR TITLE
Reduce code duplication in unit tests introduced by #80

### DIFF
--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -11,9 +11,17 @@
 
 namespace tdms_tests {
 
-inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
+  inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
 
-/**
+  /**
+  * @brief Determines whether a value is close to zero
+  *
+  * @param x Value to test
+  * @param tol Tolerance for being "close" to zero
+  */
+  inline bool near_zero(const double &x, double tol=TOLERANCE) { return std::abs(x) < tol; }
+
+  /**
  * @brief Determines if two numerical values are close by relative comparison.
  *
  * Checks the truth value of the condition
@@ -24,19 +32,19 @@ inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
  * @param tol Relative comparison tolerance
  * @param close_to_zero_tol Cutoff value for the "close to zero" criterion
  */
-template<typename T>
-inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E-30) {
+  template<typename T>
+  inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E-30) {
 
-  auto max_norm = std::max(std::abs(a), std::abs(b));
+    auto max_norm = std::max(std::abs(a), std::abs(b));
 
-  if (max_norm < close_to_zero_tol) {// Prevent dividing by zero
-    return true;
+    if (near_zero(max_norm, close_to_zero_tol)) {// Prevent dividing by zero
+      return true;
+    }
+
+    return std::abs(a - b) / max_norm < tol;
   }
 
-  return std::abs(a - b) / std::max(std::abs(a), std::abs(b)) < tol;
-}
-
-/**
+  /**
  * @brief Determines whether an error value is better than a benchmark, or sufficiently close to be insignificant.
  *
  * If the error to check is superior (IE, closer to zero in absolute value) than the benchmark, return true.
@@ -49,19 +57,47 @@ inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E
  * @return true to_check is a superior or equivalent error to to_beat
  * @return false to_check is an inferior error
  */
-template<typename T>
-inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
-                                double close_to_zero_tol = 1E-30) {
-  if (std::abs(to_check) < std::abs(to_beat)) {
-    // return true if the value to_check is better (closer to 0) than to_beat
-    return true;
-  } else {
-    // determine if the numerical values are close by relative comparison
-    return is_close(to_check, to_beat, tol, close_to_zero_tol);
+  template<typename T>
+  inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
+                                 double close_to_zero_tol = 1E-30) {
+    if (std::abs(to_check) < std::abs(to_beat)) {
+      // return true if the value to_check is better (closer to 0) than to_beat
+      return true;
+    } else {
+      // determine if the numerical values are close by relative comparison
+      return is_close(to_check, to_beat, tol, close_to_zero_tol);
+    }
   }
-}
 
-/**
+  /**
+ * @brief Compute the relative mean square difference of two arrays
+ *
+ * @param x,y Arrays to read from
+ * @param n_elements Number of elements in the arrays
+ * @param x_start,y_start Index to start reading the buffer from the x, y array respectively (default 0)
+ * @param close_to_zero_tol Tolerance for MSDs being zero (to avoid /0 errors)
+ * @return double The relative mean square difference of x and y
+ */
+  inline double relative_mean_square_difference(double *x, double *y, int n_elements,
+                                                int x_start = 0, int y_start = 0,
+                                                double close_to_zero_tol = TOLERANCE) {
+    double mean_sq_x = 0., mean_sq_y = 0., mean_sq_diff = 0.;
+    for (int i = 0; i < n_elements; i++) {
+      mean_sq_x += x[i + x_start] * x[i + x_start];
+      mean_sq_y += y[i + y_start] * y[i + y_start];
+      mean_sq_diff += (x[i + x_start] - y[i + y_start]) * (x[i + x_start] - y[i + y_start]);
+    }
+    mean_sq_x = mean_sq_x / (double) n_elements;
+    mean_sq_y = mean_sq_y / (double) n_elements;
+    if (mean_sq_x < close_to_zero_tol && mean_sq_y < close_to_zero_tol) {
+      return 0.;
+    } else {
+      mean_sq_diff = mean_sq_diff / (((double) n_elements) * std::max(mean_sq_x, mean_sq_y));
+      return mean_sq_diff;
+    }
+  }
+
+  /**
 * @brief Computes the Euclidean norm of the vector provided
 *
 * @param v Vector or array
@@ -69,14 +105,19 @@ inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
 * @param start (Inclusive) start of buffer to read vector from
 * @return double Euclidean norm
 */
-template<typename T>
-inline double euclidean(T *v, int end, int start = 0) {
-  double norm_val = 0.;
-  for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
-  return std::sqrt(norm_val);
-}
+  template<typename T>
+  inline double euclidean(T *v, int end, int start = 0) {
+    double norm_val = 0.;
+    for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
+    return std::sqrt(norm_val);
+  }
 
-/**
+  // returns the order of magnitude of the value x
+  inline int order_of_magnitude(double x) {
+    return floor(log10(x));
+  }
+
+  /**
  * @brief Create a temporary directory for writing files.
  *
  * Creates a subdirectory (with randomised name) in the system tmp.  This can be
@@ -87,19 +128,19 @@ inline double euclidean(T *v, int end, int start = 0) {
  *
  * @return std::filesystem::path Path to the temporary directory.
  */
-inline std::filesystem::path create_tmp_dir() {
-  // random number setup
-  std::random_device device_seed;
-  std::mt19937 random_number_generator(device_seed());
+  inline std::filesystem::path create_tmp_dir() {
+    // random number setup
+    std::random_device device_seed;
+    std::mt19937 random_number_generator(device_seed());
 
-  // get system tmp directory (OS-dependent), add a uniquely named subdirectory
-  auto tmp = std::filesystem::temp_directory_path();
-  std::string subdir = "tdms_unit_tests_" + std::to_string(random_number_generator());
-  auto path = tmp / subdir;
+    // get system tmp directory (OS-dependent), add a uniquely named subdirectory
+    auto tmp = std::filesystem::temp_directory_path();
+    std::string subdir = "tdms_unit_tests_" + std::to_string(random_number_generator());
+    auto path = tmp / subdir;
 
-  // mkdir and return the path to the directory we've just created
-  std::filesystem::create_directory(path);
-  return path;
-}
+    // mkdir and return the path to the directory we've just created
+    std::filesystem::create_directory(path);
+    return path;
+  }
 
 }// namespace tdms_tests

--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -9,6 +9,10 @@
 #include <random>
 #include <string>
 
+#include "globals.h"
+
+using tdms_math_constants::DCPI;
+
 namespace tdms_tests {
 
   inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance

--- a/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_interpolation_functions.m
+++ b/tdms/tests/unit/matlab_benchmark_scripts/benchmark_test_interpolation_functions.m
@@ -17,32 +17,55 @@ close all;
 nSamples = 100; % number of sample points to use
 r = 2; % interpolate to midpoints of samples
 N = 4; % use 2*4=8 sample points in interpolation
-x = linspace(0,1,r*nSamples); % sample points
+xi = linspace(0,1,nSamples);
+xi5 = linspace(0,1,nSamples) + (0.5/(nSamples-1));
+xi5 = xi5(1:end-1);
 
 % Constant function interpolation
-const_fn_data = const_fn(x);
-const_fn_interp = interp(const_fn_data(1:r:end),r,N);
-const_fn_err = max(abs( const_fn_interp(2:r:end-1) - const_fn_data(2:r:end-1) ));
+const_fn_data = const_fn(xi);
+const_fn_exact = const_fn(xi5);
+const_fn_interp = interp(const_fn_data,r,N);
+const_fn_interp = const_fn_interp(2:r:end-1);
+const_fn_ptwise_errors = const_fn_exact - const_fn_interp;
+const_fn_max_ptwise_err = max(abs( const_fn_ptwise_errors ));
+const_fn_norm_err = norm(const_fn_ptwise_errors);
 
 % sin(2\pi x) interpolation
-s2pi_data = s2pi(x);
-s2pi_interp = interp(s2pi_data(1:r:end),r,N);
-s2pi_err = max(abs( s2pi_interp(2:r:end-1) - s2pi_data(2:r:end-1) ));
+s2pi_data = s2pi(xi);
+s2pi_exact = s2pi(xi5);
+s2pi_interp = interp(s2pi_data,r,N);
+s2pi_interp = s2pi_interp(2:r:end-1);
+s2pi_ptwise_errors = s2pi_exact - s2pi_interp;
+s2pi_max_ptwise_err = max(abs( s2pi_ptwise_errors ));
+s2pi_norm_err = norm(s2pi_ptwise_errors);
 
 % pulse function interpolation
-pulse_data = pulse_fn(x);
-pulse_interp = interp(pulse_data(1:r:end),r,N);
-pulse_err = max(abs( pulse_interp(2:r:end-1) - pulse_data(2:r:end-1) ));
+pulse_data = pulse_fn(xi);
+pulse_exact = pulse_fn(xi5);
+pulse_interp = interp(pulse_data,r,N);
+pulse_interp = pulse_interp(2:r:end-1);
+pulse_ptwise_errors = pulse_exact - pulse_interp;
+pulse_max_ptwise_err = max(abs( pulse_ptwise_errors ));
+pulse_norm_err = norm(pulse_ptwise_errors);
 
 % complex: s2pi(x) + i*pulse_fn(x) interpolation
-complex_data = complex_test(x);
-complex_interp = interp(complex_data(1:r:end),r,N);
-complex_err = max(abs( complex_interp(2:r:end-1) - complex_data(2:r:end-1) ));
+complex_data = complex_test(xi);
+complex_exact = complex_test(xi5);
+complex_interp = interp(complex_data,r,N);
+complex_interp = complex_interp(2:r:end-1);
+complex_ptwise_errors = complex_interp - complex_exact;
+complex_max_ptwise_err = max(abs( complex_ptwise_errors ));
+complex_norm_err = norm(complex_ptwise_errors);
 
-fprintf("Constant function error: %.8e \n", const_fn_err);
-fprintf("sin function error:      %.8e \n", s2pi_err);
-fprintf("pulse function error:    %.8e \n", pulse_err);
-fprintf("complex fn error:        %.8e \n", complex_err);
+fprintf("Constant function max ptwise error: %.8e \n", const_fn_max_ptwise_err);
+fprintf("sin function max ptwise error:      %.8e \n", s2pi_max_ptwise_err);
+fprintf("pulse function max ptwise error:    %.8e \n", pulse_max_ptwise_err);
+fprintf("complex fn max ptwise error:        %.8e \n", complex_max_ptwise_err);
+
+fprintf("constant function norm error: %.8e \n", const_fn_norm_err);
+fprintf("sin function norm error:      %.8e \n", s2pi_norm_err);
+fprintf("pulse function norm error:    %.8e \n", pulse_norm_err);
+fprintf("complex fn norm error:        %.8e \n", complex_norm_err);
 
 %% constant function
 function [out] = const_fn(x)

--- a/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
+++ b/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
@@ -11,25 +11,15 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-using namespace std;
+#include "unit_test_utils.h"
 
-// Computes the 2-norm of the vector v from buffer start to buffer end
-inline double norm(double *v, int end, int start = 0) {
-    double norm_val = 0.;
-    for (int i = start; i <= end; i++) {
-        norm_val += v[i] * v[i];
-    }
-    return sqrt(norm_val);
-}
+using namespace std;
+using tdms_tests::order_of_magnitude;
+using tdms_tests::euclidean;
 
 // function to interpolate
 inline double f_BLi_vs_Cubic(double x) {
     return 1. / ((10. * x * x) + 1.);
-}
-
-// computes order of magnitude of a double
-int orderOfMagnitude(double x) {
-    return floor(log10(x));
 }
 
 /**
@@ -129,8 +119,8 @@ TEST_CASE("Benchmark: BLi is better than cubic interpolation") {
             cub_err[i] = abs(cub_interp[i] - exact_field_values[i]);
         }
         // compute square-norm error
-        BLi_norm_errs[trial] = norm(BLi_err, n_datapts - 2);
-        cub_norm_errs[trial] = norm(cub_err, n_datapts - 2);
+        BLi_norm_errs[trial] = euclidean(BLi_err, n_datapts - 2);
+        cub_norm_errs[trial] = euclidean(cub_err, n_datapts - 2);
 
         // value-testing commences: the better method should be superior, and the worse method should be worse.
         // assert this is the case for each cellSize we used.
@@ -138,7 +128,7 @@ TEST_CASE("Benchmark: BLi is better than cubic interpolation") {
         SPDLOG_INFO("BLi err: {0:.8e} | Cubic err : {1:.8e} | Expected BLi to be better: {2:d}", BLi_norm_errs[trial], cub_norm_errs[trial], BLi_is_better[trial]);
 
         // in all cases, assert that the order of magnitude of error is what we expect, if we had used MATLAB
-        CHECK(orderOfMagnitude(BLi_norm_errs[trial]) == orderOfMagnitude(MATLAB_BLi_errs[trial]));
-        CHECK(orderOfMagnitude(cub_norm_errs[trial]) == orderOfMagnitude(MATLAB_cub_errs[trial]));
+        CHECK(order_of_magnitude(BLi_norm_errs[trial]) == order_of_magnitude(MATLAB_BLi_errs[trial]));
+        CHECK(order_of_magnitude(cub_norm_errs[trial]) == order_of_magnitude(MATLAB_cub_errs[trial]));
     }
 }

--- a/tdms/tests/unit/test_interpolation_functions.cpp
+++ b/tdms/tests/unit/test_interpolation_functions.cpp
@@ -8,14 +8,18 @@
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <iomanip>
+#include <sstream>
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
 #include "globals.h"
+#include "unit_test_utils.h"
 
 using namespace tdms_math_constants;
+using tdms_tests::is_close_or_better;
 using Catch::Approx;
 using namespace std;
 
@@ -26,8 +30,7 @@ using namespace std;
  *
  * Checks are run on both the old interp{1,2,3} functions and newer const Interp_scheme instances. Old cubic methods will be redundant upon integration of BLi into the codebase.
  */
-TEST_CASE("test_interpolation_functions: testing that cubic interpolation is exact") {
-    SPDLOG_INFO("===== Testing exact cubic interpolation =====");
+TEST_CASE("Cubic interpolation: exact for polynomials of degree <= 3") {
     // equidistant points
     double x[] = {0., 1., 2., 3.};
     // test acceptence tolerance. Allow for FLOP imprecision and rounding errors
@@ -127,8 +130,7 @@ TEST_CASE("test_interpolation_functions: testing that cubic interpolation is exa
  *
  * Note - the coefficients are not required to sum to unity!
  */
-TEST_CASE("bandlimited_interpolation: check that the interpolation constant values all sum to the same value") {
-    SPDLOG_INFO("===== Testing BLi coefficient sum =====");
+TEST_CASE("BLi: interpolation-coefficient sums match") {
     /* Tolerance to accept imprecision to
     max. 16 FLOPs implies max discrepency of 8*_DBL_EPSILON__ error
     (8 additions, error in each number max __DBL_EPSILON__).
@@ -151,111 +153,41 @@ TEST_CASE("bandlimited_interpolation: check that the interpolation constant valu
     // now check that the entries of coeff_sums are the same
     int n = 8;
     while (--n > 0 && abs(coeff_sums[n] - coeff_sums[0]) < tol)
-        ;
+      ;
     // we only reach the end of the while loop, IE get to n==0, when all elements in the array are the same
     REQUIRE(n == 0);
 }
 
 /**
- * @brief We will check that BLi interpolation over real-valued data gives comparible error to the equivalent functions in MATLAB
+ * @brief We will check that BLi interpolation data gives comparible error to the equivalent functions in MATLAB
+ *
+ *  * For 100 sample points, we will use BLi to interpolate the following complex-valued function with 100 sample points:
+ * real part of sin(2\pi x)
+ * imag part of pulse function.
+ *
+ * Interoplation will then be tested against over the range [0,1], the max element-wise error (by absolute value) will be determined. We will then check that this is of the same order of magnitude as the error produced by MATLAB, 5.35317432e-04.
  *
  * For 100 sample points, we will use BLi to interpolate the following functions with 100 sample points:
- * - The constant function 1    : range 0,1         : max. element-wise error (MATLAB) 2.82944733e-04
- * - sin(2\pi x)                : range 0,1         : max. element-wise error (MATLAB) 2.63468327e-04
- * - pulse function             : range 0,1         : max. element-wise error (MATLAB) 4.87599933e-04
+ * - The constant function 1    : range 0,1 : max. element-wise error (MATLAB) 2.82944733e-04
+ * - sin(2\pi x)                : range 0,1 : max. element-wise error (MATLAB) 2.63468327e-04
+ * - pulse function             : range 0,1 : max. element-wise error (MATLAB) 4.87599933e-04
+ * - complex function           : range 0,1 : max. element-wise error (MATLAB) 5.35317432e-04
  * Error values produced from benchmark_test_interpolation_functions.m
  *
+ * The complex function has real part sin(2\pi x) and its imaginary part is the pulse function.
+ *
  * We will then compare the maximum of the pointwise error between the interpolated values and exact values to the same quantity computed via MATLAB's interp function, and determine whether the order of magnitude of the errors is the same.
- *
- * For readability, we break this out into separate test cases for each function.
- *
  */
 
-/**
- * @brief Test BLi performance on the constant function.
- * - The constant function 1    : range 0,1         : max. element-wise error (MATLAB) 2.82944733e-04
- */
-TEST_CASE("(real-valued) Band limited interpolation: constant function") {
-    SPDLOG_INFO("===== (real valued) BLi: constant function =====");
-    int nSamples = 100;                         // number of datapoints in this dimension
-    double const_fn_data[nSamples];             // function data (only need 8 data points, but simulate 100 cells)
-    fill_n(const_fn_data, nSamples, 1);         // initalise to f(x)=1
-    double const_fn_interp[nSamples-1];         // interpolated values
-    double const_fn_errors[nSamples-1];         // error in interpolated values
-    double const_fn_max_error;                  // maximum error
+// Hardcode MATLAB errors from benchmark_test_interpolation_functions.m
+inline const double const_fn_MATLAB_error = 2.82944733e-04, sin_MATLAB_error = 2.63468327e-04,
+                    pulse_MATLAB_error = 4.87599933e-04, complex_fn_MATLAB_error = 5.35317432e-04;
 
-    // hardcoding the MATLAB error (benchmark_test_interpolation_functions.m)
-    double const_fn_MATLAB_error = 2.82944733e-04;
+// Evalutes f(x) = 1, for consistency with test sectioning
+inline double constant_1(double x) { return 1.; }
 
-    // constant function interpolation
-    for (int i=0; i<nSamples-1; i++) {
-        InterpolationScheme scheme = best_scheme(nSamples-1, i);
-        const_fn_interp[i] = scheme.interpolate(const_fn_data, i + 1 - scheme.number_of_datapoints_to_left);
-        // Compare interpolated values to the true values, which are just f(x)=1
-        const_fn_errors[i] = abs(1. - const_fn_interp[i]);
-    }
-
-    // get maximum error
-    const_fn_max_error = *max_element(const_fn_errors, const_fn_errors + nSamples - 1);
-    // report test results
-    SPDLOG_INFO("Error: {0:.8e} | Benchmark: {1:.8e}", const_fn_max_error, const_fn_MATLAB_error);
-    // compare O.o.Mag of error - fail if we are orders of magnitude out
-    REQUIRE(floor(log10(const_fn_max_error)) <= floor(log10(const_fn_MATLAB_error)));
-    // compare absolute error - flag (and fail, but less harshly) if we are doing worse than we expect (but are close)
-    CHECK(const_fn_max_error <= const_fn_MATLAB_error);
-}
-
-inline double s2pi(double x) {
-    return sin(2. * DCPI * x);
-}
-
-/**
- * @brief Test BLi performance on the sine function.
- * - sin(2\pi x)                : range 0,1         : max. element-wise error (MATLAB) 2.63468327e-04
- */
-TEST_CASE("(real-valued) Band limited interpolation: sin(2 pi x)") {
-    SPDLOG_INFO("===== (real valued) BLi: sin(2pi x) =====");
-    int nSamples = 100;                             // number of datapooints in this dimension
-    double spacing = 1. / (double)(nSamples - 1);   // spacing between datapoints
-    double xi[nSamples];                            // coordinates of the samples
-    double xi5[nSamples];                           // coordinates of the interpolation points
-    double f_data[nSamples];                        // function data at xi
-    double f_exact[nSamples-1];                     // function exact values at xi5
-    double f_interp[nSamples-1];                    // interpolated values at xi5
-    double f_errors[nSamples-1];                    // error at xi5
-    double max_error;                               // maximum error across xi5 points
-
-    // hardcoding the MATLAB error (benchmark_test_interpolation_functions.m)
-    double sin_MATLAB_error = 2.63468327e-04;
-
-    // setup the sample points, Yee cell centres, and function values (for sampling and exactness)
-    for (int i = 0; i < nSamples; i++)
-    {
-      xi[i] = ((double) i) * spacing;
-      f_data[i] = s2pi(xi[i]);
-      if (i != nSamples - 1) {
-        xi5[i] = xi[i] + spacing / 2.;
-        f_exact[i] = s2pi(xi5[i]);
-      }
-    }
-
-    // sin function interpolation
-    for (int i=0; i<nSamples-1; i++) {
-        InterpolationScheme scheme = best_scheme(nSamples-1, i);
-        f_interp[i] = scheme.interpolate(f_data, i + 1 - scheme.number_of_datapoints_to_left);
-        // Compare interpolated values to the true values
-        f_errors[i] = abs(f_exact[i] - f_interp[i]);
-    }
-
-    // get maximum error
-    max_error = *max_element(f_errors, f_errors + nSamples - 1);
-    // report test results
-    SPDLOG_INFO("Error: {0:.8e} | Benchmark: {1:.8e}", max_error, sin_MATLAB_error);
-    // compare O.o.Mag of error - fail if we are orders of magnitude out
-    REQUIRE(floor(log10(max_error)) <= floor(log10(sin_MATLAB_error)));
-    // compare absolute error - flag (and fail, but less harshly) if we are doing worse than we expect (but are close)
-    CHECK(max_error < sin_MATLAB_error);
-}
+// Evaluates f(x) = sin(2 \pi x)
+inline double s2pi(double x) { return sin(2. * DCPI * x); }
 
 /**
  * @brief Evaluates the smooth pulse/ mollifier Kernel function, supported between 0 and 1
@@ -273,110 +205,101 @@ TEST_CASE("(real-valued) Band limited interpolation: sin(2 pi x)") {
  * @return double Evaluted value
  */
 inline double pulse(double x) {
-    double absxhat = abs(3. * (2.*x - 1.));
-    if (absxhat >= 1) {
-        return 0.;
-    }
-    else {
-        return exp( -1. / (1 - absxhat*absxhat) );
-    }
+  double absxhat = abs(3. * (2. * x - 1.));
+  if (absxhat >= 1) {
+    return 0.;
+  } else {
+    return exp(-1. / (1 - absxhat * absxhat));
+  }
 }
 
-/**
- * @brief Test BLi performance on the compact pulse.
- * - pulse function             : range 0,1         : max. element-wise error (MATLAB) 4.87599933e-04
- */
-TEST_CASE("(real-valued) Band limited interpolation: compact pulse") {
-    SPDLOG_INFO("===== (real valued) BLi: compact pulse =====");
-    int nSamples = 100;                           // number of datapooints in this dimension
-    double spacing = 1. / (double) (nSamples - 1);// spacing between datapoints
-    double xi[nSamples];                          // coordinates of the samples
-    double xi5[nSamples];                         // coordinates of the interpolation points
-    double f_data[nSamples];                      // function data at xi
-    double f_exact[nSamples - 1];                 // function exact values at xi5
-    double f_interp[nSamples - 1];                // interpolated values at xi5
-    double f_errors[nSamples - 1];                // error at xi5
-    double max_error;                             // maximum error across xi5 points
+// Evalutes the complex function we will be using as a benchmark, f(x) = sin(2\pi x) + i * pulse(x)
+inline complex<double> complex_fn(double x) { return s2pi(x) + IMAGINARY_UNIT * pulse(x); }
 
-    // hardcoding the MATLAB error (benchmark_test_interpolation_functions.m)
-    double pulse_MATLAB_error = 4.87599933e-04;
+TEST_CASE("BLi: MATLAB benchmarking") {
+  // setup test logging information
+  stringstream logging_string;
+  logging_string << scientific << setprecision(8);
 
-    // setup the sample points, Yee cell centres, and function values (for sampling and exactness)
-    for (int i = 0; i < nSamples; i++) {
-      xi[i] = ((double) i) * spacing;
-      f_data[i] = pulse(xi[i]);
-      if (i != nSamples - 1) {
-        xi5[i] = xi[i] + spacing / 2.;
-        f_exact[i] = pulse(xi5[i]);
-      }
+  int nSamples = 100;                           //< number of datapooints in this dimension
+  double spacing = 1. / (double) (nSamples - 1);//< spacing between datapoints
+  double xi[nSamples];                          //< coordinates of the samples
+  double xi5[nSamples];                         //< coordinates of the interpolation points
+  // setup cell centres (xi5) and data sample positions (xi)
+  for (int i = 0; i < nSamples; i++) {
+    xi[i] = ((double) i) * spacing;
+    if (i != nSamples - 1) {
+      xi5[i] = xi[i] + spacing / 2.;
+    }
+  }
+
+  double f_errors[nSamples - 1];//< pointwise interpolation errors
+  double max_error;             //< maximum pointwise interpolation error
+  double MATLAB_max_error;      //< MATLAB max-error benchmark
+
+  SECTION("Real-valued functions") {
+    double f_data[nSamples];            //< function data at xi
+    double f_exact[nSamples - 1];       //< function exact values at xi5
+    double f_interp[nSamples - 1];      //< interpolated values at xi5
+    double (*analytic_function)(double);//< the (test) function to interpolate
+
+    SECTION("Constant function") {
+      logging_string << "Constant function | ";
+      MATLAB_max_error = const_fn_MATLAB_error;
+      analytic_function = &constant_1;
+    }
+    SECTION("sin(2 pi x)") {
+      logging_string << "sin(2 pi x)       | ";
+      MATLAB_max_error = sin_MATLAB_error;
+      analytic_function = &s2pi;
+    }
+    SECTION("Pulse function") {
+      logging_string << "pulse function    | ";
+      MATLAB_max_error = pulse_MATLAB_error;
+      analytic_function = &pulse;
     }
 
-    // sin function interpolation
+    // Setup sample points (xi), Yee cell centres (xi5), and function values at these points (sampled data & exact values)
+    for (int i = 0; i < nSamples; i++) {
+      f_data[i] = analytic_function(xi[i]);
+      if (i != nSamples - 1) { f_exact[i] = analytic_function(xi5[i]); }
+    }
+    // perform interpolation
     for (int i = 0; i < nSamples - 1; i++) {
       InterpolationScheme scheme = best_scheme(nSamples - 1, i);
       f_interp[i] = scheme.interpolate(f_data, i + 1 - scheme.number_of_datapoints_to_left);
       // Compare interpolated values to the true values
       f_errors[i] = abs(f_exact[i] - f_interp[i]);
     }
+  }
+  SECTION("Complex-valued functions") {
+    complex<double> f_data[nSamples];      // function data at xi
+    complex<double> f_exact[nSamples - 1]; // function exact values at xi5
+    complex<double> f_interp[nSamples - 1];// interpolated values at xi5
 
-    // get maximum error
-    max_error = *max_element(f_errors, f_errors + nSamples - 1);
-    // compare O.o.Mag of error - fail if we are orders of magnitude out
-    REQUIRE(floor(log10(max_error)) <= floor(log10(pulse_MATLAB_error)));
-    // compare absolute error - flag (and fail, but less harshly) if we are doing worse than we expect (but are close)
-    CHECK(max_error < pulse_MATLAB_error);
-    // report test results
-    SPDLOG_INFO("Error: {0:.8e} | Benchmark: {1:.8e}", max_error, pulse_MATLAB_error);
-}
+    logging_string << "complex function   | ";
+    MATLAB_max_error = complex_fn_MATLAB_error;
 
-/**
- * @brief We will check that BLi interpolation over complex-valued data gives comparible error to the equivalent functions in MATLAB
- *
- * For 100 sample points, we will use BLi to interpolate the following complex-valued function with 100 sample points:
- * real part of sin(2\pi x)
- * imag part of pulse function.
- *
- * Interoplation will then be tested against over the range [0,1], the max element-wise error (by absolute value) will be determined. We will then check that this is of the same order of magnitude as the error produced by MATLAB, 5.35317432e-04.
- */
-TEST_CASE("(complex-valued) Band limited interpolation") {
-    SPDLOG_INFO("===== (complex valued) BLi: complex function test case =====");
-    int nSamples = 100;                            // number of "Yee cells" in this dimension
-    double spacing = 1. / (double)(nSamples - 1);  // spacing between Yee cell centres
-    double xi[nSamples];                           // positions of the "field components"
-    double xi5[nSamples];                          // positions of the "Yee cell" centres, xi5[i] = centre of cell i
-    complex<double> f_data[nSamples];              // function data at xi
-    complex<double> f_exact[nSamples - 1];         // function exact values at xi5
-    complex<double> f_interp[nSamples - 1];        // interpolated values at xi5
-    double f_abs_errors[nSamples - 1];             // error at xi5
-
-    double max_error;                              // maximum (abs) error across xi5 points
-    // hardcoding the MATLAB error (benchmark_test_interpolation_functions.m)
-    double MATLAB_error = 5.35317432e-04;
-
-    // setup the sample points, Yee cell centres, and function values (for sampling and exactness)
+    // Setup sample points (xi), Yee cell centres (xi5), and function values at these points (sampled data & exact values)
     for (int i = 0; i < nSamples; i++) {
-      xi[i] = ((double) i) * spacing;
-      f_data[i] = s2pi(xi[i]) + IMAGINARY_UNIT*pulse(xi[i]);
-      if (i != nSamples - 1) {
-        xi5[i] = xi[i] + spacing / 2.;
-        f_exact[i] = s2pi(xi5[i]) + IMAGINARY_UNIT*pulse(xi5[i]);
-      }
+      f_data[i] = complex_fn(xi[i]);
+      if (i != nSamples - 1) { f_exact[i] = complex_fn(xi5[i]); }
     }
-
-    // sin function interpolation
+    // perform interpolation
     for (int i = 0; i < nSamples - 1; i++) {
       InterpolationScheme scheme = best_scheme(nSamples - 1, i);
       f_interp[i] = scheme.interpolate(f_data, i + 1 - scheme.number_of_datapoints_to_left);
       // Compare interpolated values to the true values
-      f_abs_errors[i] = abs(f_exact[i] - f_interp[i]);
+      f_errors[i] = abs(f_exact[i] - f_interp[i]);
     }
+  }
 
-    // get maximum error
-    max_error = *max_element(f_abs_errors, f_abs_errors + nSamples - 1);
-    // compare O.o.Mag of error - fail if we are orders of magnitude out
-    REQUIRE(floor(log10(max_error)) <= floor(log10(MATLAB_error)));
-    // compare absolute error - flag (and fail, but less harshly) if we are doing worse than we expect (but are close)
-    CHECK(max_error < MATLAB_error);
-    // report test results
-    SPDLOG_INFO("Error: {0:.8e} | Benchmark {1:.8e}", max_error, MATLAB_error);
+  // get maximum pointwise error
+  max_error = *max_element(f_errors, f_errors + nSamples - 1);
+  // compare worst pointwise error
+  REQUIRE(is_close_or_better(max_error, MATLAB_max_error));
+
+  // report test results
+  logging_string << "Error: " << max_error << " | Benchmark: " << MATLAB_max_error;
+  SPDLOG_INFO(logging_string.str());
 }

--- a/tdms/tests/unit/test_numerical_derivative.cpp
+++ b/tdms/tests/unit/test_numerical_derivative.cpp
@@ -9,7 +9,10 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include "unit_test_utils.h"
+
 using Catch::Approx;
+using tdms_tests::near_zero;
 
 // fftw_complex is typdef to a double[2] - first element is Re, second Im.
 const int REAL=0, IMAG=1;
@@ -38,13 +41,6 @@ TEST_CASE("Element-by-element multiplication of array of complex numbers") {
         REQUIRE(output[i][REAL] == expected[i][REAL]);
         REQUIRE(output[i][IMAG] == expected[i][IMAG]);
     }
-}
-
-/**
- * @brief Is x close to zero?
- */
-inline bool near_zero(const double& x){
-  return std::abs(x) < 1E-12;
 }
 
 /**


### PR DESCRIPTION
Uses `Catch2`'s sectioning abilities to reduce the amount of code repetition in the tests that were introduced in #80. Closes #125 .

This is mainly just using sections to breakout the few portions of each of these tests that are different - creation of the data, the exact function values, etc.

Sadly it's impossible to go the full throw and drop the distinction between complex-valued and real-valued function tests (unless we want to treat "real" functions as "complex" functions with no imaginary part, but then we aren't testing the time-domain stuff).

**Half the diff** is an indentation bug in `unit_test_utils.m`. Not sure why this appears.