### PR TITLE
Introduce a versioning system.

### DIFF
--- a/doc/developers.md
+++ b/doc/developers.md
@@ -22,6 +22,34 @@ We depend on ...
 * [spdlog](https://github.com/gabime/spdlog) for logging (this is installed automatically by a CMake [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) if not found).
 * [MATLAB](https://www.mathworks.com/products/matlab.html) since we read in and write out MATLAB format files. We are actually thinking of removing this as a strict dependency ([#70](https://github.com/UCL/TDMS/issues/70)).
 
+### Versions
+
+We follow [semantic versioning](https://semver.org): major, minor, patch.
+Major versions may contain changes to the API and UI, minor versions contain new features but preserve backwards-compatibility of UI, patches are bugfixes.
+
+So (for example) version v1.2.0 is major version 1, minor version 2, and the zeroth patch. v1.2.0 will be backwards-compatible with v1.1.99.
+
+**Mechanics**: Version control is via `git tag`s on the `main` branch and propagated to the C++ source [code via CMake](https://github.com/UCL/TDMS/blob/main/tdms/cmake/version_from_git.cmake). Release notes are kept in the [GitHub release page](https://github.com/UCL/TDMS/releases).
+
+As well as official releases, a placeholder "version" is assigned to every commit on every development branch, or can be supplied at compile-time (which takes the highest precedence).
+
+```{.sh}
+$ cmake .. <usual cmake options> -DTDMS_VERSION=this_version_string_will_be_highest_priority
+$ make install
+$ tdms --version
+TDMS version: this_version_string_will_be_highest_priority
+```
+
+If on a development branch then the placeholder version is `<branchname>_<tag>` if tagged, or `<branchname>_<commit hash>` if not tagged. This is useful when debugging problems introduced between commits (with the assistance of `git bisect`).
+
+```{.sh}
+$ git checkout myfeaturebranch
+$ cmake ..
+$ make install
+$ tdms --version
+TDMS version: myfeaturebranch_a341ab
+```
+
 ### Code style and other admin
 
 We try to stick to [Google style C++](https://google.github.io/styleguide/cppguide.html) wherever practicable. <!-- And we run `clang-format` and `cppclean` linters as part of our CI. -->

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -81,6 +81,17 @@ else()
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
 endif()
 
+
+# TDMS version ----------------------------------------------------------------
+# if supplied via the cmake configuration (-DTDMS_VERSION=whatever_I_want) then
+# respect that, otherwise construct a version from a git tag or commit hash.
+if (NOT TDMS_VERSION)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_from_git.cmake)
+endif()
+add_compile_definitions(TDMS_VERSION="${TDMS_VERSION}")
+message(STATUS "Compiling TDMS version: ${TDMS_VERSION}")
+
+
 # TDMS target -----------------------------------------------------------------
 
 # wildcard to find all *.cpp files in the src directory except for main.cpp
@@ -100,6 +111,8 @@ endif()
 
 # Compile options -------------------------------------------------------------
 target_compile_options(tdms PUBLIC -DMX_COMPAT_32 -c ${DFLAG} -O3)
+add_compile_definitions(TDMS_VERSION="${TDMS_VERSION}")
+#target_compile_definitions(tdms PRIVATE TDMS_VERSION="${TDMS_VERSION}")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(tdms PRIVATE /W4)

--- a/tdms/cmake/version_from_git.cmake
+++ b/tdms/cmake/version_from_git.cmake
@@ -1,0 +1,30 @@
+find_package(Git)
+if(GIT_FOUND)
+
+	# Get current branch name.
+	execute_process(OUTPUT_VARIABLE CURRENT_BRANCH
+		COMMAND ${GIT_EXECUTABLE} symbolic-ref --short HEAD
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+	# Get current tag (or short-form of the commit hash if not tagged).
+	execute_process(OUTPUT_VARIABLE TAG_OR_SHORT_HASH
+		COMMAND ${GIT_EXECUTABLE} describe --tags --always
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+	string(REGEX MATCH "v[0-9]+\.[0-9]+\.[0-9]+" IS_SEMVER "${TAG_OR_SHORT_HASH}")
+	if (CURRENT_BRANCH STREQUAL "main" AND IS_SEMVER)
+	    # If main is tagged with a sememantic version (of the form v1.2.3) then
+	    # that is the version.
+		set(TDMS_VERSION "${TAG_OR_SHORT_HASH}")
+	else()
+		# If it's not a tag on main or if it's a commit hash then the "version"
+		# placeholder is <branchname>_<tag>.
+		#
+		# E.g. my-feature-branch_04ad23
+		#      my-feature-branch_taggingForSomeReason
+		set(TDMS_VERSION "${CURRENT_BRANCH}_${TAG_OR_SHORT_HASH}")
+	endif()
+
+endif()

--- a/tdms/include/argument_parser.h
+++ b/tdms/include/argument_parser.h
@@ -116,6 +116,8 @@ class ArgumentParser {
 private:
     /** Prints the help message (all options).  */
     static void print_help_message();
+    /** Prints this software version. */
+    static void print_version();
 
 public:
     /**

--- a/tdms/include/globals.h
+++ b/tdms/include/globals.h
@@ -5,6 +5,19 @@
 #pragma once
 
 #include <complex>
+#include <string>
+
+namespace tdms {
+
+// TDMS_VERSION might have been defined in CMake from git tags or the git
+// branch, if not then we assume it's a development version
+#ifdef TDMS_VERSION
+const std::string VERSION = std::string(TDMS_VERSION);
+#else
+const std::string VERSION = "development";
+#endif
+
+}
 
 // ******************
 //  Type Definitions

--- a/tdms/src/argument_parser.cpp
+++ b/tdms/src/argument_parser.cpp
@@ -4,6 +4,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include "globals.h"
+
 using namespace std;
 
 
@@ -14,6 +16,11 @@ ArgumentNamespace ArgumentParser::parse_args(int n_args, char *arg_ptrs[]) {
 
   if (args.have_flag("-h")){
     print_help_message();
+    exit(0);
+  }
+
+  if (args.have_flag("-v") || args.have_flag("--version")) {
+    print_version();
     exit(0);
   }
 
@@ -51,9 +58,14 @@ void ArgumentParser::print_help_message(){
                  "tdms [options] infile gridfile outfile\n"
                  "Options:\n"
                  "-h:\tDisplay this help message\n"
+                 "-v, --version:\tDisplay tdms version information\n"
                  "-fd, --finite-difference:\tUse the finite-difference solver, instead of the pseudo-spectral method.\n"
                  "-q:\tQuiet operation. Silence all logging\n"
                  "-m:\tMinimise output file size by not saving vertex and facet information\n\n");
+}
+
+void ArgumentParser::print_version() {
+  fprintf(stdout,"TDMS version: %s\n", tdms::VERSION.c_str());
 }
 
 ArgumentNamespace::ArgumentNamespace(int n_args, char *arg_ptrs[]) {


### PR DESCRIPTION
* Add a mechanism for CMake to read a git hash and construct a version. 
* A tag of semver format on main (v1.2.3) is taken as an **_official_** version, otherwise it constructs a placeholder <branchname>_<tag or short format commit hash>.
* (Useful for debugging) you can also overwrite this with CMake configuration...
   ```
   cmake .. -DTDMS_VERSION=Ive_just_introduced_a_bug
   make install
   tdms --version
   ```

With a bit of luck I've explained all of this in the developers documentation 😸 

***

Resolves #201.

***

Thanks to @giordano and @alessandrofelder for their suggestions.