### PR TITLE
Iterator refactor [3/N]

### DIFF
--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -172,6 +172,16 @@ public:
 
 public:
   explicit DispersiveMultiLayer(const mxArray *ptr);
+
+  /**
+   * @brief Determines whether the (background) medium is dispersive
+   *
+   * @param K_tot Number of Yee cells in the z-direction (number of entries in this->gamma)
+   * @param near_zero_tolerance Tolerance for non-zero gamma (attenuation) values
+   * @return true Background is dispersive
+   * @return false Background is not dispersive
+   */
+  bool is_dispersive(int K_tot, double near_zero_tolerance=1e-15);
 };
 
 template<typename T>

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -84,6 +84,30 @@ public:
    * @param ptr Pointer to assign
    */
   void set_ptr(AxialDirection d, double *ptr);
+
+  /**
+   * @brief Determines whether all elements in the x, y, or z vector are less than a given value.
+   *
+   * @param comparison_value Value to compare elements to
+   * @param vector_length Number of elements to compare against
+   * @param component Vector to compare elements against; x, y, or z
+   * @param buffer_start Only compare elements between buffer_start (inclusive) and buffer_start+vector_length-1 (inclusive)
+   * @return true All elements are less than the comparison_value
+   * @return false At least one element is not less than the comparison_value
+   */
+  bool all_elements_less_than(double comparison_value, int vector_length,
+                                 AxialDirection component, int buffer_start = 0);
+  bool all_elements_less_than(double comparison_value, int vector_length, char component,
+                                 int buffer_start = 0);
+  /**
+   * @brief Determines whether all elements in the x, y, AND z vectors are less than a given value.
+   *
+   * @param comparison_value Value to compare elements to
+   * @param nx,ny,nz Number of elements in the nx, ny, and nz vectors respectively
+   * @return true All elements are less than the comparison_value
+   * @return false At least one element is not less than the comparison_value
+   */
+  bool all_elements_less_than(double comparison_value, int nx, int ny, int nz);
 };
 
 // TODO: docstring

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -97,8 +97,6 @@ public:
    */
   bool all_elements_less_than(double comparison_value, int vector_length,
                                  AxialDirection component, int buffer_start = 0);
-  bool all_elements_less_than(double comparison_value, int vector_length, char component,
-                                 int buffer_start = 0);
   /**
    * @brief Determines whether all elements in the x, y, AND z vectors are less than a given value.
    *

--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -127,6 +127,16 @@ public:
     void initialise_fftw_plan(int n_threads, EHVec &eh_vec);
 
     /**
+     * @brief Fetches the largest (by absolute value) field value.
+     *
+     * Split field values are sums of the corresponding components, so this function returns the largest absolute value of the entries in
+     * (xy + xz), (yx + yz), (zx + zy)
+     *
+     * @return double Largest (by absolute value) field value
+     */
+    double largest_field_value();
+
+    /**
    * @brief Interpolates a SplitField component to the centre of a Yee cell
    *
    * @param d SplitField component to interpolate

--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -353,7 +353,7 @@ public:
    * @param other The other field
    * @return double Maximum relative pointwise absolute difference
    */
-  double max_pointwise_difference_over_max_element(Field &other);
+  double normalised_difference(Field &other);
 
   ~Field();
 };

--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -341,6 +341,20 @@ public:
    */
   void set_values_from(Field &other);
 
+  /**
+   * @brief Computes the maximum pointwise absolute difference of the other field to this one, divided by the largest absolute value of this field's components.
+   *
+   * Specifically, we compute and return the quantity
+   * $$ \frac{ \max_{i,j,k}(this[k][j][i] - other[k][j][i]) }{ \max_{i,j,k}this[k][j][i] } $$
+   * This quantity is used to determine convergence of phasors.
+   *
+   * The other field must have the same dimensions as this field.
+   *
+   * @param other The other field
+   * @return double Maximum relative pointwise absolute difference
+   */
+  double max_pointwise_difference_over_max_element(Field &other);
+
   ~Field();
 };
 

