### PR TITLE
`matrixnames` as `std::vector<std::string>`s

### DIFF
--- a/tdms/include/matrix_collection.h
+++ b/tdms/include/matrix_collection.h
@@ -3,6 +3,8 @@
  * @brief A collection of named MATLAB matrices.
  */
 #pragma once
+#include <string>
+#include <vector>
 
 #include "mat_io.h"
 
@@ -13,7 +15,7 @@ class MatrixCollection {
 
 public:
     int n_matrices = 0;            //< The number of matrices in the collection
-    char** matrix_names = nullptr; //< The names of the matrices
+    std::vector<std::string> matrix_names; //< The names of the matrices
 
     /** @brief Construct a new Matrix Collection object */
     MatrixCollection() = default;
@@ -24,7 +26,14 @@ public:
      * @param names of the matrices
      * @param number of matrices in the collection
      */
-    explicit MatrixCollection(char **names, int number);
+    //explicit MatrixCollection(char **names, int number);
+
+    /**
+     * @brief Construct a new Matrix Collection object
+     *
+     * @param names of the matrices
+     */
+    explicit MatrixCollection(std::vector<std::string> names);
 
     /**
      * @brief Check we have as many or more matrices than another

--- a/tdms/include/openandorder.h
+++ b/tdms/include/openandorder.h
@@ -20,7 +20,9 @@
  * @param matrix_ptrs pointers to arrays in C++ that will be populated by the MATLAB matrices
  * @param n_matrices the number of matrices in the MATLAB file
  */
-void openandorder(const char *mat_filename, char **matrix_names, const mxArray **matrix_ptrs, int n_matrices);
+void openandorder(const char *mat_filename,
+                  const std::vector<std::string>& matrix_names,
+                  const mxArray **matrix_ptrs, int n_matrices);
 
 /**
  * @brief Save the resultant matrices into a file with name outputfilename
@@ -32,7 +34,8 @@ void openandorder(const char *mat_filename, char **matrix_names, const mxArray *
  * @param nmatrices the number of matrices to save
  * @param outputfilename name of the output file
  */
-void saveoutput(mxArray **plhs, const int *matricestosave, char *matrixnames[], int nmatrices, const char *outputfilename);
+void saveoutput(mxArray **plhs, const int *matricestosave,
+                const std::vector<std::string>& matrixnames, int nmatrices, const char *outputfilename);
 
 /**
  * @brief Check that all input and output files can be accessed

--- a/tdms/src/main.cpp
+++ b/tdms/src/main.cpp
@@ -2,6 +2,9 @@
  * @file main.cpp
  * @brief The main function. Launches TDMS.
  */
+#include <vector>
+#include <string>
+
 #include <spdlog/spdlog.h>
 
 #include "openandorder.h"
@@ -15,37 +18,65 @@
 
 int main(int nargs, char *argv[]){
 
-  // Set the logging level with a compile-time define for debugging
+  // Set the logging level with a compile-time #define for debugging.
   #if SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_DEBUG
     spdlog::set_level(spdlog::level::debug);
   #elif SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_INFO
     spdlog::set_level(spdlog::level::info);
   #endif
 
-  /*
-    There are two cases to consider, when the fdtdgrid matrix is specified in a separate mat file
-    and when it is in the same file as the other matrices.
-  */
+  // the names of the matrices expected in the input file with a separate grid file
+  std::vector<std::string> matrixnames_infile = {
+    "Cmaterial", "Dmaterial", "C", "D", "freespace", "disp_params", "delta",
+    "interface", "Isource", "Jsource", "Ksource", "grid_labels", "omega_an",
+    "to_l", "hwhm", "Dxl", "Dxu", "Dyl", "Dyu", "Dzl", "Dzu", "Nt", "dt",
+    "tind", "sourcemode", "runmode", "exphasorsvolume", "exphasorssurface",
+    "intphasorssurface", "phasorsurface", "phasorinc", "dimension",
+    "conductive_aux", "dispersive_aux", "structure", "f_ex_vec",
+    "exdetintegral", "f_vec", "Pupil", "D_tilde", "k_det_obs_global",
+    "air_interface", "intmatprops", "intmethod", "tdfield", "tdfdir",
+    "fieldsample", "campssample"
+  };
+  // the name of the matrix expected in a separate grid file
+  std::vector<std::string> matrixnames_gridfile = {"fdtdgrid"};
 
-  const char *matrixnames[] = {"fdtdgrid","Cmaterial","Dmaterial","C","D","freespace","disp_params","delta","interface","Isource","Jsource","Ksource","grid_labels","omega_an","to_l","hwhm","Dxl","Dxu","Dyl","Dyu","Dzl","Dzu","Nt","dt","tind","sourcemode","runmode","exphasorsvolume","exphasorssurface","intphasorssurface","phasorsurface","phasorinc","dimension","conductive_aux","dispersive_aux","structure","f_ex_vec","exdetintegral","f_vec","Pupil","D_tilde","k_det_obs_global","air_interface","intmatprops","intmethod","tdfield","tdfdir","fieldsample","campssample"};
-  const char *matrixnames_infile[] = {"Cmaterial","Dmaterial","C","D","freespace","disp_params","delta","interface","Isource","Jsource","Ksource","grid_labels","omega_an","to_l","hwhm","Dxl","Dxu","Dyl","Dyu","Dzl","Dzu","Nt","dt","tind","sourcemode","runmode","exphasorsvolume","exphasorssurface","intphasorssurface","phasorsurface","phasorinc","dimension","conductive_aux","dispersive_aux","structure","f_ex_vec","exdetintegral","f_vec","Pupil","D_tilde","k_det_obs_global","air_interface","intmatprops","intmethod","tdfield","tdfdir","fieldsample","campssample"};
-  const char *matrixnames_gridfile[] = {"fdtdgrid"};
-  const char *outputmatrices_all[] = {"Ex_out","Ey_out","Ez_out","Hx_out","Hy_out","Hz_out","x_out","y_out","z_out","Ex_i","Ey_i","Ez_i","Hx_i","Hy_i","Hz_i","x_i","y_i","z_i","vertices","camplitudes","facets","maxresfield","Id","fieldsample","campssample"};
-  const char *outputmatrices[] = {"Ex_out","Ey_out","Ez_out","Hx_out","Hy_out","Hz_out","x_out","y_out","z_out","Ex_i","Ey_i","Ez_i","Hx_i","Hy_i","Hz_i","x_i","y_i","z_i","camplitudes","maxresfield","Id","fieldsample","campssample"};
-  int  matricestosave_all[]   = {0,1,2,3,4,5,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28};
-  int  matricestosave[]   = {0,1,2,3,4,5,10,11,12,13,14,15,16,17,18,19,20,21,23,25,26,27,28};
+  // the names of the matrices expected in the input file if the grid is included
+  std::vector<std::string> matrixnames_input_and_grid(matrixnames_infile);
+  matrixnames_input_and_grid.insert(
+    matrixnames_input_and_grid.end(),
+    matrixnames_gridfile.begin(),
+    matrixnames_gridfile.end()
+  );
+
+  std::vector<std::string> outputmatrices_all = {
+    "Ex_out", "Ey_out", "Ez_out", "Hx_out", "Hy_out", "Hz_out", "x_out",
+    "y_out", "z_out", "Ex_i", "Ey_i", "Ez_i", "Hx_i", "Hy_i", "Hz_i", "x_i",
+    "y_i", "z_i", "vertices", "camplitudes", "facets", "maxresfield", "Id",
+    "fieldsample", "campssample"
+  };
+  std::vector<std::string> outputmatrices = {
+    "Ex_out", "Ey_out", "Ez_out", "Hx_out", "Hy_out", "Hz_out", "x_out",
+    "y_out", "z_out", "Ex_i", "Ey_i", "Ez_i", "Hx_i", "Hy_i", "Hz_i", "x_i",
+    "y_i", "z_i", "camplitudes", "maxresfield", "Id", "fieldsample",
+    "campssample"
+  };
+  int matricestosave_all[] = {0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28};
+  int matricestosave[]     = {0, 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,     23,     25, 26, 27, 28};
+
   mxArray *plhs[NOUTMATRICES_PASSED];
   const mxArray *matrixptrs[NMATRICES];
 
   auto args = ArgumentParser::parse_args(nargs, argv);
   check_files_can_be_accessed(args);
 
-  //now it is safe to use matlab routines to open the file and order the matrices
+  // Now it is safe to use matlab routines to open the file and order the matrices.
+  // There are two cases to consider, when the fdtdgrid matrix is specified in a
+  // separate mat file and when it is in the same file as the other matrices.
   if(!args.has_grid_filename())
-    openandorder(args.input_filename(), (char **)matrixnames, matrixptrs, NMATRICES);
+    openandorder(args.input_filename(), matrixnames_input_and_grid, matrixptrs, NMATRICES);
   else{
-    openandorder(args.input_filename(), (char **)matrixnames_infile, matrixptrs+1, NMATRICES-1);
-    openandorder(args.grid_filename(), (char **)matrixnames_gridfile, matrixptrs, 1);
+    openandorder(args.input_filename(), matrixnames_infile, matrixptrs+1, NMATRICES-1);
+    openandorder(args.grid_filename(), matrixnames_gridfile, matrixptrs, 1);
   }
 
   // decide which derivative method to use (PSTD or FDTD)
@@ -60,15 +91,15 @@ int main(int nargs, char *argv[]){
     preferred_interpolation_methods = PreferredInterpolationMethods::Cubic;
   }
 
-  //now run the time propagation code
+  // now run the time propagation code
   execute_simulation(NOUTMATRICES_PASSED, (mxArray **) plhs, NMATRICES,
                      (const mxArray **) matrixptrs, solver_method, preferred_interpolation_methods);
 
   if (!args.have_flag("-m")) {//prints vertices and facets
-    saveoutput(plhs, matricestosave_all, (char **) outputmatrices_all, NOUTMATRICES_WRITE_ALL,
+    saveoutput(plhs, matricestosave_all, outputmatrices_all, NOUTMATRICES_WRITE_ALL,
                args.output_filename());
   } else {// minimise the file size by not printing vertices and facets
-    saveoutput(plhs, matricestosave, (char **) outputmatrices, NOUTMATRICES_WRITE,
+    saveoutput(plhs, matricestosave, outputmatrices, NOUTMATRICES_WRITE,
                args.output_filename());
   }
 

--- a/tdms/src/matrix_collection.cpp
+++ b/tdms/src/matrix_collection.cpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <spdlog/spdlog.h>
+
 #include "mat_io.h"
 
 using namespace std;
@@ -15,14 +17,15 @@ MatFileMatrixCollection::MatFileMatrixCollection(const char *filename){
   }
 
   int tmp_n;
-  matrix_names = matGetDir(mat_file, &tmp_n);
+  char** matlab_file_contents = matGetDir(mat_file, &tmp_n);
+  matrix_names = std::vector<std::string>(matlab_file_contents, matlab_file_contents+tmp_n);
   n_matrices = tmp_n;
 }
 
-MatrixCollection::MatrixCollection(char **names, int number) {
+MatrixCollection::MatrixCollection(std::vector<std::string> names) {
 
   matrix_names = names;
-  n_matrices = number;
+  n_matrices = names.size();
 }
 
 void MatrixCollection::check_has_at_least_as_many_matrices_as(MatrixCollection &other) {
@@ -39,5 +42,8 @@ MatFileMatrixCollection::~MatFileMatrixCollection() {
   if (mat_file != nullptr){
     matClose(mat_file);
   }
-  mxFree(matrix_names);
+  std::vector<char*> matrix_names_cstrs{};
+  for(auto& matrixname : matrix_names)
+    matrix_names_cstrs.push_back(&matrixname.front());
+  mxFree(matrix_names_cstrs.data());
 }

--- a/tdms/src/openandorder.cpp
+++ b/tdms/src/openandorder.cpp
@@ -17,9 +17,11 @@
 
 using namespace std;
 
-void openandorder(const char *mat_filename, char **matrix_names, const mxArray **matrix_ptrs, int n_matrices){
+void openandorder(const char *mat_filename,
+                  const std::vector<std::string>& matrix_names,
+                  const mxArray **matrix_ptrs, int n_matrices){
 
-  auto expected = MatrixCollection(matrix_names, n_matrices);
+  auto expected = MatrixCollection(matrix_names);
   auto actual = MatFileMatrixCollection(mat_filename);
 
   actual.check_has_at_least_as_many_matrices_as(expected);
@@ -29,7 +31,7 @@ void openandorder(const char *mat_filename, char **matrix_names, const mxArray *
   //fprintf(stderr, "Got all %d matrices\n",nmatrices);
   //fprintf(stderr, "%d\n",mxGetFieldNumber( (mxArray *)matrixptrs[0], "I_tot"));
 
-  if (!are_equal(matrix_names[0], "fdtdgrid")){
+  if (matrix_names[0] != "fdtdgrid"){
     return;
   }
 
@@ -85,9 +87,9 @@ void assign_matrix_pointers(MatrixCollection &expected, MatFileMatrixCollection 
     for(int j=0; j < actual.n_matrices; j++){
       auto actual_matrix_name = actual.matrix_names[j];
 
-      if(are_equal(actual_matrix_name, expected_matrix_name)){
+      if(actual_matrix_name == expected_matrix_name){
         //fprintf(stderr,"Got %s/%s (%d)\n",mat_matrixnames[j],matrixnames[i],j);
-        auto pointer = matGetVariable(actual.mat_file, actual_matrix_name);
+        auto pointer = matGetVariable(actual.mat_file, actual_matrix_name.c_str());
 
         if(pointer == nullptr){
           throw runtime_error("Could not get pointer to "+string(actual_matrix_name));

--- a/tdms/src/openandorder.cpp
+++ b/tdms/src/openandorder.cpp
@@ -45,7 +45,9 @@ void openandorder(const char *mat_filename, char **matrix_names, const mxArray *
   }
 }
 
-void saveoutput(mxArray **plhs, const int *matricestosave, char *matrixnames[], int nmatrices, const char *outputfilename){
+void saveoutput(mxArray **plhs, const int *matricestosave,
+                const std::vector<std::string>& matrixnames, int nmatrices,
+                const char *outputfilename){
 
   auto outfile = matOpen(outputfilename, "w7.3");
   if (outfile == nullptr){
@@ -54,12 +56,12 @@ void saveoutput(mxArray **plhs, const int *matricestosave, char *matrixnames[], 
 
   //now iterate through the matrices, set names and add to matfile
   for(int i=0; i<nmatrices; i++){
-    auto mpv_out = matPutVariable(outfile, matrixnames[i], (mxArray *)plhs[matricestosave[i]]);
+    auto mpv_out = matPutVariable(outfile, matrixnames[i].c_str(), (mxArray *)plhs[matricestosave[i]]);
 
     if(mpv_out){
       auto fp = matGetFp(outfile);
       fprintf(stderr, "Could not write array %s to %s (%d,%d,%d)\n",
-              matrixnames[i], outputfilename, mpv_out, feof(fp), ferror(fp));
+              matrixnames[i].c_str(), outputfilename, mpv_out, feof(fp), ferror(fp));
     }
   }
 


### PR DESCRIPTION
I don't think we want to merge this, given #206. Instead, let me leave it here so you can `cherry-pick` or `checkout` certain files or whatever. Assuming that's helpful.