--- a/tdms/include/grid_labels.h
+++ b/tdms/include/grid_labels.h
@@ -11,11 +11,20 @@
  */
 class GridLabels{
 public:
-    double *x = nullptr;  // Start of the labels in the x direction
-    double *y = nullptr;  //                            y
-    double *z = nullptr;  //                            z
+    double *x = nullptr;  //< Start of the labels in the x direction
+    double *y = nullptr;  //< Start of the labels in the y direction
+    double *z = nullptr;  //< Start of the labels in the z direction
 
     GridLabels() = default;
 
     explicit GridLabels(const mxArray *ptr);
+
+    /**
+     * @brief Set values by copying from another GridLabels object
+     *
+     * @param other_labels The GridLabels object to copy values from
+     * @param i_l,j_l,k_l The first item to copy from the x, y, z attributes (respectively)
+     * @param i_u,j_u,k_u The final (inclusive) item to copy from the x, y, z attributes (respectively)
+     */
+    void initialise_from(GridLabels &labels_to_copy_from, int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
 };

--- a/tdms/include/iterator.h
+++ b/tdms/include/iterator.h
@@ -57,8 +57,6 @@ void update_EH(double **EHr, double **EHi, int vindex, int idx, std::complex<dou
 
 bool is_conductive(const XYZVectors &rho, int I_tot, int J_tot, int K_tot);
 
-bool is_dispersive_ml(const DispersiveMultiLayer &ml, int K_tot);
-
 void extractPhasorsVertices(double **EHr, double **EHi, ElectricSplitField &E, MagneticSplitField &H,
                             ComplexAmplitudeSample &campssample, int n, double omega, double dt, int Nt,
                             int dimension,int J_tot,int intmethod );

--- a/tdms/include/iterator.h
+++ b/tdms/include/iterator.h
@@ -31,8 +31,6 @@ void initialiseDouble2DArray(double **inArray, int i_lim, int j_lim);
 
 double linearRamp(double t, double period, double rampwidth);
 
-double checkPhasorConvergence(ElectricField &A, ElectricField &B);
-
 void setGridLabels(GridLabels &input_labels, GridLabels &output_labels,
                    int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
 

--- a/tdms/include/iterator.h
+++ b/tdms/include/iterator.h
@@ -31,9 +31,6 @@ void initialiseDouble2DArray(double **inArray, int i_lim, int j_lim);
 
 double linearRamp(double t, double period, double rampwidth);
 
-void setGridLabels(GridLabels &input_labels, GridLabels &output_labels,
-                   int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
-
 void extractPhasorsSurface(double **surface_EHr, double **surface_EHi, ElectricSplitField &E, MagneticSplitField &H,
 			    int **surface_vertices, int n_surface_vertices, int n, double omega, int Nt, int J_tot, SimulationParameters &params);
 

--- a/tdms/include/iterator.h
+++ b/tdms/include/iterator.h
@@ -55,8 +55,6 @@ void normaliseVertices( double **EHr, double **EHi, ComplexAmplitudeSample &camp
 
 void update_EH(double **EHr, double **EHi, int vindex, int idx, std::complex<double> &phase_term, double &value);
 
-bool is_conductive(const XYZVectors &rho, int I_tot, int J_tot, int K_tot);
-
 void extractPhasorsVertices(double **EHr, double **EHi, ElectricSplitField &E, MagneticSplitField &H,
                             ComplexAmplitudeSample &campssample, int n, double omega, double dt, int Nt,
                             int dimension,int J_tot,int intmethod );

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -114,7 +114,7 @@ DispersiveMultiLayer::DispersiveMultiLayer(const mxArray *ptr) {
 
 bool DispersiveMultiLayer::is_dispersive(int K_tot, double near_zero_tolerance) {
   for (int i = 0; i < K_tot; i++) {
-    if (fabs(gamma[i]) > 1e-15) {
+    if (fabs(gamma[i]) > near_zero_tolerance) {
       // non-zero attenuation constant of a Yee cell implies media is dispersive
       return true;
     }

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -112,6 +112,16 @@ DispersiveMultiLayer::DispersiveMultiLayer(const mxArray *ptr) {
   sigma.z = mxGetPr(ptr_to_matrix_in(ptr, "sigma_z", "dispersive_aux"));
 }
 
+bool DispersiveMultiLayer::is_dispersive(int K_tot, double near_zero_tolerance) {
+  for (int i = 0; i < K_tot; i++) {
+    if (fabs(gamma[i]) > 1e-15) {
+      // non-zero attenuation constant of a Yee cell implies media is dispersive
+      return true;
+    }
+  }
+  return false;
+}
+
 GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
 
   if (mxIsEmpty(ptr)) {

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -27,6 +27,54 @@ void XYZVectors::set_ptr(AxialDirection d, double* ptr){
   }
 }
 
+bool XYZVectors::all_elements_less_than(double comparison_value, int vector_length,
+                                        AxialDirection component, int buffer_start) {
+  double *component_pointer;
+  switch (component) {
+    case AxialDirection::X:
+      component_pointer = x;
+      break;
+    case AxialDirection::Y:
+      component_pointer = y;
+      break;
+    case AxialDirection::Z:
+      component_pointer = z;
+      break;
+    default:
+      throw runtime_error("Error - component not recognised");
+      break;
+  }
+  for (int index = buffer_start; index < vector_length; index++) {
+    if (component_pointer[buffer_start + index] > comparison_value) { return false; }
+  }
+  return true;
+}
+bool XYZVectors::all_elements_less_than(double comparison_value, int vector_length, char component,
+                                        int buffer_start) {
+  AxialDirection d;
+  switch (component) {
+    case 'x':
+      d = AxialDirection::X;
+      break;
+    case 'y':
+      d = AxialDirection::Y;
+      break;
+    case 'z':
+      d = AxialDirection::Z;
+      break;
+    default:
+      throw runtime_error("Error - component not recognised");
+      break;
+  }
+  return all_elements_less_than(comparison_value, vector_length, d, buffer_start);
+}
+bool XYZVectors::all_elements_less_than(double comparison_value, int nx, int ny, int nz) {
+  if (!all_elements_less_than(comparison_value, nx, AxialDirection::X)) { return false; }
+  if (!all_elements_less_than(comparison_value, ny, AxialDirection::Y)) { return false; }
+  if (!all_elements_less_than(comparison_value, nz, AxialDirection::Z)) { return false; }
+  return true;
+}
+
 CMaterial::CMaterial(const mxArray *ptr) {
 
   assert_num_fields_equals(9, ptr, "Cmaterials");

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -49,25 +49,6 @@ bool XYZVectors::all_elements_less_than(double comparison_value, int vector_leng
   }
   return true;
 }
-bool XYZVectors::all_elements_less_than(double comparison_value, int vector_length, char component,
-                                        int buffer_start) {
-  AxialDirection d;
-  switch (component) {
-    case 'x':
-      d = AxialDirection::X;
-      break;
-    case 'y':
-      d = AxialDirection::Y;
-      break;
-    case 'z':
-      d = AxialDirection::Z;
-      break;
-    default:
-      throw runtime_error("Error - component not recognised");
-      break;
-  }
-  return all_elements_less_than(comparison_value, vector_length, d, buffer_start);
-}
 bool XYZVectors::all_elements_less_than(double comparison_value, int nx, int ny, int nz) {
   if (!all_elements_less_than(comparison_value, nx, AxialDirection::X)) { return false; }
   if (!all_elements_less_than(comparison_value, ny, AxialDirection::Y)) { return false; }

--- a/tdms/src/fields/base.cpp
+++ b/tdms/src/fields/base.cpp
@@ -137,8 +137,32 @@ void Field::interpolate_over_range(mxArray **x_out, mxArray **y_out, mxArray **z
   }
 }
 void Field::interpolate_over_range(mxArray **x_out, mxArray **y_out, mxArray **z_out,
-                            Dimension mode) {
+                                   Dimension mode) {
   interpolate_over_range(x_out, y_out, z_out, 0, I_tot, 0, J_tot, 0, K_tot, mode);
+}
+
+double Field::max_pointwise_difference_over_max_element(Field &other) {
+  if (other.I_tot != I_tot || other.J_tot != J_tot || other.K_tot != K_tot) {
+    throw runtime_error("Cannot compare the values of fields with different sizes");
+  }
+
+  double max_abs = 0., max_abs_diff = 0.;
+  for (char c : {'x', 'y', 'z'})
+    for (int k = 0; k < K_tot; k++)
+      for (int j = 0; j < J_tot; j++)
+        for (int i = 0; i < I_tot; i++) {
+
+          complex<double> field_value = real[c][k][j][i] + IMAGINARY_UNIT * imag[c][k][j][i],
+                          other_field_value =
+                                  other.real[c][k][j][i] + IMAGINARY_UNIT * other.imag[c][k][j][i];
+
+          // update the denominator (this field's max absolute value)
+          max_abs = max(max_abs, abs(field_value));
+          // update the numerator (maximum absolute difference between field entries)
+          max_abs_diff = max(max_abs_diff, abs(field_value - other_field_value));
+        }
+  // return the ratio
+  return max_abs_diff / max_abs;
 }
 
 Field::~Field() {

--- a/tdms/src/fields/base.cpp
+++ b/tdms/src/fields/base.cpp
@@ -141,7 +141,7 @@ void Field::interpolate_over_range(mxArray **x_out, mxArray **y_out, mxArray **z
   interpolate_over_range(x_out, y_out, z_out, 0, I_tot, 0, J_tot, 0, K_tot, mode);
 }
 
-double Field::max_pointwise_difference_over_max_element(Field &other) {
+double Field::normalised_difference(Field &other) {
   if (other.I_tot != I_tot || other.J_tot != J_tot || other.K_tot != K_tot) {
     throw runtime_error("Cannot compare the values of fields with different sizes");
   }

--- a/tdms/src/fields/split.cpp
+++ b/tdms/src/fields/split.cpp
@@ -75,3 +75,20 @@ void SplitField::initialise_fftw_plan(int n_threads, EHVec &eh_vec) {
   zx.initialise_fftw_plan(n_threads, n_x, eh_vec);
   zy.initialise_fftw_plan(n_threads, n_y, eh_vec);
 }
+
+double SplitField::largest_field_value() {
+  double largest_value = 0.;
+  for (int k = 0; k < (K_tot + 1); k++) {
+    for (int j = 0; j < (J_tot + 1); j++) {
+      for (int i = 0; i < (I_tot + 1); i++) {
+        double x_field = fabs(xy[k][j][i] + xz[k][j][i]);
+        double y_field = fabs(yx[k][j][i] + yz[k][j][i]);
+        double z_field = fabs(zx[k][j][i] + zy[k][j][i]);
+        if (largest_value < x_field) { largest_value = x_field; }
+        if (largest_value < y_field) { largest_value = y_field; }
+        if (largest_value < z_field) { largest_value = z_field; }
+      }
+    }
+  }
+  return largest_value;
+}

--- a/tdms/src/grid_labels.cpp
+++ b/tdms/src/grid_labels.cpp
@@ -8,3 +8,10 @@ GridLabels::GridLabels(const mxArray *ptr){
   y = mxGetPr(ptr_to_vector_in(ptr, "y_grid_labels", "grid_labels"));
   z = mxGetPr(ptr_to_vector_in(ptr, "z_grid_labels", "grid_labels"));
 }
+
+void GridLabels::initialise_from(GridLabels &labels_to_copy_from, int i_l, int i_u, int j_l,
+                                 int j_u, int k_l, int k_u) {
+  for (int i = i_l; i <= i_u; i++) { x[i - i_l] = labels_to_copy_from.x[i]; }
+  for (int j = j_l; j <= j_u; j++) { y[j - j_l] = labels_to_copy_from.y[j]; }
+  for (int k = k_l; k <= k_u; k++) { z[k - k_l] = labels_to_copy_from.z[k]; }
+}

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -4520,7 +4520,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
   *mxGetPr((mxArray *) plhs[25]) = maxfield;
 
   if (params.run_mode == RunMode::complete && params.exphasorsvolume) {
-    setGridLabels(input_grid_labels, output_grid_labels, E.il, E.iu, E.jl, E.ju, E.kl, E.ku);
+    output_grid_labels.initialise_from(input_grid_labels, E.il, E.iu, E.jl, E.ju, E.kl, E.ku);
   }
 
   auto interp_output_grid_labels = GridLabels();
@@ -4566,12 +4566,12 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
     interp_output_grid_labels.z = mxGetPr((mxArray *) plhs[21]);
 
     if (params.dimension == THREE) {
-      //fprintf(stderr,"Pos 15a-1\n");
-      setGridLabels(output_grid_labels, interp_output_grid_labels, 2, E.I_tot - 2, 2,
-                    E.J_tot - 2, 2, E.K_tot - 2);
-    } else
-      setGridLabels(output_grid_labels, interp_output_grid_labels, 2, E.I_tot - 2, 2,
-                    E.J_tot - 2, 0, 0);
+      interp_output_grid_labels.initialise_from(output_grid_labels, 2, E.I_tot - 2, 2, E.J_tot - 2,
+                                                2, E.K_tot - 2);
+    } else {
+      interp_output_grid_labels.initialise_from(output_grid_labels, 2, E.I_tot - 2, 2, E.J_tot - 2,
+                                                0, 0);
+    }
     //fprintf(stderr,"Pos 15f\n");
   } else {
     mwSize *emptydims;
@@ -5129,17 +5129,6 @@ double linearRamp(double t, double period, double rampwidth) {
   else
     return t / (period * rampwidth);
 }
-
-/*Load up the output grid labels*/
-void setGridLabels(GridLabels &input_labels, GridLabels &output_labels, int i_l, int i_u, int j_l,
-                   int j_u, int k_l, int k_u) {
-  //fprintf(stderr,"Entered: setGridLabels\n");
-  //fprintf(stderr,"setGridLabels: %d,%d\n",j_u,j_l);
-  for (int i = i_l; i <= i_u; i++) { output_labels.x[i - i_l] = input_labels.x[i]; }
-  for (int j = j_l; j <= j_u; j++) { output_labels.y[j - j_l] = input_labels.y[j]; }
-  for (int k = k_l; k <= k_u; k++) { output_labels.z[k - k_l] = input_labels.z[k]; }
-}
-
 
 /* These functions are used by the dispersive component of the code*/
 

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -1124,7 +1124,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
 
       dft_counter = 0;
 
-      double tol = E.max_pointwise_difference_over_max_element(E_copy);
+      double tol = E.normalised_difference(E_copy);
       if (tol < TOL) break; //required accuracy obtained
 
       spdlog::debug("Phasor convergence: {} (actual) > {} (required)", tol, TOL);

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -274,7 +274,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
   //these are used for boot strapping. There is currently no way of exporting this.
   double **iwave_lEx_Rbs, **iwave_lEy_Rbs, **iwave_lHx_Rbs, **iwave_lHy_Rbs, **iwave_lEx_Ibs,
           **iwave_lEy_Ibs, **iwave_lHx_Ibs, **iwave_lHy_Ibs;
-  double maxfield = 0, tempfield;
+  double maxfield = 0.;
 
   //refractive index of the first layer of the multilayer, or of the bulk of homogeneous
   double refind;
@@ -4425,25 +4425,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
 
     if ((((double) time(NULL)) - t0) > 1) {
 
-      maxfield = 0.;
-      for (k = 0; k < (K_tot + 1); k++) {
-        for (j = 0; j < (J_tot + 1); j++) {
-          for (i = 0; i < (I_tot + 1); i++) {
-            tempfield = fabs(E_s.xy[k][j][i] + E_s.xz[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-            tempfield = fabs(E_s.yx[k][j][i] + E_s.yz[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-            tempfield = fabs(E_s.zx[k][j][i] + E_s.zy[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-            tempfield = fabs(H_s.xy[k][j][i] + H_s.xz[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-            tempfield = fabs(H_s.yx[k][j][i] + H_s.yz[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-            tempfield = fabs(H_s.zx[k][j][i] + H_s.zy[k][j][i]);
-            if (maxfield < tempfield) { maxfield = tempfield; }
-          }
-        }
-      }
+      maxfield = max(E_s.largest_field_value(), H_s.largest_field_value());
 
       fprintf(stdout, "Iterating: %d %e\n", tind, maxfield);
       //fprintf(stderr,"Post-iter 1\n");
@@ -4528,25 +4510,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
 
   //now find the maximum absolute value of residual field in the grid
   // after resetting the maxfield value calculated in the main loop
-  maxfield = 0.0;
-  for (k = 0; k < (K_tot + 1); k++) {
-    for (j = 0; j < (J_tot + 1); j++) {
-      for (i = 0; i < (I_tot + 1); i++) {
-        tempfield = fabs(E_s.xy[k][j][i] + E_s.xz[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-        tempfield = fabs(E_s.yx[k][j][i] + E_s.yz[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-        tempfield = fabs(E_s.zx[k][j][i] + E_s.zy[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-        tempfield = fabs(H_s.xy[k][j][i] + H_s.xz[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-        tempfield = fabs(H_s.yx[k][j][i] + H_s.yz[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-        tempfield = fabs(H_s.zx[k][j][i] + H_s.zy[k][j][i]);
-        if (maxfield < tempfield) { maxfield = tempfield; }
-      }
-    }
-  }
+  maxfield = max(E_s.largest_field_value(), H_s.largest_field_value());
   //fprintf(stderr,"Pos 15\n");
   //noe set the output
   ndims = 2;

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -1124,7 +1124,7 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
 
       dft_counter = 0;
 
-      double tol = checkPhasorConvergence(E, E_copy);
+      double tol = E.max_pointwise_difference_over_max_element(E_copy);
       if (tol < TOL) break; //required accuracy obtained
 
       spdlog::debug("Phasor convergence: {} (actual) > {} (required)", tol, TOL);
@@ -5128,26 +5128,6 @@ double linearRamp(double t, double period, double rampwidth) {
   if (t > period * rampwidth) return 1.;
   else
     return t / (period * rampwidth);
-}
-
-double checkPhasorConvergence(ElectricField &E, ElectricField &E_copy) {
-
-  double max_abs = 0., max_abs_diff = 0.;
-
-  //find the largest maximum absolute value the largest difference (in absolute value) between phasors
-  for (char c : {'x', 'y', 'z'})
-    for (int k = 0; k < E.K_tot; k++)
-      for (int j = 0; j < E.J_tot; j++)
-        for (int i = 0; i < E.I_tot; i++){
-
-            auto E_ijk = E.real[c][k][j][i] + IMAGINARY_UNIT * E.imag[c][k][j][i];
-            auto E_copy_ijk = E_copy.real[c][k][j][i] + IMAGINARY_UNIT * E_copy.imag[c][k][j][i];
-
-            max_abs = max(max_abs, abs(E_ijk));  // max(max_abs, |Re(E_x) + i Im(E_x)|)
-            max_abs_diff = max(max_abs_diff, abs(E_ijk - E_copy_ijk));
-          }
-
-  return max_abs_diff / max_abs;
 }
 
 /*Load up the output grid labels*/

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -873,8 +873,8 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
   bool is_disp = is_dispersive(materials, gamma, params.dt, I_tot, J_tot, K_tot);
   //work out if we have conductive background
   bool is_cond = is_conductive(rho_cond, I_tot, J_tot, K_tot);
-  //work out if we have a dispersive background
-  if (params.is_disp_ml) params.is_disp_ml = is_dispersive_ml(ml, K_tot);
+  // work out if we have a dispersive background
+  if (params.is_disp_ml) params.is_disp_ml = ml.is_dispersive(K_tot);
   //  fprintf(stderr,"is_disp:%d, is_cond%d, params.is_disp_ml: %d\n",is_disp,is_cond,params.is_disp_ml);
   //if we have dispersive materials we need to create additional field variables
   auto E_nm1 = ElectricSplitField(I_tot, J_tot, K_tot);
@@ -5191,12 +5191,5 @@ bool is_conductive(const XYZVectors &rho, int I_tot, int J_tot, int K_tot) {
   for (int k = 0; k < (K_tot + 1); k++)
     if (fabs(rho.z[k]) > 1e-15) return true;
 
-  return false;
-}
-
-/*work out if we have a dispersive background*/
-bool is_dispersive_ml(const DispersiveMultiLayer &ml, int K_tot) {
-  for (int i = 0; i < K_tot; i++)
-    if (fabs(ml.gamma[i]) > 1e-15) return true;
   return false;
 }

--- a/tdms/src/iterator.cpp
+++ b/tdms/src/iterator.cpp
@@ -871,8 +871,8 @@ void execute_simulation(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs
 
   //work out if we have any disperive materials
   bool is_disp = is_dispersive(materials, gamma, params.dt, I_tot, J_tot, K_tot);
-  //work out if we have conductive background
-  bool is_cond = is_conductive(rho_cond, I_tot, J_tot, K_tot);
+  //work out if we have conductive background: background is conductive if at least one entry exceeds 1e-15
+  bool is_cond = !(rho_cond.all_elements_less_than(1e-15, I_tot + 1, J_tot + 1, K_tot + 1));
   // work out if we have a dispersive background
   if (params.is_disp_ml) params.is_disp_ml = ml.is_dispersive(K_tot);
   //  fprintf(stderr,"is_disp:%d, is_cond%d, params.is_disp_ml: %d\n",is_disp,is_cond,params.is_disp_ml);
@@ -5179,17 +5179,4 @@ bool is_dispersive(unsigned char ***materials, double *gamma, double dt, int I_t
     if (fabs(gamma[i] / dt) > 1e-15) { return 1; }
   }
   return 0;
-}
-
-/*work out if we have a conductive background*/
-bool is_conductive(const XYZVectors &rho, int I_tot, int J_tot, int K_tot) {
-
-  for (int i = 0; i < (I_tot + 1); i++)
-    if (fabs(rho.x[i]) > 1e-15) return true;
-  for (int j = 0; j < (J_tot + 1); j++)
-    if (fabs(rho.y[j]) > 1e-15) return true;
-  for (int k = 0; k < (K_tot + 1); k++)
-    if (fabs(rho.z[k]) > 1e-15) return true;
-
-  return false;
 }

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -293,7 +293,7 @@ private:
   const static int n_rows = 16;
 
   void test_correct_construction() override;
-  // set_ptr()
+  // set_ptr(), all_elements_less_than()
   void test_other_methods() override;
 
 public:

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -76,6 +76,8 @@ private:
   void test_empty_construction() override;
   void test_wrong_input_type() override;
   void test_correct_construction() override;
+  // test: is_dispersive()
+  void test_other_methods() override;
 
 public:
   std::string get_class_name() override { return "DispersiveMultilayer"; }

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -73,10 +73,10 @@ void DispersiveMultilayerTest::test_other_methods() {
     // create DispersiveMultiLayer object
     DispersiveMultiLayer dml(matlab_input);
 
-    // all entries in gamma are 1. -> so a tolerance of 1.5 should flag the dml as dispersive
-    REQUIRE(dml.is_dispersive(n_numeric_elements, 1.5));
-    // yet a tolerance of 0.5 should not
-    REQUIRE(!dml.is_dispersive(n_numeric_elements, 0.5));
+    // all entries in gamma are 1. -> so a tolerance of 1.5 should flag the dml as not dispersive
+    REQUIRE(!dml.is_dispersive(n_numeric_elements, 1.5));
+    // yet a tolerance of 0.5 should flag it as dispersive
+    REQUIRE(dml.is_dispersive(n_numeric_elements, 0.5));
   }
 }
 

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -57,6 +57,29 @@ void DispersiveMultilayerTest::test_correct_construction() {
   }
 }
 
+void DispersiveMultilayerTest::test_other_methods() {
+  SECTION("is_dispersive()") {
+    create_1by1_struct(n_fields, fieldnames);
+    // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
+    const int array_size[2] = {1, n_numeric_elements};
+    mxArray *field_array_ptrs[n_fields];
+    for (int i = 0; i < n_fields; i++) {
+      field_array_ptrs[i] =
+              mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
+      mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
+      for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) 1.; }
+      mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
+    }
+    // create DispersiveMultiLayer object
+    DispersiveMultiLayer dml(matlab_input);
+
+    // all entries in gamma are 1. -> so a tolerance of 1.5 should flag the dml as dispersive
+    REQUIRE(dml.is_dispersive(n_numeric_elements, 1.5));
+    // yet a tolerance of 0.5 should not
+    REQUIRE(!dml.is_dispersive(n_numeric_elements, 0.5));
+  }
+}
+
 TEST_CASE("DispersiveMultiLayer") {
   DispersiveMultilayerTest().run_all_class_tests();
 }

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -60,14 +60,14 @@ void DispersiveMultilayerTest::test_correct_construction() {
 void DispersiveMultilayerTest::test_other_methods() {
   SECTION("is_dispersive()") {
     create_1by1_struct(n_fields, fieldnames);
-    // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
+    // build "data" for each of the fields, just a constant array of 1s
     const int array_size[2] = {1, n_numeric_elements};
     mxArray *field_array_ptrs[n_fields];
     for (int i = 0; i < n_fields; i++) {
       field_array_ptrs[i] =
               mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
       mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
-      for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) 1.; }
+      for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = 1.; }
       mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
     }
     // create DispersiveMultiLayer object

--- a/tdms/tests/unit/array_tests/test_XYZVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZVectors.cpp
@@ -24,9 +24,10 @@ void XYZVectorsTest::test_correct_construction() {
 
 void XYZVectorsTest::test_other_methods() {
   XYZVectors v;
+  // create some arrays to assign to the members
+  double x_vec[n_rows] = {0.}, y_vec[n_cols] = {2., 1.}, z_vec[n_layers] = {1., 2., 3., 4.};
+
   SECTION("set_ptr()") {
-    // create some arrays to assign to the members
-    double x_vec[n_rows] = {0.}, y_vec[n_cols] = {2., 1.}, z_vec[n_layers] = {4., 3., 2., 1.};
     // now let's try assigning
     v.set_ptr(AxialDirection::X, x_vec);
     v.set_ptr(AxialDirection::Y, y_vec);
@@ -58,7 +59,19 @@ void XYZVectorsTest::test_other_methods() {
     }
     REQUIRE(correct_elements);
   }
-
+  SECTION("all_elements_less_than()") {
+    v.set_ptr(AxialDirection::X, x_vec);
+    v.set_ptr(AxialDirection::Y, y_vec);
+    v.set_ptr(AxialDirection::Z, z_vec);
+    // v.x: max element is 0, v.y: max is 2, v.z: max is 4
+    REQUIRE(v.all_elements_less_than(5., 1, 2, 4));
+    // v.x has no elements less than 0
+    REQUIRE(!v.all_elements_less_than(-1, 1, AxialDirection::X));
+    // v.y has all elements but the first less than 2
+    REQUIRE(v.all_elements_less_than(2., 1, AxialDirection::Y, 1));
+    // v.z has all elements except the last less than 4
+    REQUIRE(v.all_elements_less_than(4., 3, 'z'));
+  }
 }
 
 TEST_CASE("XYZVectors") {

--- a/tdms/tests/unit/array_tests/test_XYZVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZVectors.cpp
@@ -70,7 +70,7 @@ void XYZVectorsTest::test_other_methods() {
     // v.y has all elements but the first less than 2
     REQUIRE(v.all_elements_less_than(2., 1, AxialDirection::Y, 1));
     // v.z has all elements except the last less than 4
-    REQUIRE(v.all_elements_less_than(4., 3, 'z'));
+    REQUIRE(v.all_elements_less_than(4., 3, AxialDirection::Z));
   }
 }
 


### PR DESCRIPTION
Attempting to do some small refactors to `iterator.cpp` that don't touch anything that will need to be touched by #70. Docstrings are added to all refactored functions, classes, etc.

## List of replacements:

### `checkPhasorConvergence`

Replaced with the `Field` class method `max_pointwise_difference_over_max_element`. The name of the old function is misleading, it is only computing an error metric and NOT checking convergence - this happens later in the `iterator.cpp` main loop.

Pulling this out into a class method to make things a bit cleaner. Also, both the inputs are `Field`s, and the function is asymmetric, so it makes sense to have this as a class method.

### `setGridLabels`

Changed to the `initialise_from` method of the `GridLabels` class.

### `is_dispersive_ml`

Changed to `is_dispersive` method of `DispersiveMultilayer` class.

### `is_conductive`

Superceeded by the `all_elements_less_than` method of the `XYZVector` class. The check for whether a material is conductive is just whether at least one entry of an XYZVector exceeds a particular threshold.