### PR TITLE
Add clang-format to the pre-commit.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
-ColumnLimit: 100
+ColumnLimit: 80
 CompactNamespaces: false
 ContinuationIndentWidth: 8
 IndentCaseLabels: true
@@ -41,11 +41,11 @@ IndentPPDirectives: None
 IndentWidth: 2
 KeepEmptyLinesAtTheStartOfBlocks: true
 MaxEmptyLinesToKeep: 2
-NamespaceIndentation: All
+NamespaceIndentation: None
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PointerAlignment: Right
-ReflowComments: false
+ReflowComments: true
 SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: Run python code linting
+name: Run code linting
 on:
   push:
     branches: "main"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       hooks:
         - id: trailing-whitespace
         - id: end-of-file-fixer
-    # Add clang-format
+    # Add C++ linting
     - repo: https://github.com/pocc/pre-commit-hooks
       rev: v1.3.5
       hooks:
@@ -33,3 +33,6 @@ repos:
         #   args: ["--project=tdms/build/compile_commands.json"]
         - id: cpplint
           args: ["--filter=-whitespace/comments,-legal/copyright", "--linelength=120", "--quiet"]
+          # suppress whitespace because it conflicts with clang-tidy and doxygen
+          # suppress copyright in file headers because we don't require them in the developer docs
+          # run quietly so we don't see you doing this if everything is fine

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
     # Sort order of Python imports
     - repo: https://github.com/pycqa/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
     # Python code formatting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,15 @@ repos:
       hooks:
         - id: trailing-whitespace
         - id: end-of-file-fixer
+    # Add clang-format
+    - repo: https://github.com/pocc/pre-commit-hooks
+      rev: v1.3.5
+      hooks:
+        - id: clang-format
+          args: ["--style=file"]
+        - id: clang-tidy
+          args: ["-p=tdms/build/compile_commands.json"]
+        # - id: cppcheck
+        #   args: ["--project=tdms/build/compile_commands.json"]
+        - id: cpplint
+          args: ["--filter=-whitespace/comments,-legal/copyright", "--linelength=120", "--quiet"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,10 @@ repos:
       hooks:
         - id: clang-format
           args: ["--style=file"]
-        - id: clang-tidy
-          args: ["-p=tdms/build/compile_commands.json"]
-        # - id: cppcheck
-        #   args: ["--project=tdms/build/compile_commands.json"]
-        - id: cpplint
-          args: ["--filter=-whitespace/comments,-legal/copyright", "--linelength=120", "--quiet"]
-          # suppress whitespace because it conflicts with clang-tidy and doxygen
-          # suppress copyright in file headers because we don't require them in the developer docs
-          # run quietly so we don't see you doing this if everything is fine
+      # - id: cppcheck
+      #   args: ["--project=tdms/build/compile_commands.json"]
+      # - id: cpplint
+      #   args: ["--filter=-whitespace/comments,-legal/copyright", "--linelength=120", "--quiet"]
+      # suppress whitespace because it conflicts with clang-tidy and doxygen
+      # suppress copyright in file headers because we don't require them in the developer docs
+      # run quietly so we don't see you doing this if everything is fine

--- a/examples/arc_01/.clang-format
+++ b/examples/arc_01/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/tdms/include/argument_parser.h
+++ b/tdms/include/argument_parser.h
@@ -12,113 +12,115 @@
 /**
  * @brief Wraps a vector of string CL arguments with some helpful functionality.
  */
-class ArgumentNamespace{
+class ArgumentNamespace {
 
 private:
-    std::vector<std::string> arguments;          //< The arguments from flags
-    std::vector<std::string> non_flag_arguments; //< Arguments not from flags
+  std::vector<std::string> arguments;         //< The arguments from flags
+  std::vector<std::string> non_flag_arguments;//< Arguments not from flags
 
 public:
-    int num_non_flag = 0; //< A count of arguments not from flags
+  int num_non_flag = 0;//< A count of arguments not from flags
 
-    /**
-     * @brief Construct a new Argument Namespace object
-     *
-     * @param n_args the number of arguments (argc)
-     * @param argv pointers to the arguments (argv)
-     */
-    explicit ArgumentNamespace(int n_args, char *argv[]);
+  /**
+   * @brief Construct a new Argument Namespace object
+   *
+   * @param n_args the number of arguments (argc)
+   * @param argv pointers to the arguments (argv)
+   */
+  explicit ArgumentNamespace(int n_args, char *argv[]);
 
-    /**
-     * @brief Searches the arguments for the flag provided
-     *
-     * @param flag to search for
-     * @return true if the flag is present
-     * @return false otherwise
-     */
-    bool have_flag(std::string const &flag) const;
+  /**
+   * @brief Searches the arguments for the flag provided
+   *
+   * @param flag to search for
+   * @return true if the flag is present
+   * @return false otherwise
+   */
+  bool have_flag(std::string const &flag) const;
 
-    /**
-     * @brief Have we been provided with a grid filename?
-     *
-     * @return true if there are 3 non-flag arguments (therefore a grid filename)
-     * @return false otherwise
-     */
-    bool has_grid_filename() const;
+  /**
+   * @brief Have we been provided with a grid filename?
+   *
+   * @return true if there are 3 non-flag arguments (therefore a grid filename)
+   * @return false otherwise
+   */
+  bool has_grid_filename() const;
 
-    /**
-     * @brief Check that the correct number of filename arguments are provided
-     * (either 2 or 3 non-flag arguments)
-     *
-     * @return true if correct
-     * @return false otherwise
-     */
-    bool have_correct_number_of_filenames() const;
+  /**
+   * @brief Check that the correct number of filename arguments are provided
+   * (either 2 or 3 non-flag arguments)
+   *
+   * @return true if correct
+   * @return false otherwise
+   */
+  bool have_correct_number_of_filenames() const;
 
-    /**
-     * @brief Check whether an argument is a flag (starts '-')
-     *
-     * @param arg the argument
-     * @return true if arg is a flag
-     * @return false otherwise
-     */
-    static bool is_a_flag_argument(std::string arg);
+  /**
+   * @brief Check whether an argument is a flag (starts '-')
+   *
+   * @param arg the argument
+   * @return true if arg is a flag
+   * @return false otherwise
+   */
+  static bool is_a_flag_argument(std::string arg);
 
-    /**
-     * @brief Check whether we were asked to use the finite-difference method.
-     * (the default is pseudospectral.)
-     *
-     * @return true if provided '-fd' or '--finite-difference'
-     * @return false otherwise
-     */
-    bool finite_difference() const;
+  /**
+   * @brief Check whether we were asked to use the finite-difference method.
+   * (the default is pseudospectral.)
+   *
+   * @return true if provided '-fd' or '--finite-difference'
+   * @return false otherwise
+   */
+  bool finite_difference() const;
 
-    /**
-     * @brief Check whether we were asked to use the cubic interpolation schemes over the BLi schemes (default is no)
-     *
-     * @return true if provided '-nbli' or '--no-band-limited'
-     * @return false otheriwse
-     */
-    bool cubic_interpolation() const;
+  /**
+   * @brief Check whether we were asked to use the cubic interpolation schemes
+   * over the BLi schemes (default is no)
+   *
+   * @return true if provided '-nbli' or '--no-band-limited'
+   * @return false otheriwse
+   */
+  bool cubic_interpolation() const;
 
-    /**
-     * @brief Gets the input filename
-     *
-     * @return const char* the input filename
-     */
-    const char* input_filename();
+  /**
+   * @brief Gets the input filename
+   *
+   * @return const char* the input filename
+   */
+  const char *input_filename();
 
-    /**
-     * @brief Gets the output filename
-     *
-     * The output filename is either the second or third positional argument
-     * depending on whether a grid filename is provided or not.
-     *
-     * @return const char*  the output filename
-     */
-    const char* output_filename();
+  /**
+   * @brief Gets the output filename
+   *
+   * The output filename is either the second or third positional argument
+   * depending on whether a grid filename is provided or not.
+   *
+   * @return const char*  the output filename
+   */
+  const char *output_filename();
 
-    /**
-     * @brief Gets the grid filename
-     *
-     * @return const char* the grid filename
-     */
-    const char* grid_filename();
+  /**
+   * @brief Gets the grid filename
+   *
+   * @return const char* the grid filename
+   */
+  const char *grid_filename();
 
-    /**
-     * @brief Get all input filenames
-     *
-     * A vector containing the input filename and the grid filename (if
-     * provided)
-     *
-     * @return std::vector<std::string> the input filenames
-     */
-    std::vector<std::string> input_filenames();
+  /**
+   * @brief Get all input filenames
+   *
+   * A vector containing the input filename and the grid filename (if
+   * provided)
+   *
+   * @return std::vector<std::string> the input filenames
+   */
+  std::vector<std::string> input_filenames();
 
-    /**
-     * @brief Check that all input and output files can be accessed with the correct privilages
-     */
-    void check_files_can_be_accessed();
+  /**
+   * @brief Check that all input and output files can be accessed with the
+   * correct privilages
+   */
+  void check_files_can_be_accessed();
 };
 
 /**
@@ -127,16 +129,16 @@ public:
 class ArgumentParser {
 
 private:
-    /** Prints the help message (all options).  */
-    static void print_help_message();
+  /** Prints the help message (all options).  */
+  static void print_help_message();
 
 public:
-    /**
-     * @brief Parse the command line arguments and perform relevant actions.
-     *
-     * @param n_args The number of arguments (argc)
-     * @param arg_ptrs Pointers to to the arguments (argv)
-     * @return ArgumentNamespace populated with options
-     */
-    static ArgumentNamespace parse_args(int n_args, char *arg_ptrs[]);
+  /**
+   * @brief Parse the command line arguments and perform relevant actions.
+   *
+   * @param n_args The number of arguments (argc)
+   * @param arg_ptrs Pointers to to the arguments (argv)
+   * @return ArgumentNamespace populated with options
+   */
+  static ArgumentNamespace parse_args(int n_args, char *arg_ptrs[]);
 };

--- a/tdms/include/array_init.h
+++ b/tdms/include/array_init.h
@@ -9,11 +9,12 @@
 #include "mat_io.h"
 
 /**
- * Initialise the grid tensors/arrays, including the electric and magnetic split fields and the
- * materials array.
+ * Initialise the grid tensors/arrays, including the electric and magnetic split
+ * fields and the materials array.
  * @param ptr Pointer to the matlab struct
  * @param E_s Electric split field
  * @param H_s Magnetic split field
  * @param materials Materials array
  */
-void init_grid_arrays(const mxArray *ptr, SplitField &E_s, SplitField &H_s, uint8_t*** &materials);
+void init_grid_arrays(const mxArray *ptr, SplitField &E_s, SplitField &H_s,
+                      uint8_t ***&materials);

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -5,14 +5,14 @@
 #pragma once
 
 #include <complex>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 #include <fftw3.h>
 
+#include "globals.h"
 #include "matlabio.h"
 #include "utils.h"
-#include "globals.h"
 
 template<typename T>
 class XYZTensor3D {
@@ -21,25 +21,34 @@ public:
   T ***y = nullptr;
   T ***z = nullptr;
 
-  T*** operator[] (char c) const{
+  T ***operator[](char c) const {
     switch (c) {
-      case 'x': return x;
-      case 'y': return y;
-      case 'z': return z;
-      default: throw std::runtime_error("Have no element " + to_string(c));
+      case 'x':
+        return x;
+      case 'y':
+        return y;
+      case 'z':
+        return z;
+      default:
+        throw std::runtime_error("Have no element " + to_string(c));
     }
   }
-  T*** operator[] (AxialDirection d) const{
+  T ***operator[](AxialDirection d) const {
     switch (d) {
-      case AxialDirection::X: return x;
-      case AxialDirection::Y: return y;
-      case AxialDirection::Z: return z;
-      default: throw std::runtime_error("Have no element " + to_string(d));
+      case AxialDirection::X:
+        return x;
+      case AxialDirection::Y:
+        return y;
+      case AxialDirection::Z:
+        return z;
+      default:
+        throw std::runtime_error("Have no element " + to_string(d));
     }
   }
 
   /**
-   * @brief Allocates x, y, and z as (K_total+1) * (J_total+1) * (I_total+1) arrays
+   * @brief Allocates x, y, and z as (K_total+1) * (J_total+1) * (I_total+1)
+   * arrays
    *
    * @param I_total,J_total,K_total Dimensions of the tensor size to set
    */
@@ -62,9 +71,9 @@ public:
 
 class XYZVectors {
 public:
-  double* x = nullptr;
-  double* y = nullptr;
-  double* z = nullptr;
+  double *x = nullptr;
+  double *y = nullptr;
+  double *z = nullptr;
 
   /**
    * Default constructor
@@ -76,7 +85,7 @@ public:
    * @param c Character labeling the vector
    * @param ptr Pointer to assign
    */
-  void set_ptr(char c, double* ptr);
+  void set_ptr(char c, double *ptr);
   /**
    * Set the pointer for one of the vectors in this collection with a name of c
    * @param d AxialDirection labeling the vector
@@ -85,32 +94,39 @@ public:
   void set_ptr(AxialDirection d, double *ptr);
 
   /**
-   * @brief Determines whether all elements in the x, y, or z vector are less than a given value.
+   * @brief Determines whether all elements in the x, y, or z vector are less
+   * than a given value.
    *
    * @param comparison_value Value to compare elements to
    * @param vector_length Number of elements to compare against
    * @param component Vector to compare elements against; x, y, or z
-   * @param buffer_start Only compare elements between buffer_start (inclusive) and buffer_start+vector_length-1 (inclusive)
+   * @param buffer_start Only compare elements between buffer_start (inclusive)
+   * and buffer_start+vector_length-1 (inclusive)
    * @return true All elements are less than the comparison_value
    * @return false At least one element is not less than the comparison_value
    */
   bool all_elements_less_than(double comparison_value, int vector_length,
-                                 AxialDirection component, int buffer_start = 0) const;
+                              AxialDirection component,
+                              int buffer_start = 0) const;
   /**
-   * @brief Determines whether all elements in the x, y, AND z vectors are less than a given value.
+   * @brief Determines whether all elements in the x, y, AND z vectors are less
+   * than a given value.
    *
    * @param comparison_value Value to compare elements to
-   * @param nx,ny,nz Number of elements in the nx, ny, and nz vectors respectively
+   * @param nx,ny,nz Number of elements in the nx, ny, and nz vectors
+   * respectively
    * @return true All elements are less than the comparison_value
    * @return false At least one element is not less than the comparison_value
    */
-  bool all_elements_less_than(double comparison_value, int nx, int ny, int nz) const;
+  bool all_elements_less_than(double comparison_value, int nx, int ny,
+                              int nz) const;
 };
 
 // TODO: docstring
-class MaterialCollection{
+class MaterialCollection {
 protected:
-  static void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const std::string &prefix);
+  static void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays,
+                               const std::string &prefix);
 };
 
 /**
@@ -135,7 +151,8 @@ public:
 /*! @copydoc CCollectionBase */
 class CCollection : public CCollectionBase {
 private:
-  void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const std::string &prefix);
+  void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays,
+                        const std::string &prefix);
 
 public:
   bool is_multilayer = false;
@@ -169,9 +186,10 @@ public:
 };
 
 /*! @copydoc DCollectionBase */
-class DCollection: public DCollectionBase{
+class DCollection : public DCollectionBase {
 private:
-  static void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const std::string &prefix);
+  static void init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays,
+                               const std::string &prefix);
 
 public:
   explicit DCollection(const mxArray *ptr);
@@ -183,11 +201,11 @@ public:
   explicit DMaterial(const mxArray *ptr);
 };
 
-class DispersiveMultiLayer{
+class DispersiveMultiLayer {
 public:
-  double* alpha = nullptr;
-  double* beta = nullptr;
-  double* gamma = nullptr;
+  double *alpha = nullptr;
+  double *beta = nullptr;
+  double *gamma = nullptr;
   XYZVectors kappa;
   XYZVectors sigma;
 
@@ -197,20 +215,22 @@ public:
   /**
    * @brief Determines whether the (background) medium is dispersive
    *
-   * @param K_tot Number of Yee cells in the z-direction (number of entries in this->gamma)
-   * @param near_zero_tolerance Tolerance for non-zero gamma (attenuation) values
+   * @param K_tot Number of Yee cells in the z-direction (number of entries in
+   * this->gamma)
+   * @param near_zero_tolerance Tolerance for non-zero gamma (attenuation)
+   * values
    * @return true Background is dispersive
    * @return false Background is not dispersive
    */
-  bool is_dispersive(int K_tot, double near_zero_tolerance=1e-15);
+  bool is_dispersive(int K_tot, double near_zero_tolerance = 1e-15);
 };
 
 template<typename T>
-class Matrix{
+class Matrix {
 protected:
   int n_rows = 0;
   int n_cols = 0;
-  T** matrix = nullptr;
+  T **matrix = nullptr;
 
 public:
   /**
@@ -222,20 +242,19 @@ public:
    * @brief Construct a new Matrix object, providing the dimensions
    *
    * @param n_rows,n_cols Number of rows and columns in the matrix
-   * @param initial_value The initial value of the elements, defaults to 0 to avoid initalised but unassigned values
+   * @param initial_value The initial value of the elements, defaults to 0 to
+   * avoid initalised but unassigned values
    */
-  Matrix(int n_rows, int n_cols) {
-    allocate(n_rows, n_cols);
-  }
+  Matrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
 
-  inline T* operator[] (int value) const { return matrix[value]; }
+  inline T *operator[](int value) const { return matrix[value]; }
   /**
    * @brief Check whether this matrix has elements assigned
    *
    * @return true If this matrix has assigned elements
    * @return false This matrix is currently unassigned
    */
-  bool has_elements(){ return matrix != nullptr; };
+  bool has_elements() { return matrix != nullptr; };
 
   /**
    * Allocate the memory for this matrix
@@ -243,7 +262,7 @@ public:
    * @param n_rows Number of rows
    * @param n_cols Number of columns
    */
-  void allocate(int n_rows, int n_cols, T initial_value = 0){
+  void allocate(int n_rows, int n_cols, T initial_value = 0) {
     this->n_rows = n_rows;
     this->n_cols = n_cols;
 
@@ -256,7 +275,7 @@ public:
   /**
    * Destructor. Must be defined in the header
    */
-  ~Matrix(){
+  ~Matrix() {
     if (has_elements()) {
       for (int i = 0; i < n_rows; i++) { free(matrix[i]); }
       free(matrix);
@@ -264,7 +283,7 @@ public:
   };
 };
 
-class GratingStructure: public Matrix<int>{
+class GratingStructure : public Matrix<int> {
 
 public:
   GratingStructure(const mxArray *ptr, int I_tot);
@@ -273,10 +292,10 @@ public:
 };
 
 template<typename T>
-class Vector{
+class Vector {
 protected:
-  int n = 0;        // Number of elements
-  T* vector = nullptr; // Internal array
+  int n = 0;          // Number of elements
+  T *vector = nullptr;// Internal array
 
 public:
   Vector() = default;
@@ -291,19 +310,19 @@ public:
 
   bool has_elements() { return vector != nullptr; }
 
-  inline T operator[] (int value) const { return vector[value]; };
+  inline T operator[](int value) const { return vector[value]; };
 
   inline int size() const { return n; };
 };
 
-class FrequencyExtractVector: public Vector<double>{
+class FrequencyExtractVector : public Vector<double> {
 public:
   FrequencyExtractVector(const mxArray *ptr, double omega_an);
 
   double max();
 };
 
-class FrequencyVectors{
+class FrequencyVectors {
 public:
   Vector<double> x;
   Vector<double> y;
@@ -312,7 +331,7 @@ public:
 };
 
 // TODO: docstring
-class Pupil: public Matrix<double>{
+class Pupil : public Matrix<double> {
 public:
   Pupil() = default;
 
@@ -322,23 +341,23 @@ public:
 };
 
 template<typename T>
-class Tensor3D{
+class Tensor3D {
 protected:
   int n_layers = 0;
   int n_cols = 0;
   int n_rows = 0;
-  T*** tensor = nullptr;
+  T ***tensor = nullptr;
 
 public:
   bool is_matlab_initialised = false;
 
   Tensor3D() = default;
 
-  Tensor3D(T*** tensor, int n_layers, int n_cols, int n_rows) {
+  Tensor3D(T ***tensor, int n_layers, int n_cols, int n_rows) {
     initialise(tensor, n_layers, n_cols, n_rows);
   }
 
-  void initialise(T*** _tensor, int _n_layers, int _n_cols, int _n_rows) {
+  void initialise(T ***_tensor, int _n_layers, int _n_cols, int _n_rows) {
     tensor = _tensor;
     n_layers = _n_layers;
     n_cols = _n_cols;
@@ -347,7 +366,7 @@ public:
 
   inline T **operator[](int value) const { return tensor[value]; };
 
-  bool has_elements(){ return tensor != nullptr; };
+  bool has_elements() { return tensor != nullptr; };
 
   void zero() {
     for (int k = 0; k < n_layers; k++)
@@ -355,17 +374,17 @@ public:
         for (int i = 0; i < n_rows; i++) { tensor[k][j][i] = 0; }
   }
 
-  void allocate(int nK, int nJ, int nI){
+  void allocate(int nK, int nJ, int nI) {
     n_layers = nK, n_cols = nJ, n_rows = nI;
-    tensor = (T ***)malloc(n_layers * sizeof(T **));
+    tensor = (T ***) malloc(n_layers * sizeof(T **));
 
-    for(int k=0; k < n_layers; k++){
-      tensor[k] = (T **)malloc(n_cols * sizeof(T *));
+    for (int k = 0; k < n_layers; k++) {
+      tensor[k] = (T **) malloc(n_cols * sizeof(T *));
     }
 
-    for(int k=0; k < n_layers; k++){
-      for(int j=0; j < n_cols; j++){
-        tensor[k][j] = (T *)malloc(n_rows * sizeof(T));
+    for (int k = 0; k < n_layers; k++) {
+      for (int j = 0; j < n_cols; j++) {
+        tensor[k][j] = (T *) malloc(n_rows * sizeof(T));
       }
     }
   };
@@ -373,27 +392,28 @@ public:
   /**
    * @brief Computes the Frobenius norm of the tensor
    *
-   * fro_norm = \f$\sqrt{ \sum_{i=0}^{I_tot}\sum_{j=0}^{J_tot}\sum_{k=0}^{K_tot} |t[k][j][i]|^2 }\f$
+   * fro_norm = \f$\sqrt{ \sum_{i=0}^{I_tot}\sum_{j=0}^{J_tot}\sum_{k=0}^{K_tot}
+   * |t[k][j][i]|^2 }\f$
    */
   double frobenius() {
     T norm_val = 0;
     for (int i1 = 0; i1 < n_layers; i1++) {
       for (int i2 = 0; i2 < n_cols; i2++) {
-        for (int i3 = 0; i3 < n_rows; i3++) { norm_val += abs(tensor[i1][i2][i3]) * abs(tensor[i1][i2][i3]); }
+        for (int i3 = 0; i3 < n_rows; i3++) {
+          norm_val += abs(tensor[i1][i2][i3]) * abs(tensor[i1][i2][i3]);
+        }
       }
     }
     return sqrt(norm_val);
   }
 
-  ~Tensor3D(){
+  ~Tensor3D() {
     if (tensor == nullptr) return;
-    if (is_matlab_initialised){
+    if (is_matlab_initialised) {
       free_cast_matlab_3D_array(tensor, n_layers);
     } else {
       for (int k = 0; k < n_layers; k++) {
-        for (int j = 0; j < n_cols; j++) {
-          free(tensor[k][j]);
-        }
+        for (int j = 0; j < n_cols; j++) { free(tensor[k][j]); }
         free(tensor[k]);
       }
       free(tensor);
@@ -401,11 +421,13 @@ public:
   }
 };
 
-class DTilde{
+class DTilde {
 protected:
   int n_det_modes = 0;
-  static void set_component(Tensor3D<std::complex<double>> &tensor, const mxArray *ptr,
-                     const std::string &name, int n_rows, int n_cols);
+  static void set_component(Tensor3D<std::complex<double>> &tensor,
+                            const mxArray *ptr, const std::string &name,
+                            int n_rows, int n_cols);
+
 public:
   inline int num_det_modes() const { return n_det_modes; };
 
@@ -415,9 +437,10 @@ public:
   void initialise(const mxArray *ptr, int n_rows, int n_cols);
 };
 
-class IncidentField{
+class IncidentField {
 protected:
-  void set_component(Tensor3D<double> &component, const mxArray *ptr, const std::string &name);
+  void set_component(Tensor3D<double> &component, const mxArray *ptr,
+                     const std::string &name);
 
 public:
   Tensor3D<double> x;
@@ -429,9 +452,8 @@ public:
 /**
  * List of field components as integers
  */
-class FieldComponentsVector: public Vector<int>{
+class FieldComponentsVector : public Vector<int> {
 public:
-
   FieldComponentsVector() = default;
 
   void initialise(const mxArray *ptr);
@@ -445,28 +467,25 @@ public:
   int index(int value);
 };
 
-class Vertices: public Matrix<int>{
+class Vertices : public Matrix<int> {
 public:
-
   Vertices() = default;
 
   void initialise(const mxArray *ptr);
 
-  int n_vertices(){ return n_rows; }
+  int n_vertices() { return n_rows; }
 
-  ~Vertices(){
-    if (has_elements()){
-      free_cast_matlab_2D_array(matrix);
-    }
+  ~Vertices() {
+    if (has_elements()) { free_cast_matlab_2D_array(matrix); }
     matrix = nullptr;
   };
 };
 
-class DetectorSensitivityArrays{
+class DetectorSensitivityArrays {
 public:
-  fftw_complex* v = nullptr;            // Flat fftw vector
-  fftw_plan plan = nullptr;             // fftw plan for the setup
-  std::complex<double>** cm = nullptr;  // Column major matrix
+  fftw_complex *v = nullptr;          // Flat fftw vector
+  fftw_plan plan = nullptr;           // fftw plan for the setup
+  std::complex<double> **cm = nullptr;// Column major matrix
 
   void initialise(int n_rows, int n_cols);
 
@@ -476,12 +495,12 @@ public:
 /**
  * Matrix of c coefficients. See the pdf documentation for their definition
  */
-class CCoefficientMatrix: public Matrix<double>{};
+class CCoefficientMatrix : public Matrix<double> {};
 
 /**
  * Temporary storage 'vector'
  */
-class EHVec: public Matrix<fftw_complex>{
+class EHVec : public Matrix<fftw_complex> {
 public:
   ~EHVec();
 };
@@ -491,17 +510,18 @@ public:
  */
 class FullFieldSnapshot {
 public:
-  std::complex<double> Ex = 0.; //< x-component of the electric field
-  std::complex<double> Ey = 0.; //< y-component of the electric field
-  std::complex<double> Ez = 0.; //< z-component of the electric field
-  std::complex<double> Hx = 0.; //< x-component of the magnetic field
-  std::complex<double> Hy = 0.; //< y-component of the magnetic field
-  std::complex<double> Hz = 0.; //< z-component of the magnetic field
+  std::complex<double> Ex = 0.;//< x-component of the electric field
+  std::complex<double> Ey = 0.;//< y-component of the electric field
+  std::complex<double> Ez = 0.;//< z-component of the electric field
+  std::complex<double> Hx = 0.;//< x-component of the magnetic field
+  std::complex<double> Hy = 0.;//< y-component of the magnetic field
+  std::complex<double> Hz = 0.;//< z-component of the magnetic field
 
   FullFieldSnapshot() = default;
 
   /**
-   * @brief Return the component of the field corresponding to the index provided.
+   * @brief Return the component of the field corresponding to the index
+   * provided.
    *
    * 0 = Ex, 1 = Ey, 2 = Ez, 3 = Hx, 4 = Hy, 5 = Hz.
    * This is the indexing order that other storage containers use.
@@ -512,7 +532,7 @@ public:
    * @return std::complex<double> The field component
    */
   std::complex<double> operator[](int index) {
-    switch(index) {
+    switch (index) {
       case 0:
         return Ex;
         break;
@@ -532,7 +552,8 @@ public:
         return Hz;
         break;
       default:
-        throw std::runtime_error("Index " + std::to_string(index) + " does not correspond to a field component.");
+        throw std::runtime_error("Index " + std::to_string(index) +
+                                 " does not correspond to a field component.");
         break;
     }
   }

--- a/tdms/include/cell_coordinate.h
+++ b/tdms/include/cell_coordinate.h
@@ -7,6 +7,9 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+
+
 /**
  * @brief A structure for holding three values, which typically pertain to the same quantity but for each of the axial directions.
  *
@@ -22,7 +25,12 @@ struct ijk {
   /** @brief Print the (i,j,k) values */
   void print() const { spdlog::info("ijk: ({},{},{})", i, j, k); }
 
-  ijk &operator+=(int n) { this->i += n; this->j += n; this->k += n; return *this; }
+  ijk &operator+=(int n) {
+    this->i += n;
+    this->j += n;
+    this->k += n;
+    return *this;
+  }
 };
 
 /* Synonyms for code readability */

--- a/tdms/include/cell_coordinate.h
+++ b/tdms/include/cell_coordinate.h
@@ -11,9 +11,12 @@
 
 
 /**
- * @brief A structure for holding three values, which typically pertain to the same quantity but for each of the axial directions.
+ * @brief A structure for holding three values, which typically pertain to the
+ * same quantity but for each of the axial directions.
  *
- * Effectively stores the 3-vector (i,j,k). This is typically used to represent Yee cell indices, or 3D-array dimensions, or the maximum number of Yee cells in each coordinate direction, for example.
+ * Effectively stores the 3-vector (i,j,k). This is typically used to represent
+ * Yee cell indices, or 3D-array dimensions, or the maximum number of Yee cells
+ * in each coordinate direction, for example.
  */
 struct ijk {
   // The values (by dimension) that the object contains

--- a/tdms/include/dimensions.h
+++ b/tdms/include/dimensions.h
@@ -6,19 +6,19 @@
 
 #include "mat_io.h"
 
-class Dimensions{
+class Dimensions {
 private:
   int i = 0;
   int j = 0;
   int k = 0;
 
-  bool are_nd(int n) const{return (bool(i) + bool(j) + bool(k)) == n;}
+  bool are_nd(int n) const { return (bool(i) + bool(j) + bool(k)) == n; }
 
 public:
-  int operator[] (int value) const;
+  int operator[](int value) const;
 
-  explicit Dimensions(const mxArray* ptr);
+  explicit Dimensions(const mxArray *ptr);
 
-  bool are_1d() const{return are_nd(1);}
-  bool are_2d() const{return are_nd(2);}
+  bool are_1d() const { return are_nd(1); }
+  bool are_2d() const { return are_nd(2); }
 };

--- a/tdms/include/fdtd_grid_initialiser.h
+++ b/tdms/include/fdtd_grid_initialiser.h
@@ -4,8 +4,8 @@
  */
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "mat_io.h"
 
@@ -15,31 +15,31 @@
 class fdtdGridInitialiser {
 
 private:
-    const mxArray *pointer;         //< Pointer to the array
-    const char *mat_filename;       //< Filename of the MATLAB file
-    std::vector<mwSize> dimensions; //< The dimensions of the array
+  const mxArray *pointer;        //< Pointer to the array
+  const char *mat_filename;      //< Filename of the MATLAB file
+  std::vector<mwSize> dimensions;//< The dimensions of the array
 
-    /**
-     * @brief Get a value from a integer attribute of the FDTD grid defined in a
-     * .mat file
-     *
-     * @param key the name of the attribute
-     * @return int the value of the attribute
-     */
-    mwSize value_of_attribute(const std::string& key);
+  /**
+   * @brief Get a value from a integer attribute of the FDTD grid defined in a
+   * .mat file
+   *
+   * @param key the name of the attribute
+   * @return int the value of the attribute
+   */
+  mwSize value_of_attribute(const std::string &key);
 
 public:
-    /**
-     * @brief Construct a new fdtd Grid Initialiser object
-     *
-     * @param fdtd_pointer pointer to the FDTD grid
-     * @param mat_filename the filename of the MATLAB file
-     */
-    fdtdGridInitialiser(const mxArray *fdtd_pointer, const char* mat_filename);
+  /**
+   * @brief Construct a new fdtd Grid Initialiser object
+   *
+   * @param fdtd_pointer pointer to the FDTD grid
+   * @param mat_filename the filename of the MATLAB file
+   */
+  fdtdGridInitialiser(const mxArray *fdtd_pointer, const char *mat_filename);
 
-    /**
-     * @brief Set an FDTD grid attribute to a tensor full of zeros
-     * @param name of the attribute
-     */
-    void add_tensor(const std::string &name);
+  /**
+   * @brief Set an FDTD grid attribute to a tensor full of zeros
+   * @param name of the attribute
+   */
+  void add_tensor(const std::string &name);
 };

--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -9,9 +9,9 @@
 #include "arrays.h"
 #include "cell_coordinate.h"
 #include "dimensions.h"
+#include "globals.h"
 #include "mat_io.h"
 #include "simulation_parameters.h"
-#include "globals.h"
 
 /**
  * A generic grid entity. For example:
@@ -24,40 +24,48 @@
  *
  *  has I_tot = 2, J_tot = 1, K_tot = 0.
  *
- * NOTE: For storage purposes, this means that field values associated to cells are stored _to the left_.
- * That is, Grid(0,0,0) is associated to the cell (-1,-1,-1). This is contrary to the way values are associated to cells, where cell (0,0,0) is associated to the field values (0,0,0).
+ * NOTE: For storage purposes, this means that field values associated to cells
+ * are stored _to the left_. That is, Grid(0,0,0) is associated to the cell
+ * (-1,-1,-1). This is contrary to the way values are associated to cells, where
+ * cell (0,0,0) is associated to the field values (0,0,0).
  */
 class Grid {
 protected:
-  // the preferred interpolation methods (pim) for interpolating between the grid values, default is BandLimited
-  PreferredInterpolationMethods pim = PreferredInterpolationMethods::BandLimited;
+  // the preferred interpolation methods (pim) for interpolating between the
+  // grid values, default is BandLimited
+  PreferredInterpolationMethods pim =
+          PreferredInterpolationMethods::BandLimited;
 
 public:
   // The {IJK}_tot values of this grid
-  IJKDimensions tot = { 0, 0, 0 };
+  IJKDimensions tot = {0, 0, 0};
 
   /**
-     * Maximum value out of I_tot, J_tot and K_tot
-     * @return value
-     */
+   * Maximum value out of I_tot, J_tot and K_tot
+   * @return value
+   */
   int max_IJK_tot() const { return tot.max(); };
 
   /**
    * @brief Set the preferred interpolation methods
    */
-  void set_preferred_interpolation_methods(PreferredInterpolationMethods _pim) { pim = _pim; };
+  void set_preferred_interpolation_methods(PreferredInterpolationMethods _pim) {
+    pim = _pim;
+  };
 };
 
-class SplitFieldComponent: public Tensor3D<double>{
+class SplitFieldComponent : public Tensor3D<double> {
 public:
-  int n_threads = 1;             // Number of threads this component was chunked with
-  fftw_plan* plan_f = nullptr;  // Forward fftw plan
-  fftw_plan* plan_b = nullptr;  // Backward fftw plan
+  int n_threads = 1;// Number of threads this component was chunked with
+  fftw_plan *plan_f = nullptr;// Forward fftw plan
+  fftw_plan *plan_b = nullptr;// Backward fftw plan
 
   double **operator[](int value) const { return tensor[value]; };
-  double operator[](CellCoordinate cell) const { return tensor[cell.k][cell.j][cell.i]; }
+  double operator[](CellCoordinate cell) const {
+    return tensor[cell.k][cell.j][cell.i];
+  }
 
-  void initialise_from_matlab(double*** tensor, Dimensions &dims);
+  void initialise_from_matlab(double ***tensor, Dimensions &dims);
 
   /**
    * Initialise a vector of 1d discrete Fourier transform plans
@@ -75,189 +83,201 @@ public:
  * To reconstruct the components we have e.g.: Ex = Exy + Exz multiplied by
  * a phase factor
  */
-class SplitField : public Grid{
+class SplitField : public Grid {
 protected:
-  virtual int delta_n() = 0;  // TODO: no idea what this is or why it's needed
+  virtual int delta_n() = 0;// TODO: no idea what this is or why it's needed
 
 public:
-    // Pointers (3D arrays) which hold the magnitude of the split field
-    // component at each grid point (i, j, k)
-    SplitFieldComponent xy;
-    SplitFieldComponent xz;
-    SplitFieldComponent yx;
-    SplitFieldComponent yz;
-    SplitFieldComponent zx;
-    SplitFieldComponent zy;
+  // Pointers (3D arrays) which hold the magnitude of the split field
+  // component at each grid point (i, j, k)
+  SplitFieldComponent xy;
+  SplitFieldComponent xz;
+  SplitFieldComponent yx;
+  SplitFieldComponent yz;
+  SplitFieldComponent zx;
+  SplitFieldComponent zy;
 
-    /**
-     * Default no arguments constructor
-     */
-    SplitField() = default;
+  /**
+   * Default no arguments constructor
+   */
+  SplitField() = default;
 
-    /**
-     * Constructor of the field with a defined size in the x, y, z Cartesian
-     * dimensions
-     */
-    SplitField(int I_total, int J_total, int K_total);
+  /**
+   * Constructor of the field with a defined size in the x, y, z Cartesian
+   * dimensions
+   */
+  SplitField(int I_total, int J_total, int K_total);
 
-    /**
-     * Allocate the memory appropriate for all the 3D tensors associated with
-     * this split field
-     */
-    void allocate();
+  /**
+   * Allocate the memory appropriate for all the 3D tensors associated with
+   * this split field
+   */
+  void allocate();
 
-    /**
-     * Set all the values of all components of the field to zero
-     */
-    void zero();
+  /**
+   * Set all the values of all components of the field to zero
+   */
+  void zero();
 
-    /**
-     * Allocate and set to zero all components of the field
-     */
-    void allocate_and_zero(){
-      allocate();
-      zero();
-    }
+  /**
+   * Allocate and set to zero all components of the field
+   */
+  void allocate_and_zero() {
+    allocate();
+    zero();
+  }
 
-    /**
-     * Initialise the fftw plans for all components
-     * @param n_threads Number of threads to split over
-     * @param eh_vec // TODO
-     */
-    void initialise_fftw_plan(int n_threads, EHVec &eh_vec);
+  /**
+   * Initialise the fftw plans for all components
+   * @param n_threads Number of threads to split over
+   * @param eh_vec // TODO
+   */
+  void initialise_fftw_plan(int n_threads, EHVec &eh_vec);
 
-    /**
-     * @brief Fetches the largest absolute value of the field.
-     *
-     * Split field values are sums of the corresponding components, so this function returns the largest absolute value of the entries in
-     * (xy + xz), (yx + yz), (zx + zy)
-     *
-     * @return double Largest (by absolute value) field value
-     */
-    double largest_field_value();
+  /**
+   * @brief Fetches the largest absolute value of the field.
+   *
+   * Split field values are sums of the corresponding components, so this
+   * function returns the largest absolute value of the entries in (xy + xz),
+   * (yx + yz), (zx + zy)
+   *
+   * @return double Largest (by absolute value) field value
+   */
+  double largest_field_value();
 
-    /**
+  /**
    * @brief Interpolates a SplitField component to the centre of a Yee cell
    *
    * @param d SplitField component to interpolate
    * @param cell Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return double The interpolated field value
    */
-    virtual double interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) = 0;
+  virtual double interpolate_to_centre_of(AxialDirection d,
+                                          CellCoordinate cell) = 0;
 };
 
-class ElectricSplitField: public SplitField{
+class ElectricSplitField : public SplitField {
 protected:
-  int delta_n() override { return -1; };  // TODO: no idea what this is or why it's needed
+  int delta_n() override {
+    return -1;
+  };// TODO: no idea what this is or why it's needed
 
 public:
-    ElectricSplitField() = default;
+  ElectricSplitField() = default;
 
-    /**
-     * Constructor of the field with a defined size in the x, y, z Cartesian
-     * dimensions
-     */
-    ElectricSplitField(int I_total, int J_total, int K_total) :
-            SplitField(I_total, J_total, K_total){};
+  /**
+   * Constructor of the field with a defined size in the x, y, z Cartesian
+   * dimensions
+   */
+  ElectricSplitField(int I_total, int J_total, int K_total)
+      : SplitField(I_total, J_total, K_total){};
 
-    /**
+  /**
    * @brief Interpolates a split E-field component to the centre of a Yee cell
    *
    * @param d Field component to interpolate
    * @param cell Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return double The interpolated component value
    */
-    double interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) override;
+  double interpolate_to_centre_of(AxialDirection d,
+                                  CellCoordinate cell) override;
 };
 
-class MagneticSplitField: public SplitField{
+class MagneticSplitField : public SplitField {
 protected:
-  int delta_n() override { return 0; };  // TODO: no idea what this is or why it's needed
+  int delta_n() override {
+    return 0;
+  };// TODO: no idea what this is or why it's needed
 
 public:
-    MagneticSplitField() = default;
+  MagneticSplitField() = default;
 
-    /**
-     * Constructor of the field with a defined size in the x, y, z Cartesian
-     * dimensions
-     */
-    MagneticSplitField(int I_total, int J_total, int K_total) :
-            SplitField(I_total, J_total, K_total){};
+  /**
+   * Constructor of the field with a defined size in the x, y, z Cartesian
+   * dimensions
+   */
+  MagneticSplitField(int I_total, int J_total, int K_total)
+      : SplitField(I_total, J_total, K_total){};
 
-    /**
+  /**
    * @brief Interpolates a split E-field component to the centre of a Yee cell
    *
    * @param d Field component to interpolate
    * @param cell Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return double The interpolated component value
    */
-    double interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) override;
+  double interpolate_to_centre_of(AxialDirection d,
+                                  CellCoordinate cell) override;
 };
 
-class CurrentDensitySplitField: public SplitField{
+class CurrentDensitySplitField : public SplitField {
 protected:
   int delta_n() override { return 0; }
 
 public:
-    CurrentDensitySplitField() = default;
+  CurrentDensitySplitField() = default;
 
-    /**
-     * Constructor of the field with a defined size in the x, y, z Cartesian
-     * dimensions
-     */
-    CurrentDensitySplitField(int I_total, int J_total, int K_total) :
-            SplitField(I_total, J_total, K_total){};
+  /**
+   * Constructor of the field with a defined size in the x, y, z Cartesian
+   * dimensions
+   */
+  CurrentDensitySplitField(int I_total, int J_total, int K_total)
+      : SplitField(I_total, J_total, K_total){};
 
-    double interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) override { return 0.; };
+  double interpolate_to_centre_of(AxialDirection d,
+                                  CellCoordinate cell) override {
+    return 0.;
+  };
 };
 
 /**
  * A complex field defined over a grid. Has real and imaginary components
  * at each (x, y, z) grid point
  */
-class Field : public Grid{
+class Field : public Grid {
 public:
-  double ft = 0.;  // TODO: an explanation of what this is
+  double ft = 0.;// TODO: an explanation of what this is
 
   std::complex<double> angular_norm = 0.;
 
-  // TODO: this is likely better as a set of complex arrays - use XYZTensor3D<std::complex<double>>
-  // This also makes implimenting normalise_volume, and the interpolation schemes, much easier...
+  // TODO: this is likely better as a set of complex arrays - use
+  // XYZTensor3D<std::complex<double>> This also makes implimenting
+  // normalise_volume, and the interpolation schemes, much easier...
   XYZTensor3D<double> real;
   XYZTensor3D<double> imag;
 
   /**
-     * Upper (u) and lower (l) indices in the x,y,z directions. e.g.
-     * il is the first non-pml cell in the i direction and iu the last in the corresponding split
-     * field grid
-     */
+   * Upper (u) and lower (l) indices in the x,y,z directions. e.g.
+   * il is the first non-pml cell in the i direction and iu the last in the
+   * corresponding split field grid
+   */
   int il = 0, iu = 0, jl = 0, ju = 0, kl = 0, ku = 0;
 
   /**
-     * Default no arguments constructor
-     */
+   * Default no arguments constructor
+   */
   Field() = default;
 
   /**
-     * Constructor of the field with a defined size in the x, y, z Cartesian
-     * dimensions
-     */
+   * Constructor of the field with a defined size in the x, y, z Cartesian
+   * dimensions
+   */
   Field(int I_total, int J_total, int K_total);
 
   /**
-     * Allocate the memory appropriate for all the 3D tensors associated with
-     * this split field
-     */
+   * Allocate the memory appropriate for all the 3D tensors associated with
+   * this split field
+   */
   void allocate();
 
   /**
-     * Set all the values of all components of the field to zero
-     */
+   * Set all the values of all components of the field to zero
+   */
   void zero();
 
   /**
-     * Allocate and set to zero all components of the field
-     */
+   * Allocate and set to zero all components of the field
+   */
   void allocate_and_zero() {
     allocate();
     zero();
@@ -267,14 +287,15 @@ public:
    * @brief Normalises the field entries by dividing by the angular norm.
    *
    * Specifically,
-   * real[c][k][j][i] + i imag[c][k][j][i] = ( real[c][k][j][i] + i imag[c][k][j][i] ) / angular_norm
+   * real[c][k][j][i] + i imag[c][k][j][i] = ( real[c][k][j][i] + i
+   * imag[c][k][j][i] ) / angular_norm
    *
    */
   void normalise_volume();
 
   /**
-   * Set the phasors for this field, given a split field. Result gives field according to the
-   * exp(-iwt) convention
+   * Set the phasors for this field, given a split field. Result gives field
+   * according to the exp(-iwt) convention
    * @param F
    * @param n
    * @param omega
@@ -287,7 +308,8 @@ public:
   void add_to_angular_norm(int n, int Nt, SimulationParameters &params);
 
   // TODO: Docstring
-  std::complex<double> phasor_norm(double f, int n, double omega, double dt, int Nt);
+  std::complex<double> phasor_norm(double f, int n, double omega, double dt,
+                                   int Nt);
 
   virtual double phase(int n, double omega, double dt) = 0;
   /**
@@ -297,7 +319,8 @@ public:
    * @param cell Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return std::complex<double> The interpolated field value
    */
-  virtual std::complex<double> interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) = 0;
+  virtual std::complex<double>
+  interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) = 0;
 
   /**
    * @brief Interpolates the Field over the range provided.
@@ -305,48 +328,60 @@ public:
    * Default range is to interpolate to the midpoint of all consecutive points.
    *
    * @param[out] x_out,y_out,z_out Output arrays for interpolated values
-   * @param i_lower,j_lower,k_lower Lower index for interpolation in the i,j,k directions, respectively
-   * @param i_upper,j_upper,k_upper Upper index for interpolation in the i,j,k directions, respectively
-   * @param mode Determines which field components to compute, based on the simulation Dimension
+   * @param i_lower,j_lower,k_lower Lower index for interpolation in the i,j,k
+   * directions, respectively
+   * @param i_upper,j_upper,k_upper Upper index for interpolation in the i,j,k
+   * directions, respectively
+   * @param mode Determines which field components to compute, based on the
+   * simulation Dimension
    */
-  void interpolate_over_range(mxArray *x_out, mxArray *y_out, mxArray *z_out, int i_lower,
-                              int i_upper, int j_lower, int j_upper, int k_lower, int k_upper,
+  void interpolate_over_range(mxArray *x_out, mxArray *y_out, mxArray *z_out,
+                              int i_lower, int i_upper, int j_lower,
+                              int j_upper, int k_lower, int k_upper,
                               Dimension mode = Dimension::THREE);
   void interpolate_over_range(mxArray *x_out, mxArray *y_out, mxArray *z_out,
                               Dimension mode = Dimension::THREE);
 
   /**
-   * @brief Interpolates the Field's transverse electric components to the centre of Yee cell i,j,k
+   * @brief Interpolates the Field's transverse electric components to the
+   * centre of Yee cell i,j,k
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  virtual void interpolate_transverse_electric_components(CellCoordinate cell,
-                                                          std::complex<double> *x_at_centre,
-                                                          std::complex<double> *y_at_centre,
-                                                          std::complex<double> *z_at_centre) = 0;
+  virtual void interpolate_transverse_electric_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) = 0;
   /**
-   * @brief Interpolates the Field's transverse magnetic components to the centre of Yee cell i,j,k
+   * @brief Interpolates the Field's transverse magnetic components to the
+   * centre of Yee cell i,j,k
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  virtual void interpolate_transverse_magnetic_components(CellCoordinate cell,
-                                                          std::complex<double> *x_at_centre,
-                                                          std::complex<double> *y_at_centre,
-                                                          std::complex<double> *z_at_centre) = 0;
+  virtual void interpolate_transverse_magnetic_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) = 0;
 
   /**
-   * Set the values of all components in this field from another, equally sized field
+   * Set the values of all components in this field from another, equally sized
+   * field
    */
   void set_values_from(Field &other);
 
   /**
-   * @brief Computes the maximum pointwise absolute difference of the other field to this one, divided by the largest absolute value of this field's components.
+   * @brief Computes the maximum pointwise absolute difference of the other
+   * field to this one, divided by the largest absolute value of this field's
+   * components.
    *
    * Specifically, we compute and return the quantity
-   * \f$ \frac{ \max_{i,j,k}(this[k][j][i] - other[k][j][i]) }{ \max_{i,j,k}this[k][j][i] } \f$
-   * This quantity is used to determine convergence of phasors.
+   * \f$ \frac{ \max_{i,j,k}(this[k][j][i] - other[k][j][i]) }{
+   * \max_{i,j,k}this[k][j][i] } \f$ This quantity is used to determine
+   * convergence of phasors.
    *
    * The other field must have the same dimensions as this field.
    *
@@ -358,14 +393,15 @@ public:
   ~Field();
 };
 
-class ElectricField: public Field{
+class ElectricField : public Field {
 
 private:
   double phase(int n, double omega, double dt) override;
 
 public:
   ElectricField() = default;
-  ElectricField(int I_total, int J_total, int K_total) : Field(I_total, J_total, K_total){};
+  ElectricField(int I_total, int J_total, int K_total)
+      : Field(I_total, J_total, K_total){};
 
   /**
    * @brief Interpolates an E-field component to the centre of a Yee cell
@@ -374,42 +410,48 @@ public:
    * @param i,j,k Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return std::complex<double> The interpolated component value
    */
-  std::complex<double> interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) override;
+  std::complex<double> interpolate_to_centre_of(AxialDirection d,
+                                                CellCoordinate cell) override;
 
   /**
-   * @brief Interpolates the transverse electric components to the centre of Yee cell i,j,k.
+   * @brief Interpolates the transverse electric components to the centre of Yee
+   * cell i,j,k.
    *
    * Ex and Ey are interpolated. Ez is set to a placeholder (default) value.
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  void interpolate_transverse_electric_components(CellCoordinate cell,
-                                                  std::complex<double> *x_at_centre,
-                                                  std::complex<double> *y_at_centre,
-                                                  std::complex<double> *z_at_centre) override;
+  void interpolate_transverse_electric_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) override;
   /**
-   * @brief Interpolates the transverse magnetic components to the centre of Yee cell i,j,k.
+   * @brief Interpolates the transverse magnetic components to the centre of Yee
+   * cell i,j,k.
    *
    * Ez is interpolated. Ex and Ey are set to a placeholder (default) values.
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  void interpolate_transverse_magnetic_components(CellCoordinate cell,
-                                                  std::complex<double> *x_at_centre,
-                                                  std::complex<double> *y_at_centre,
-                                                  std::complex<double> *z_at_centre) override;
+  void interpolate_transverse_magnetic_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) override;
 };
 
-class MagneticField: public Field{
+class MagneticField : public Field {
 
 private:
   double phase(int n, double omega, double dt) override;
 
 public:
   MagneticField() = default;
-  MagneticField(int I_total, int J_total, int K_total) : Field(I_total, J_total, K_total){};
+  MagneticField(int I_total, int J_total, int K_total)
+      : Field(I_total, J_total, K_total){};
 
   /**
    * @brief Interpolates an H-field component to the centre of a Yee cell
@@ -418,45 +460,50 @@ public:
    * @param cell Index (i,j,k) of the Yee cell to interpolate to the centre of
    * @return std::complex<double> The interpolated component value
    */
-  std::complex<double> interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) override;
+  std::complex<double> interpolate_to_centre_of(AxialDirection d,
+                                                CellCoordinate cell) override;
 
   /**
-   * @brief Interpolates the transverse electric components to the centre of Yee cell i,j,k.
+   * @brief Interpolates the transverse electric components to the centre of Yee
+   * cell i,j,k.
    *
    * Hz is interpolated. Hx and Hy are set to a placeholder (default) values.
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  void interpolate_transverse_electric_components(CellCoordinate cell,
-                                                  std::complex<double> *x_at_centre,
-                                                  std::complex<double> *y_at_centre,
-                                                  std::complex<double> *z_at_centre) override;
+  void interpolate_transverse_electric_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) override;
   /**
-   * @brief Interpolates the transverse magnetic components to the centre of Yee cell i,j,k.
+   * @brief Interpolates the transverse magnetic components to the centre of Yee
+   * cell i,j,k.
    *
    * Hx and Hy are interpolated. Hz is set to a placeholder (default) value.
    *
    * @param[in] cell Yee cell index
-   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write interpolated values for the x,y,z components (respectively)
+   * @param[out] x_at_centre,y_at_centre,z_at_centre Addresses to write
+   * interpolated values for the x,y,z components (respectively)
    */
-  void interpolate_transverse_magnetic_components(CellCoordinate cell,
-                                                  std::complex<double> *x_at_centre,
-                                                  std::complex<double> *y_at_centre,
-                                                  std::complex<double> *z_at_centre) override;
+  void interpolate_transverse_magnetic_components(
+          CellCoordinate cell, std::complex<double> *x_at_centre,
+          std::complex<double> *y_at_centre,
+          std::complex<double> *z_at_centre) override;
 };
 
 /**
  * Structure to hold a field and allow saving it to a file
  */
-class TDFieldExporter2D{
+class TDFieldExporter2D {
 private:
-  int nI = 0; //< Array size in the i direction
-  int nK = 0; //< Array size in the k direction
+  int nI = 0;//< Array size in the i direction
+  int nK = 0;//< Array size in the k direction
 public:
-  mxArray* matlab_array = nullptr;
-  double** array = nullptr;
-  const char* folder_name = nullptr;
+  mxArray *matlab_array = nullptr;
+  double **array = nullptr;
+  const char *folder_name = nullptr;
 
   /**
    * Allocate the arrays to hold the field
@@ -470,7 +517,7 @@ public:
    * @param stride Interval to compute the field component at
    * @param iteration Iteration number of the main loop. Used in the filename
    */
-  void export_field(SplitField& F, int stride, int iteration) const;
+  void export_field(SplitField &F, int stride, int iteration) const;
 
   ~TDFieldExporter2D();
 };

--- a/tdms/include/fieldsample.h
+++ b/tdms/include/fieldsample.h
@@ -8,43 +8,51 @@
 #include "field.h"
 #include "simulation_parameters.h"
 
-class FieldSample{
+class FieldSample {
 
 private:
-  double**** tensor = nullptr;
+  double ****tensor = nullptr;
 
 public:
-  mxArray* mx;       // Matlab array
+  mxArray *mx;//!< Matlab array
 
-  Vector<int> i;     //< Indices along the x-direction of locations at which to sample the field
-  Vector<int> j;     //< Indices along the y-direction of locations at which to sample the field
-  Vector<int> k;     //< Indices along the z-direction of locations at which to sample the field
-  Vector<double> n;  //< Vector of the moments of the field to sample
+  Vector<int> i;   //!< Indices along the x-direction of locations at which to
+                   //!< sample the field
+  Vector<int> j;   //!< Indices along the y-direction of locations at which to
+                   //!< sample the field
+  Vector<int> k;   //!< Indices along the z-direction of locations at which to
+                   //!< sample the field
+  Vector<double> n;//!< Vector of the moments of the field to sample
 
   FieldSample() = default;
   explicit FieldSample(const mxArray *ptr) { set_from(ptr); }
   /**
    * @brief Setup using data from an input file
    *
-   * @param ptr Pointer to the struct containing the list of vertices and components to extract phasors at/for
+   * @param ptr Pointer to the struct containing the list of vertices and
+   * components to extract phasors at/for
    */
   void set_from(const mxArray *ptr);
 
-  /** Return true if all vectors in this instance are non-empty (have size > 0) */
-  bool all_vectors_are_non_empty() const{
-          return i.size() > 0 && j.size() > 0 && k.size() > 0 && n.size() > 0;
+  /** Return true if all vectors in this instance are non-empty (have size > 0)
+   */
+  bool all_vectors_are_non_empty() const {
+    return i.size() > 0 && j.size() > 0 && k.size() > 0 && n.size() > 0;
   };
 
-  inline double*** operator[] (int value) const { return tensor[value]; };
+  inline double ***operator[](int value) const { return tensor[value]; };
 
   /**
    * @brief Extract the (Electric) field values at the vertices
    *
    * @param E_split Values of the electric (split) field
-   * @param pml A description of the perfectly matched layer being used in this simulation
-   * @param n_simulation_timesteps The (total) number of timesteps in this simulation
+   * @param pml A description of the perfectly matched layer being used in this
+   * simulation
+   * @param n_simulation_timesteps The (total) number of timesteps in this
+   * simulation
    */
-  void extract(ElectricSplitField &E_split, PerfectlyMatchedLayer &pml, int n_simulation_timesteps);
+  void extract(ElectricSplitField &E_split, PerfectlyMatchedLayer &pml,
+               int n_simulation_timesteps);
 
   ~FieldSample();
 };

--- a/tdms/include/globals.h
+++ b/tdms/include/globals.h
@@ -10,41 +10,36 @@
 //  Type Definitions
 // ******************
 
-typedef int*				IArray_1d;
-typedef IArray_1d*			IArray_2d;
-typedef IArray_2d*			IArray_3d;
+typedef int *IArray_1d;
+typedef IArray_1d *IArray_2d;
+typedef IArray_2d *IArray_3d;
 
-typedef double*				DArray_1d;
-typedef DArray_1d*			DArray_2d;
-typedef DArray_2d*			DArray_3d;
+typedef double *DArray_1d;
+typedef DArray_1d *DArray_2d;
+typedef DArray_2d *DArray_3d;
 
-typedef std::complex<double>*	CArray_1d;
-typedef CArray_1d*			CArray_2d;
-typedef CArray_2d*			CArray_3d;
+typedef std::complex<double> *CArray_1d;
+typedef CArray_1d *CArray_2d;
+typedef CArray_2d *CArray_3d;
 
-typedef struct PlanarInterface	// Structure definition for a planar six-face interface
+typedef struct PlanarInterface// Structure definition for a planar six-face
+                              // interface
 {
-	int I1;
-	int I2;
-	int J1;
-	int J2;
-	int K1;
-	int K2;
+  int I1;
+  int I2;
+  int J1;
+  int J2;
+  int K1;
+  int K2;
 } PlanarInterface;
 
-typedef struct complex_vector
-{
-	std::complex<double> X;
-	std::complex<double> Y;
-	std::complex<double> Z;
+typedef struct complex_vector {
+  std::complex<double> X;
+  std::complex<double> Y;
+  std::complex<double> Z;
 } complex_vector;
 
-enum AxialDirection
-{
-	X = 'x',
-	Y = 'y',
-	Z = 'z'
-};
+enum AxialDirection { X = 'x', Y = 'y', Z = 'z' };
 
 /**
  * Enum defining a mapping to integers used in the MATLAB initialisation
@@ -55,8 +50,8 @@ enum FieldComponents { Ex = 1, Ey, Ez, Hx, Hy, Hz };
 //  Enumerated constants
 // **********************
 
-enum ModeOfRun    { Pass1 , Pass2 };
-enum RCSType      { parallel , perpendicular };
+enum ModeOfRun { Pass1, Pass2 };
+enum RCSType { parallel, perpendicular };
 enum SolverMethod { PseudoSpectral, FiniteDifference };
 enum PreferredInterpolationMethods { BandLimited, Cubic };
 
@@ -64,20 +59,20 @@ enum PreferredInterpolationMethods { BandLimited, Cubic };
 //			Mathematical Constants
 // **************************************
 
-namespace tdms_math_constants
-{
-const double DCPI = 3.14159265358979323846;                                  // Pi
-const std::complex<double> IMAGINARY_UNIT = std::complex<double>(0.0, 1.0);  // Imaginary unit
-}
+namespace tdms_math_constants {
+const double DCPI = 3.14159265358979323846;// Pi
+const std::complex<double> IMAGINARY_UNIT =
+        std::complex<double>(0.0, 1.0);// Imaginary unit
+}// namespace tdms_math_constants
 
 // **************************************
 //			Physical Constants
 // **************************************
 
-namespace tdms_phys_constants
-{
-const double EPSILON0 = 8.85400e-12;                         // free space electric permitivity
-const double MU0 = 4.0 * tdms_math_constants::DCPI * 1.0e-7; // free space magnetic permeability
-const double LIGHT_V = 1.0 / sqrt(EPSILON0 * MU0);           // free space light velocity
-const double Z0 = 376.734;                                   // free space inpedance
-}
+namespace tdms_phys_constants {
+const double EPSILON0 = 8.85400e-12;// free space electric permitivity
+const double MU0 = 4.0 * tdms_math_constants::DCPI *
+                   1.0e-7;// free space magnetic permeability
+const double LIGHT_V = 1.0 / sqrt(EPSILON0 * MU0);// free space light velocity
+const double Z0 = 376.734;                        // free space inpedance
+}// namespace tdms_phys_constants

--- a/tdms/include/grid_labels.h
+++ b/tdms/include/grid_labels.h
@@ -7,24 +7,28 @@
 #include "mat_io.h"
 
 /**
- * Grid labels hold the cartesian labels of Yee cell, in the x, y and z directions
+ * Grid labels hold the cartesian labels of Yee cell, in the x, y and z
+ * directions
  */
-class GridLabels{
+class GridLabels {
 public:
-    double *x = nullptr;  //< Start of the labels in the x direction
-    double *y = nullptr;  //< Start of the labels in the y direction
-    double *z = nullptr;  //< Start of the labels in the z direction
+  double *x = nullptr;//< Start of the labels in the x direction
+  double *y = nullptr;//< Start of the labels in the y direction
+  double *z = nullptr;//< Start of the labels in the z direction
 
-    GridLabels() = default;
+  GridLabels() = default;
 
-    explicit GridLabels(const mxArray *ptr);
+  explicit GridLabels(const mxArray *ptr);
 
-    /**
-     * @brief Set values by copying from another GridLabels object
-     *
-     * @param other_labels The GridLabels object to copy values from
-     * @param i_l,j_l,k_l The first item to copy from the x, y, z attributes (respectively)
-     * @param i_u,j_u,k_u The final (inclusive) item to copy from the x, y, z attributes (respectively)
-     */
-    void initialise_from(const GridLabels &labels_to_copy_from, int i_l, int i_u, int j_l, int j_u, int k_l, int k_u);
+  /**
+   * @brief Set values by copying from another GridLabels object
+   *
+   * @param other_labels The GridLabels object to copy values from
+   * @param i_l,j_l,k_l The first item to copy from the x, y, z attributes
+   * (respectively)
+   * @param i_u,j_u,k_u The final (inclusive) item to copy from the x, y, z
+   * attributes (respectively)
+   */
+  void initialise_from(const GridLabels &labels_to_copy_from, int i_l, int i_u,
+                       int j_l, int j_u, int k_l, int k_u);
 };

--- a/tdms/include/input_matrices.h
+++ b/tdms/include/input_matrices.h
@@ -12,21 +12,27 @@
 
 class InputMatrices {
 private:
-  // Pointers to arrays in C++ that will be populated by the MATLAB matrices (default to nullptrs)
+  // Pointers to arrays in C++ that will be populated by the MATLAB matrices
+  // (default to nullptrs)
   const mxArray *matrix_pointers[NMATRICES];
 
   /**
-   * @brief Assigns pointers to the matrices in an input file, based on those we are expecting to recieve.
+   * @brief Assigns pointers to the matrices in an input file, based on those we
+   * are expecting to recieve.
    *
-   * MatrixCollection is a list of names of matrices we expect to be in the MatFileMatrixCollection, based on whether we are reading from a gridfile, input_file without a gridfile, or an input file that came with a gridfile.
+   * MatrixCollection is a list of names of matrices we expect to be in the
+   * MatFileMatrixCollection, based on whether we are reading from a gridfile,
+   * input_file without a gridfile, or an input file that came with a gridfile.
    *
    * @param expected The matrices we expect to be able to pull from actual
    * @param actual The matrices saved in an input file, to be loaded
    */
-  void assign_matrix_pointers(MatrixCollection &expected, MatFileMatrixCollection &actual);
+  void assign_matrix_pointers(MatrixCollection &expected,
+                              MatFileMatrixCollection &actual);
 
   /**
-   * @brief Validates that the MATLAB arrays that we are pointing to are of the type that we expect.
+   * @brief Validates that the MATLAB arrays that we are pointing to are of the
+   * type that we expect.
    */
   void validate_assigned_pointers();
 
@@ -35,7 +41,8 @@ public:
 
 
   /**
-   * @brief Fetches the index of matrix_name in the tdms_matrix_names::matrixnames array
+   * @brief Fetches the index of matrix_name in the
+   * tdms_matrix_names::matrixnames array
    *
    * @param matrix_name The matrix name to locate
    * @return int The corresponding index
@@ -45,7 +52,8 @@ public:
   /**
    * @brief Fetch a (pointer to a) MATLAB input matrix by index reference.
    *
-   * Index-references can be computed through index_from_matrix_name. They are ordered in the same way as the names in tdms_matrix_names::matrixnames.
+   * Index-references can be computed through index_from_matrix_name. They are
+   * ordered in the same way as the names in tdms_matrix_names::matrixnames.
    *
    * @param index The index to fetch
    * @return const mxArray* Pointer to the corresponding MATLAB array
@@ -64,18 +72,24 @@ public:
   /**
    * @brief Set the matrix pointer with the given index.
    *
-   * Not recommended unless you're certain you are setting the correct array pointer! Use the overload which takes the array name as an input if you are uncertain you are setting the correct pointer.
+   * Not recommended unless you're certain you are setting the correct array
+   * pointer! Use the overload which takes the array name as an input if you are
+   * uncertain you are setting the correct pointer.
    *
-   * This function mainly sees use during destruction (and output writing) when we just want to iterate over all the matrices that we are dealing with.
+   * This function mainly sees use during destruction (and output writing) when
+   * we just want to iterate over all the matrices that we are dealing with.
    *
    * @param index The index in matrix_pointers to set
    * @param new_ptr The address we want to assign
    */
-  void set_matrix_pointer(int index, mxArray *new_ptr) { matrix_pointers[index] = new_ptr; }
+  void set_matrix_pointer(int index, mxArray *new_ptr) {
+    matrix_pointers[index] = new_ptr;
+  }
   /**
    * @brief Set the pointer to the named matrix
    *
-   * @param matrix_name The name of the matrix that we want to set the pointer to
+   * @param matrix_name The name of the matrix that we want to set the pointer
+   * to
    * @param new_ptr The address we want to assign
    */
   void set_matrix_pointer(const std::string &matrix_name, mxArray *new_ptr) {
@@ -83,13 +97,15 @@ public:
   }
 
   /**
-   * @brief Open the input mat file, load the matrices, and setup pointers to the matrices
+   * @brief Open the input mat file, load the matrices, and setup pointers to
+   * the matrices
    *
    * @param mat_filename The MATLAB filename
    */
   void set_from_input_file(const char *mat_filename);
   /**
-   * @brief Open the input mat file, load the matrices, and setup pointers to the matrices
+   * @brief Open the input mat file, load the matrices, and setup pointers to
+   * the matrices
    *
    * @param mat_filename The MATLAB filename
    * @param gridfile The additional gridfile

--- a/tdms/include/input_output_names.h
+++ b/tdms/include/input_output_names.h
@@ -1,131 +1,148 @@
 /**
  * @file input_output_names.h
- * @brief Constant values associated with the format of the input and output files and matrices
+ * @brief Constant values associated with the format of the input and output
+ * files and matrices
  */
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
-#define NMATRICES 49             //< number of input matrices
-#define NOUTMATRICES_WRITE 23    //< number of output matrices to be written to output file
-#define NOUTMATRICES_WRITE_ALL 25//< number of output matrices to be written to output file
-#define NOUTMATRICES_PASSED 31   //< number of output matrices passed by mexFunction
+#define NMATRICES 49//< number of input matrices
+#define NOUTMATRICES_WRITE                                                     \
+  23//< number of output matrices to be written to output file
+#define NOUTMATRICES_WRITE_ALL                                                 \
+  25//< number of output matrices to be written to output file
+#define NOUTMATRICES_PASSED                                                    \
+  31//< number of output matrices passed by mexFunction
 
 /*
-These are the names of the arrays that we expect to recieve from the input file (and posibly gridfile) that is passed to tdms on the command line.
-In the case where we are given an input file and a gridfile, the array names we expect to recieve from each is also recorded.
-In the case where the -m (compressed output) flag is passed, we do not save all the possible output arrays and so have a complete list of outputs and a shortened list of those which are saved when using -m.
+These are the names of the arrays that we expect to recieve from the input file
+(and posibly gridfile) that is passed to tdms on the command line. In the case
+where we are given an input file and a gridfile, the array names we expect to
+recieve from each is also recorded. In the case where the -m (compressed output)
+flag is passed, we do not save all the possible output arrays and so have a
+complete list of outputs and a shortened list of those which are saved when
+using -m.
 */
 namespace tdms_matrix_names {
-    const std::vector<std::string> matrixnames_infile = {"Cmaterial",
-                                                         "Dmaterial",
-                                                         "C",
-                                                         "D",
-                                                         "freespace",
-                                                         "disp_params",
-                                                         "delta",
-                                                         "interface",
-                                                         "Isource",
-                                                         "Jsource",
-                                                         "Ksource",
-                                                         "grid_labels",
-                                                         "omega_an",
-                                                         "to_l",
-                                                         "hwhm",
-                                                         "Dxl",
-                                                         "Dxu",
-                                                         "Dyl",
-                                                         "Dyu",
-                                                         "Dzl",
-                                                         "Dzu",
-                                                         "Nt",
-                                                         "dt",
-                                                         "tind",
-                                                         "sourcemode",
-                                                         "runmode",
-                                                         "exphasorsvolume",
-                                                         "exphasorssurface",
-                                                         "intphasorssurface",
-                                                         "phasorsurface",
-                                                         "phasorinc",
-                                                         "dimension",
-                                                         "conductive_aux",
-                                                         "dispersive_aux",
-                                                         "structure",
-                                                         "f_ex_vec",
-                                                         "exdetintegral",
-                                                         "f_vec",
-                                                         "Pupil",
-                                                         "D_tilde",
-                                                         "k_det_obs_global",
-                                                         "air_interface",
-                                                         "intmatprops",
-                                                         "intmethod",
-                                                         "tdfield",
-                                                         "tdfdir",
-                                                         "fieldsample",
-                                                         "campssample"};//< All matrices that we could expect to get from an input file with a separate gridfile
-    const std::vector<std::string> matrixnames_input_with_grid = {"fdtdgrid",
-                                                                  "Cmaterial",
-                                                                  "Dmaterial",
-                                                                  "C",
-                                                                  "D",
-                                                                  "freespace",
-                                                                  "disp_params",
-                                                                  "delta",
-                                                                  "interface",
-                                                                  "Isource",
-                                                                  "Jsource",
-                                                                  "Ksource",
-                                                                  "grid_labels",
-                                                                  "omega_an",
-                                                                  "to_l",
-                                                                  "hwhm",
-                                                                  "Dxl",
-                                                                  "Dxu",
-                                                                  "Dyl",
-                                                                  "Dyu",
-                                                                  "Dzl",
-                                                                  "Dzu",
-                                                                  "Nt",
-                                                                  "dt",
-                                                                  "tind",
-                                                                  "sourcemode",
-                                                                  "runmode",
-                                                                  "exphasorsvolume",
-                                                                  "exphasorssurface",
-                                                                  "intphasorssurface",
-                                                                  "phasorsurface",
-                                                                  "phasorinc",
-                                                                  "dimension",
-                                                                  "conductive_aux",
-                                                                  "dispersive_aux",
-                                                                  "structure",
-                                                                  "f_ex_vec",
-                                                                  "exdetintegral",
-                                                                  "f_vec",
-                                                                  "Pupil",
-                                                                  "D_tilde",
-                                                                  "k_det_obs_global",
-                                                                  "air_interface",
-                                                                  "intmatprops",
-                                                                  "intmethod",
-                                                                  "tdfield",
-                                                                  "tdfdir",
-                                                                  "fieldsample",
-                                                                  "campssample"};//< Matrices we expect to get from an input file that also contains grid information
-    const std::vector<std::string> matrixnames_gridfile = {
-            "fdtdgrid"};//< Matrices we expect to obtain from a separate gridfile
-    const std::vector<std::string> outputmatrices_all = {
-            "Ex_out", "Ey_out",      "Ez_out", "Hx_out",      "Hy_out",
-            "Hz_out", "x_out",       "y_out",  "z_out",       "Ex_i",
-            "Ey_i",   "Ez_i",        "Hx_i",   "Hy_i",        "Hz_i",
-            "x_i",    "y_i",         "z_i",    "vertices",    "camplitudes",
-            "facets", "maxresfield", "Id",     "fieldsample", "campssample"};//< All output matrices we might want to write
-    const std::vector<std::string> outputmatrices = {
-            "Ex_out",      "Ey_out",      "Ez_out", "Hx_out",      "Hy_out",     "Hz_out",
-            "x_out",       "y_out",       "z_out",  "Ex_i",        "Ey_i",       "Ez_i",
-            "Hx_i",        "Hy_i",        "Hz_i",   "x_i",         "y_i",        "z_i",
-            "camplitudes", "maxresfield", "Id",     "fieldsample", "campssample"};//< Output matrices we want to write in a compressed (-m) output
-}
+const std::vector<std::string> matrixnames_infile = {
+        "Cmaterial",
+        "Dmaterial",
+        "C",
+        "D",
+        "freespace",
+        "disp_params",
+        "delta",
+        "interface",
+        "Isource",
+        "Jsource",
+        "Ksource",
+        "grid_labels",
+        "omega_an",
+        "to_l",
+        "hwhm",
+        "Dxl",
+        "Dxu",
+        "Dyl",
+        "Dyu",
+        "Dzl",
+        "Dzu",
+        "Nt",
+        "dt",
+        "tind",
+        "sourcemode",
+        "runmode",
+        "exphasorsvolume",
+        "exphasorssurface",
+        "intphasorssurface",
+        "phasorsurface",
+        "phasorinc",
+        "dimension",
+        "conductive_aux",
+        "dispersive_aux",
+        "structure",
+        "f_ex_vec",
+        "exdetintegral",
+        "f_vec",
+        "Pupil",
+        "D_tilde",
+        "k_det_obs_global",
+        "air_interface",
+        "intmatprops",
+        "intmethod",
+        "tdfield",
+        "tdfdir",
+        "fieldsample",
+        "campssample"};//< All matrices that we could expect to get from an
+                       // input file with a separate gridfile
+const std::vector<std::string> matrixnames_input_with_grid = {
+        "fdtdgrid",
+        "Cmaterial",
+        "Dmaterial",
+        "C",
+        "D",
+        "freespace",
+        "disp_params",
+        "delta",
+        "interface",
+        "Isource",
+        "Jsource",
+        "Ksource",
+        "grid_labels",
+        "omega_an",
+        "to_l",
+        "hwhm",
+        "Dxl",
+        "Dxu",
+        "Dyl",
+        "Dyu",
+        "Dzl",
+        "Dzu",
+        "Nt",
+        "dt",
+        "tind",
+        "sourcemode",
+        "runmode",
+        "exphasorsvolume",
+        "exphasorssurface",
+        "intphasorssurface",
+        "phasorsurface",
+        "phasorinc",
+        "dimension",
+        "conductive_aux",
+        "dispersive_aux",
+        "structure",
+        "f_ex_vec",
+        "exdetintegral",
+        "f_vec",
+        "Pupil",
+        "D_tilde",
+        "k_det_obs_global",
+        "air_interface",
+        "intmatprops",
+        "intmethod",
+        "tdfield",
+        "tdfdir",
+        "fieldsample",
+        "campssample"};//< Matrices we expect to get from an input file that
+                       // also contains grid information
+const std::vector<std::string> matrixnames_gridfile = {
+        "fdtdgrid"};//< Matrices we expect to obtain from a separate gridfile
+const std::vector<std::string> outputmatrices_all = {
+        "Ex_out",     "Ey_out",      "Ez_out",   "Hx_out",
+        "Hy_out",     "Hz_out",      "x_out",    "y_out",
+        "z_out",      "Ex_i",        "Ey_i",     "Ez_i",
+        "Hx_i",       "Hy_i",        "Hz_i",     "x_i",
+        "y_i",        "z_i",         "vertices", "camplitudes",
+        "facets",     "maxresfield", "Id",       "fieldsample",
+        "campssample"};//< All output matrices we might want to write
+const std::vector<std::string> outputmatrices = {
+        "Ex_out", "Ey_out",      "Ez_out",     "Hx_out",      "Hy_out",
+        "Hz_out", "x_out",       "y_out",      "z_out",       "Ex_i",
+        "Ey_i",   "Ez_i",        "Hx_i",       "Hy_i",        "Hz_i",
+        "x_i",    "y_i",         "z_i",        "camplitudes", "maxresfield",
+        "Id",     "fieldsample", "campssample"};//< Output matrices we want to
+                                                // write in a compressed (-m)
+                                                // output
+}// namespace tdms_matrix_names

--- a/tdms/include/interface.h
+++ b/tdms/include/interface.h
@@ -7,7 +7,7 @@
 
 #include "mat_io.h"
 
-class InterfaceComponent{
+class InterfaceComponent {
 public:
   bool apply;
   int index;

--- a/tdms/include/interpolation_methods.h
+++ b/tdms/include/interpolation_methods.h
@@ -3,7 +3,8 @@
  * @author William Graham (ccaegra@ucl.ac.uk)
  * @brief InterpScheme class methods and supporting functions
  *
- * Non InterpScheme methods are required to preserve functionality whilst testing new schemes
+ * Non InterpScheme methods are required to preserve functionality whilst
+ * testing new schemes
  */
 #pragma once
 
@@ -14,140 +15,171 @@
 /**
  * @brief Defines our order of preference for the use of the various schemes.
  *
- * There should never be an instance in which we wish to use BLi to position 7 - this will take us to a point OUTSIDE the computational domain. However for completion purposes (and if we find a use for it), it is included.
+ * There should never be an instance in which we wish to use BLi to position 7 -
+ * this will take us to a point OUTSIDE the computational domain. However for
+ * completion purposes (and if we find a use for it), it is included.
  *
  * MODIFICATIONS TO THE ALIASED INTS WILL CHANGE THE ORDER OF SCHEME PREFERENCE!
  *
- * For band-limited schemes, we have 8 equidistant datapoints and can interpolate to the midpoint of any pair of consecutive points, or "half a point spacing" to the right of the final data point.
- * These "interpolation positions" (interp positions) are marked with "o" below:
- * v0   v1   v2   v3   v4   v5   v6   v7
- *    o    o    o    o    o    o    o    o
- * We label these interp positions with the index of the point to the left: a data point at interp position 0 is effectively a data point "v0.5", being at the midpoint of v0 and v1, for example.
+ * For band-limited schemes, we have 8 equidistant datapoints and can
+ * interpolate to the midpoint of any pair of consecutive points, or "half a
+ * point spacing" to the right of the final data point. These "interpolation
+ * positions" (interp positions) are marked with "o" below: v0   v1   v2   v3 v4
+ * v5   v6   v7 o    o    o    o    o    o    o    o We label these interp
+ * positions with the index of the point to the left: a data point at interp
+ * position 0 is effectively a data point "v0.5", being at the midpoint of v0
+ * and v1, for example.
  */
-enum scheme_value
-{
-    BAND_LIMITED_0 = 4,             // use bandlimited interpolation w/ interp position = 0
-    BAND_LIMITED_1 = 6,             // use bandlimited interpolation w/ interp position = 1
-    BAND_LIMITED_2 = 8,             // use bandlimited interpolation w/ interp position = 2
-    BAND_LIMITED_3 = 9,             // use bandlimited interpolation w/ interp position = 3 [Preferred method if available]
-    BAND_LIMITED_4 = 7,             // use bandlimited interpolation w/ interp position = 4
-    BAND_LIMITED_5 = 5,             // use bandlimited interpolation w/ interp position = 5
-    BAND_LIMITED_6 = 3,             // use bandlimited interpolation w/ interp position = 6
-    BAND_LIMITED_7 = 2,             // use bandlimited interpolation w/ interp position = 7
-    BAND_LIMITED_CELL_ZERO = 1,     // use bandlimited interpolation to interpolate to the centre of Yee cell 0
-    CUBIC_INTERP_MIDDLE = 0,        // cubic interpolation to middle 2 of 4 points (interp1)
-    CUBIC_INTERP_FIRST = -1,        // cubic interpolation to first 2 of 4 points (interp2)
-    CUBIC_INTERP_LAST = -2          // cubic interpolation to last 2 of 4 points (interp3)
+enum scheme_value {
+  BAND_LIMITED_0 = 4,// use bandlimited interpolation w/ interp position = 0
+  BAND_LIMITED_1 = 6,// use bandlimited interpolation w/ interp position = 1
+  BAND_LIMITED_2 = 8,// use bandlimited interpolation w/ interp position = 2
+  BAND_LIMITED_3 = 9,// use bandlimited interpolation w/ interp position = 3
+                     // [Preferred method if available]
+  BAND_LIMITED_4 = 7,// use bandlimited interpolation w/ interp position = 4
+  BAND_LIMITED_5 = 5,// use bandlimited interpolation w/ interp position = 5
+  BAND_LIMITED_6 = 3,// use bandlimited interpolation w/ interp position = 6
+  BAND_LIMITED_7 = 2,// use bandlimited interpolation w/ interp position = 7
+  BAND_LIMITED_CELL_ZERO = 1,// use bandlimited interpolation to interpolate to
+                             // the centre of Yee cell 0
+  CUBIC_INTERP_MIDDLE =
+          0,// cubic interpolation to middle 2 of 4 points (interp1)
+  CUBIC_INTERP_FIRST =
+          -1,           // cubic interpolation to first 2 of 4 points (interp2)
+  CUBIC_INTERP_LAST = -2// cubic interpolation to last 2 of 4 points (interp3)
 };
 
 class InterpolationScheme {
-    private:
-        // the "preference" or "value" of applying this scheme. It may be better to apply another scheme with a higher priority.
-        scheme_value priority;
+private:
+  // the "preference" or "value" of applying this scheme. It may be better to
+  // apply another scheme with a higher priority.
+  scheme_value priority;
 
-        // the constants that will be used in the interpolation scheme.
-        double scheme_coeffs[8];
-    public:
-        /**
-         * @brief Construct a new interp Scheme object, by providing the scheme value
-         *
-         * @param value A value associtated to one of the possible schemes
-         */
-        InterpolationScheme(scheme_value value);
+  // the constants that will be used in the interpolation scheme.
+  double scheme_coeffs[8];
 
-        /* FETCH METHODS */
+public:
+  /**
+   * @brief Construct a new interp Scheme object, by providing the scheme value
+   *
+   * @param value A value associtated to one of the possible schemes
+   */
+  InterpolationScheme(scheme_value value);
 
-        /**
-         * @brief Get the value object
-         *
-         * @return scheme_value
-         */
-        scheme_value get_priority() const;
+  /* FETCH METHODS */
 
-        /* END FETCH METHODS */
+  /**
+   * @brief Get the value object
+   *
+   * @return scheme_value
+   */
+  scheme_value get_priority() const;
 
-        /* The number of datapoints "to the left" of where we are planning to interpolate to.
-        For example, interpolating to interpolation position 0 requires 1 datapoint at a position before the location of the interpolation, whilst interpolation position 6 requires there to be 7.
+  /* END FETCH METHODS */
+
+  /* The number of datapoints "to the left" of where we are planning to
+     interpolate to. For example, interpolating to interpolation position 0
+     requires 1 datapoint at a position before the location of the
+     interpolation, whilst interpolation position 6 requires there to be 7.
         */
-        int number_of_datapoints_to_left;
+  int number_of_datapoints_to_left;
 
-        // cubic and BLi schemes use different numbers of coefficients. To avoid switches, we store these variables.
-        int first_nonzero_coeff, last_nonzero_coeff;
+  // cubic and BLi schemes use different numbers of coefficients. To avoid
+  // switches, we store these variables.
+  int first_nonzero_coeff, last_nonzero_coeff;
 
-        /**
-         * @brief Compute the number of non-zero coefficients in the interpolation scheme
-         *
-         * @return int Number of non-zero coefficients in the interpolation scheme
-         */
-        int num_nonzero_coeffs() const;
+  /**
+   * @brief Compute the number of non-zero coefficients in the interpolation
+   * scheme
+   *
+   * @return int Number of non-zero coefficients in the interpolation scheme
+   */
+  int num_nonzero_coeffs() const;
 
-        /**
-         * @brief Executes the interpolation scheme on the data provided
-         *
-         * The interpolation schemes are all of the form
-         * interpolated_value = \sum_{i=0}^{7} scheme_coeffs[i] * v[i],
-         * so provided that the coefficients have been set correctly in construction (and the data gathered appropriately), we can run the same for loop for each interpolation scheme.
-         *
-         * For slight speedup, the actual sum performed loops over those i such that
-         * 0 <= first_nonzero_coeff <= i <= last_nonzero_coeff <= 7.
-         *
-         * @param v Sample datapoints to use in interpolation; v[0] should be the first of 8 values
-         * @param offset [Default 0] Read buffer from v[offset] rather than v[0]
-         * @return double Interpolated value
-         */
-        template<typename T>
-        T interpolate(const T *v, const int offset = 0) const {
-          T interp_value = 0.;
-          for (int ind = first_nonzero_coeff; ind <= last_nonzero_coeff; ind++) {
-            interp_value += scheme_coeffs[ind] * v[ind + offset];
-          }
-          return interp_value;
-        };
+  /**
+   * @brief Executes the interpolation scheme on the data provided
+   *
+   * The interpolation schemes are all of the form
+   * interpolated_value = \sum_{i=0}^{7} scheme_coeffs[i] * v[i],
+   * so provided that the coefficients have been set correctly in construction
+   * (and the data gathered appropriately), we can run the same for loop for
+   * each interpolation scheme.
+   *
+   * For slight speedup, the actual sum performed loops over those i such that
+   * 0 <= first_nonzero_coeff <= i <= last_nonzero_coeff <= 7.
+   *
+   * @param v Sample datapoints to use in interpolation; v[0] should be the
+   * first of 8 values
+   * @param offset [Default 0] Read buffer from v[offset] rather than v[0]
+   * @return double Interpolated value
+   */
+  template<typename T>
+  T interpolate(const T *v, const int offset = 0) const {
+    T interp_value = 0.;
+    for (int ind = first_nonzero_coeff; ind <= last_nonzero_coeff; ind++) {
+      interp_value += scheme_coeffs[ind] * v[ind + offset];
+    }
+    return interp_value;
+  };
 
-        /**
-         * @brief Determines whether another interpScheme has greater value than this one
-         *
-         * @param s The other interpScheme to compare against
-         * @return true This scheme has greater value
-         * @return false This scheme has lesser, or equal, value to s
-         */
-        bool is_better_than(const InterpolationScheme &s) const;
+  /**
+   * @brief Determines whether another interpScheme has greater value than this
+   * one
+   *
+   * @param s The other interpScheme to compare against
+   * @return true This scheme has greater value
+   * @return false This scheme has lesser, or equal, value to s
+   */
+  bool is_better_than(const InterpolationScheme &s) const;
 };
 
 /* Constant members of the interpScheme class */
-const InterpolationScheme BL0 =
-        InterpolationScheme(BAND_LIMITED_0);//< Scheme performing BLi to position 0.5
-const InterpolationScheme BL1 =
-        InterpolationScheme(BAND_LIMITED_1);//< Scheme performing BLi to position 1.5
-const InterpolationScheme BL2 =
-        InterpolationScheme(BAND_LIMITED_2);//< Scheme performing BLi to position 2.5
-const InterpolationScheme BL3 =
-        InterpolationScheme(BAND_LIMITED_3);//< Scheme performing BLi to position 3.5
-const InterpolationScheme BL4 =
-        InterpolationScheme(BAND_LIMITED_4);//< Scheme performing BLi to position 4.5
-const InterpolationScheme BL5 =
-        InterpolationScheme(BAND_LIMITED_5);//< Scheme performing BLi to position 5.5
-const InterpolationScheme BL6 =
-        InterpolationScheme(BAND_LIMITED_6);//< Scheme performing BLi to position 6.5
-const InterpolationScheme BL7 = InterpolationScheme(
-        BAND_LIMITED_7);//< Scheme performing BLi to position 7.5 (after last cell)
+const InterpolationScheme BL0 = InterpolationScheme(
+        BAND_LIMITED_0);//< Scheme performing BLi to position 0.5
+const InterpolationScheme BL1 = InterpolationScheme(
+        BAND_LIMITED_1);//< Scheme performing BLi to position 1.5
+const InterpolationScheme BL2 = InterpolationScheme(
+        BAND_LIMITED_2);//< Scheme performing BLi to position 2.5
+const InterpolationScheme BL3 = InterpolationScheme(
+        BAND_LIMITED_3);//< Scheme performing BLi to position 3.5
+const InterpolationScheme BL4 = InterpolationScheme(
+        BAND_LIMITED_4);//< Scheme performing BLi to position 4.5
+const InterpolationScheme BL5 = InterpolationScheme(
+        BAND_LIMITED_5);//< Scheme performing BLi to position 5.5
+const InterpolationScheme BL6 = InterpolationScheme(
+        BAND_LIMITED_6);//< Scheme performing BLi to position 6.5
+const InterpolationScheme BL7 =
+        InterpolationScheme(BAND_LIMITED_7);//< Scheme performing BLi to
+                                            // position 7.5 (after last cell)
 const InterpolationScheme BL_TO_CELL_0 = InterpolationScheme(
-        BAND_LIMITED_CELL_ZERO);//< Scheme performing BLi to position -0.5 (before 1st cell)
+        BAND_LIMITED_CELL_ZERO);//< Scheme performing BLi to position -0.5
+                                //(before 1st cell)
 const InterpolationScheme CBFst = InterpolationScheme(
-        CUBIC_INTERP_FIRST);//< Scheme performing cubic interpolation to the midpoint of the first pair of a set of 4 datapoints
+        CUBIC_INTERP_FIRST);//< Scheme performing cubic interpolation to the
+                            // midpoint of the first pair of a set of 4
+                            // datapoints
 const InterpolationScheme CBMid = InterpolationScheme(
-        CUBIC_INTERP_MIDDLE);//< Scheme performing cubic interpolation to the midpoint of the central pair of a set of 4 datapoints
+        CUBIC_INTERP_MIDDLE);//< Scheme performing cubic interpolation to the
+                             // midpoint of the central pair of a set of 4
+                             // datapoints
 const InterpolationScheme CBLst = InterpolationScheme(
-        CUBIC_INTERP_LAST);//< Scheme performing cubic interpolation to the midpoint of the last pair of a set of 4 datapoints
+        CUBIC_INTERP_LAST);//< Scheme performing cubic interpolation to the
+                           // midpoint of the last pair of a set of 4 datapoints
 
 /**
- * @brief Determine the appropriate interpolation scheme to use, given the number of datapoints available and the position to which we wish to interpolate to.
+ * @brief Determine the appropriate interpolation scheme to use, given the
+ * number of datapoints available and the position to which we wish to
+ * interpolate to.
  *
- * @param datapts_in_direction The number of datapoints available along this axis
- * @param interpolation_position Interpolation is to be performed to the midpoint of the datapoints indexed with (interpolation_position-1) and (interpolation_position)
+ * @param datapts_in_direction The number of datapoints available along this
+ * axis
+ * @param interpolation_position Interpolation is to be performed to the
+ * midpoint of the datapoints indexed with (interpolation_position-1) and
+ * (interpolation_position)
  * @param interpolation_methods The preferred interpolation methods to use
  * @return const InterpolationScheme&
  */
-const InterpolationScheme &best_scheme(int datapts_in_direction, int interpolation_position,
-                                       PreferredInterpolationMethods interpolation_methods =
-                                               PreferredInterpolationMethods::BandLimited);
+const InterpolationScheme &
+best_scheme(int datapts_in_direction, int interpolation_position,
+            PreferredInterpolationMethods interpolation_methods =
+                    PreferredInterpolationMethods::BandLimited);

--- a/tdms/include/mat_io.h
+++ b/tdms/include/mat_io.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <mat.h>
-#include <mex.h>
 #include <matrix.h>
+#include <mex.h>
 // https://stackoverflow.com/questions/27069676/how-to-dynamically-create-an-array-of-mxarray-in-a-matlab-mex-file
 
 #ifdef CLUSTER

--- a/tdms/include/matrix_collection.h
+++ b/tdms/include/matrix_collection.h
@@ -4,8 +4,8 @@
  */
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "mat_io.h"
 
@@ -15,42 +15,42 @@
 class MatrixCollection {
 
 public:
-    int n_matrices = 0;            //< The number of matrices in the collection
-    std::vector<std::string> matrix_names; //< The names of the matrices
+  int n_matrices = 0;//< The number of matrices in the collection
+  std::vector<std::string> matrix_names;//< The names of the matrices
 
-    /** @brief Construct a new Matrix Collection object */
-    MatrixCollection() = default;
+  /** @brief Construct a new Matrix Collection object */
+  MatrixCollection() = default;
 
-    /**
-     * @brief Construct a new Matrix Collection object
-     *
-     * @param names of the matrices
-     * @param number of matrices in the collection
-     */
-    explicit MatrixCollection(std::vector<std::string> names);
+  /**
+   * @brief Construct a new Matrix Collection object
+   *
+   * @param names of the matrices
+   * @param number of matrices in the collection
+   */
+  explicit MatrixCollection(std::vector<std::string> names);
 
-    /**
-     * @brief Check we have as many or more matrices than another
-     * MatrixCollection
-     *
-     * Throws a runtime error if there are fewer matrices in the other
-     * MatrixCollection
-     *
-     * @param other the other MatrixCollection
-     */
-    void check_has_at_least_as_many_matrices_as(MatrixCollection &other);
+  /**
+   * @brief Check we have as many or more matrices than another
+   * MatrixCollection
+   *
+   * Throws a runtime error if there are fewer matrices in the other
+   * MatrixCollection
+   *
+   * @param other the other MatrixCollection
+   */
+  void check_has_at_least_as_many_matrices_as(MatrixCollection &other);
 };
 
 
 /**
  * A collection of matlab matrices with names created from a .mat file
  */
-class MatFileMatrixCollection : public MatrixCollection{
+class MatFileMatrixCollection : public MatrixCollection {
 
 public:
-    MATFile* mat_file;
+  MATFile *mat_file;
 
-    explicit MatFileMatrixCollection(const char *filename);
+  explicit MatFileMatrixCollection(const char *filename);
 
-    ~MatFileMatrixCollection();
+  ~MatFileMatrixCollection();
 };

--- a/tdms/include/mesh_base.h
+++ b/tdms/include/mesh_base.h
@@ -43,8 +43,9 @@
  *         +------------>j
  *          J0        J1
  *
- * @param order specifies the direction of the surface normals of the triangles. This
- * can take only 2 possible values +1 or -1. They have the following meaning:
+ * @param order specifies the direction of the surface normals of the triangles.
+ * This can take only 2 possible values +1 or -1. They have the following
+ * meaning:
  *
  * order = 1 means that the surface normal for a triangle in the:
  *     xy plane will || to the z-axis
@@ -57,21 +58,26 @@
  * facet matrix.
  *
  * The space allocated by *vertexMatrix must be freed after use.
-*/
-void triangulatePlane(int I0, int I1, int J0, int J1, int K,int coordmap[], int order, mxArray **vertexMatrix);
-void triangulatePlaneSkip(int I0, int I1, int J0, int J1, int K,int coordmap[], int order, mxArray **vertexMatrix, int dI, int dJ);
+ */
+void triangulatePlane(int I0, int I1, int J0, int J1, int K, int coordmap[],
+                      int order, mxArray **vertexMatrix);
+void triangulatePlaneSkip(int I0, int I1, int J0, int J1, int K, int coordmap[],
+                          int order, mxArray **vertexMatrix, int dI, int dJ);
 /**
  * @brief
  *
- * @param vertexMatrix should be a 6 element array. Generates 6 arrays of facets using triangulatePlane.
- *  Each matrix is a plane of the cuboid which is defined by:
+ * @param vertexMatrix should be a 6 element array. Generates 6 arrays of facets
+ * using triangulatePlane. Each matrix is a plane of the cuboid which is defined
+ * by:
  *
  * (I0,I1)x(J0,J1)x(K0,K1)
  *
  * Each vertexMatrix[i] should be destroyed after calling this function
  */
-void triangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1, mxArray **vertexMatrix);
-void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1, mxArray **vertexMatrix, int dI, int dJ, int dK);
+void triangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1,
+                       mxArray **vertexMatrix);
+void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1,
+                           mxArray **vertexMatrix, int dI, int dJ, int dK);
 
 /**
  * @brief Generates a triangulation of a cuboid defined the surface of a regular
@@ -91,9 +97,12 @@ void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1, mxArr
  * @param facets an array of facets each of which is created using 3 vertex
  * indices. Each index is an index in to the vertices array.
  */
-void conciseTriangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1, mxArray **vertices,
-                              mxArray **facets);
-void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1,
-                                  const SurfaceSpacingStride &spacing_stride, mxArray **vertices, mxArray **facets);
+void conciseTriangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1,
+                              mxArray **vertices, mxArray **facets);
+void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0,
+                                  int K1,
+                                  const SurfaceSpacingStride &spacing_stride,
+                                  mxArray **vertices, mxArray **facets);
 
-void conciseCreateBoundary(int I0, int I1,int K0, int K1, mxArray **vertices, mxArray ** facets);
+void conciseCreateBoundary(int I0, int I1, int K0, int K1, mxArray **vertices,
+                           mxArray **facets);

--- a/tdms/include/numerical_derivative.h
+++ b/tdms/include/numerical_derivative.h
@@ -37,13 +37,14 @@ void init_diff_shift_op(double delta, fftw_complex *Dk, int N);
 
 /**
  * @brief Calculate the first derivative of a sampled function.
- * @note in_pb_pf must be the buffer which is the input for both plans pf and pb.
- * Likewise, out_pb_pf must be the output for both plans pf and pb.
+ * @note in_pb_pf must be the buffer which is the input for both plans pf and
+ * pb. Likewise, out_pb_pf must be the output for both plans pf and pb.
  *
  * @param[in] in_pb_pf The buffer containing the data to be differentiated.
  * 	    @warning This buffer will be overwritten as part of the computation.
  * @param[out] out_pb_pf The buffer which will contain the computed derivative.
- * @param[inout] Dk Buffer to write the coefficients for performing differentiation and shifting in Fourier space.
+ * @param[inout] Dk Buffer to write the coefficients for performing
+ * differentiation and shifting in Fourier space.
  * @param[in] N Number of elements in buffers.
  * @param[in] pf The plan for forward FFT.
  * @param[in] pb The plan for backward FFT.

--- a/tdms/include/output_matrices/id_variables.h
+++ b/tdms/include/output_matrices/id_variables.h
@@ -11,37 +11,50 @@
 /**
  * @brief Class that handles the variables associated with the ID output.
  *
- * The ID output is a MATLAB struct that we create during runtime, so we need to free the memory we reserve upon destruction, as well as link pointers to the MATLAB structs to our native C++ arrays.
+ * The ID output is a MATLAB struct that we create during runtime, so we need to
+ * free the memory we reserve upon destruction, as well as link pointers to the
+ * MATLAB structs to our native C++ arrays.
  */
 class IDVariables {
 private:
-  int n_frequencies = 0;//< Number of frequencies that we're extracting at. ( = to f_ex_vec.size() )
-  int n_det_modes = 0;//< D_tilde.num_det_modes()
+  int n_frequencies = 0;//< Number of frequencies that we're extracting at. ( =
+                        // to f_ex_vec.size() )
+  int n_det_modes = 0;  //< D_tilde.num_det_modes()
 
-  bool memory_assigned = false;//< Flags whether MATLAB memory has been assigned and needs to be free'd
+  bool memory_assigned = false;//< Flags whether MATLAB memory has been assigned
+                               // and needs to be free'd
 public:
-  mxArray *x_ptr = nullptr;//< Holds the array in the Idx field of OutputMatrices["Id"]
-  mxArray *y_ptr = nullptr;//< Holds the arrays in the Idy field of OutputMatrices["Id"]
+  mxArray *x_ptr =
+          nullptr;//< Holds the array in the Idx field of OutputMatrices["Id"]
+  mxArray *y_ptr =
+          nullptr;//< Holds the arrays in the Idy field of OutputMatrices["Id"]
 
   std::complex<double> **x = nullptr, **y = nullptr;
 
-  // pointers to the real (re) and imaginary (im) parts of the data in the Id output
-  double **x_real = nullptr, **y_real = nullptr, **x_imag = nullptr, **y_imag = nullptr;
+  // pointers to the real (re) and imaginary (im) parts of the data in the Id
+  // output
+  double **x_real = nullptr, **y_real = nullptr, **x_imag = nullptr,
+         **y_imag = nullptr;
 
   IDVariables() = default;
 
   /**
-   * @brief Creates MATLAB arrays that constitute the fields of the ID output, and assigns them as the appropriate fields of the ID output.
+   * @brief Creates MATLAB arrays that constitute the fields of the ID output,
+   * and assigns them as the appropriate fields of the ID output.
    *
-   * The ID output is a 1-by-1 structure array with 2 fields, which is pointed to in id_pointer.
-   * In order to assign arrays as the field values, we need to create fresh MATLAB structures using the member variables of this class.
-   * The arrays assigned to the two fieldnames, "x" and "y", are of side n_frequencies-by-n_det_modes.
+   * The ID output is a 1-by-1 structure array with 2 fields, which is pointed
+   * to in id_pointer. In order to assign arrays as the field values, we need to
+   * create fresh MATLAB structures using the member variables of this class.
+   * The arrays assigned to the two fieldnames, "x" and "y", are of side
+   * n_frequencies-by-n_det_modes.
    *
    * @param id_pointer Pointer to the ID output structure array
-   * @param _n_frequencies The number of frequencies we are considering in this simulation
+   * @param _n_frequencies The number of frequencies we are considering in this
+   * simulation
    * @param n_det_modes TODO:: DTilde.n_det_modes()
    */
-  void link_to_pointer(mxArray *&id_pointer, int _n_frequencies, int n_det_modes);
+  void link_to_pointer(mxArray *&id_pointer, int _n_frequencies,
+                       int n_det_modes);
 
   ~IDVariables();
 };

--- a/tdms/include/output_matrices/output_matrices.h
+++ b/tdms/include/output_matrices/output_matrices.h
@@ -10,33 +10,42 @@
 #include "field.h"
 #include "fieldsample.h"
 #include "grid_labels.h"
-#include "output_matrices/id_variables.h"
 #include "matrix.h"
+#include "output_matrices/id_variables.h"
 #include "output_matrices/output_matrix_pointers.h"
+#include "shapes.h"
 #include "simulation_parameters.h"
 #include "surface_phasors.h"
-#include "shapes.h"
 #include "vertex_phasors.h"
 
 /**
- * @brief Handles the data that is written to the output file, and the associated native C++ classes and datatypes.
+ * @brief Handles the data that is written to the output file, and the
+ * associated native C++ classes and datatypes.
  *
- * Some of the C++ datatypes are updated in the main iterative loop, whilst others are created later using the data from the main loop. This class handles both cases, and uses pointers to track where the MATLAB-structures to be written out are stored.
+ * Some of the C++ datatypes are updated in the main iterative loop, whilst
+ * others are created later using the data from the main loop. This class
+ * handles both cases, and uses pointers to track where the MATLAB-structures to
+ * be written out are stored.
  *
- * Upon writing the output, an instance of this class can go out of scope and will take with it any reserved memory for MATLAB structures and native C++ arrays of dynamic size.
+ * Upon writing the output, an instance of this class can go out of scope and
+ * will take with it any reserved memory for MATLAB structures and native C++
+ * arrays of dynamic size.
  */
 class OutputMatrices {
 private:
-  // Pointers to arrays in C++ that will be populated by pointers to the output data
+  // Pointers to arrays in C++ that will be populated by pointers to the output
+  // data
   OutputMatrixPointers output_arrays;
 
   // Holds the pointer to the MATLAB structure that surface_phasors is bound to
   mxArray *mx_surface_vertices = nullptr;
 
-  IJKDimensions n_Yee_cells;//< Number of Yee cells in each axial direction for the simulation (dictated by E_s split-field)
+  IJKDimensions n_Yee_cells;//< Number of Yee cells in each axial direction for
+                            // the simulation (dictated by E_s split-field)
 
   /**
-   * @brief Computes the field values at the centre of the Yee cells, and the corresponding spatial coordinates of these locations.
+   * @brief Computes the field values at the centre of the Yee cells, and the
+   * corresponding spatial coordinates of these locations.
    *
    * @param dimension Dimensionality of the simulation: THREE, TE, or TM.
    */
@@ -46,7 +55,8 @@ public:
   OutputMatrices() = default;
 
   /**
-   * @brief Record the number of Yee cells in each axial direction from the split-electric field that was input.
+   * @brief Record the number of Yee cells in each axial direction from the
+   * split-electric field that was input.
    *
    * @param IJK_tot Number of Yee cells in the {I,J,K} directions
    */
@@ -75,7 +85,8 @@ public:
 
   ElectricField E;//< Electric field and phasors at the Yee cell positions
   MagneticField H;//< Magnetic field and phasors at the Yee cell positions
-  GridLabels output_grid_labels;//< Co-ordinates (spatial positions) of the field values
+  GridLabels output_grid_labels;//< Co-ordinates (spatial positions) of the
+                                // field values
 
   /**
    * @brief Set the up E, H, and output_grid_labels outputs
@@ -84,67 +95,79 @@ public:
    * @param input_grid_labels The grid labels obtained from the input file
    * @param pim The interpolation methods to use on the field values
    */
-  void setup_EH_and_gridlabels(const SimulationParameters &params, const GridLabels &input_grid_labels, PreferredInterpolationMethods pim);
+  void setup_EH_and_gridlabels(const SimulationParameters &params,
+                               const GridLabels &input_grid_labels,
+                               PreferredInterpolationMethods pim);
   /**
    * @brief Get the dimensions of the electric (and magnetic) field.
    *
    * @return IJKDimensions The dimensions of the electric (and magnetic) field
    */
-  IJKDimensions get_E_dimensions() const {
-    return E.tot;
-  }
+  IJKDimensions get_E_dimensions() const { return E.tot; }
   // set the interpolation method for the E and H fields
   void set_interpolation_methods(PreferredInterpolationMethods pim) {
     E.set_preferred_interpolation_methods(pim);
     H.set_preferred_interpolation_methods(pim);
   }
 
-  SurfacePhasors surface_phasors;//< Phasors extracted over the user-specified surface
+  SurfacePhasors
+          surface_phasors;//< Phasors extracted over the user-specified surface
 
-  void setup_surface_mesh(const Cuboid &cuboid, const SimulationParameters &params, int n_frequencies);
+  void setup_surface_mesh(const Cuboid &cuboid,
+                          const SimulationParameters &params,
+                          int n_frequencies);
   /**
    * @brief Create MATLAB memory for the surface phasor outputs
    *
    * @param empty_allocation If true, empty arrays will be allocated
    * @param mx_surface_facets The surface facets to write out
    */
-  void assign_surface_phasor_outputs(bool empty_allocation, mxArray *mx_surface_facets);
+  void assign_surface_phasor_outputs(bool empty_allocation,
+                                     mxArray *mx_surface_facets);
 
   VertexPhasors vertex_phasors;//< Phasors extracted at user-specified vertices
 
   /**
-   * @brief Setup the object that will handle extraction of the phasors at the vertices
+   * @brief Setup the object that will handle extraction of the phasors at the
+   * vertices
    *
    * @param vp_ptr Pointer to the input array containing vertex data
    * @param n_frequencies The number of frequencies we are extracting at
    */
   void setup_vertex_phasors(const mxArray *vp_ptr, int n_frequencies);
 
-  FieldSample fieldsample;//< E,H split-field values sampled at user-specified locations and frequencies
+  FieldSample fieldsample;//< E,H split-field values sampled at user-specified
+                          // locations and frequencies
 
   /**
-   * @brief Setup the object that handles extraction of the field values at the sample positions
+   * @brief Setup the object that handles extraction of the field values at the
+   * sample positions
    *
-   * @param fieldsample_input_data Pointer to the input array containing sample positions
+   * @param fieldsample_input_data Pointer to the input array containing sample
+   * positions
    */
   void setup_fieldsample(const mxArray *fieldsample_input_data);
 
   /**
-   * @brief Set the maxresfield object. If memory has not been reserved yet, it can be assigned here.
+   * @brief Set the maxresfield object. If memory has not been reserved yet, it
+   * can be assigned here.
    *
    * @param maxfield Value to write to output memory
-   * @param overwrite_existing If true, overwrite existing value (do not assign new memory). Otherwise, create new memory for the maxresfield output.
+   * @param overwrite_existing If true, overwrite existing value (do not assign
+   * new memory). Otherwise, create new memory for the maxresfield output.
    */
   void set_maxresfield(double maxfield, bool overwrite_existing);
 
-  GridLabels interp_output_grid_labels;//< Holds the spatial co-ordinates of the interpolated fields
+  GridLabels interp_output_grid_labels;//< Holds the spatial co-ordinates of the
+                                       // interpolated fields
 
   /**
    * @brief Create MATLAB memory for the gridlabels for the interpolated fields
    *
    * @param empty_allocation If true, empty arrays will be allocated
    * @param E,H The {electric,magnetic} field that will be interpolated
-   * @param simulation_dimension Whether we are running a 3D, TE, or TM simulation
+   * @param simulation_dimension Whether we are running a 3D, TE, or TM
+   * simulation
    */
   void setup_interpolation_outputs(SimulationParameters params);
 
@@ -152,9 +175,11 @@ public:
    * @brief Save the output matrices to the output file
    *
    * @param output_file_name The file to write the simulation outputs to
-   * @param compressed_output If true, write compressed output (do not write facets and vertices)
+   * @param compressed_output If true, write compressed output (do not write
+   * facets and vertices)
    */
-  void save_outputs(const std::string& output_file_name, bool compressed_output = false);
+  void save_outputs(const std::string &output_file_name,
+                    bool compressed_output = false);
 
   ~OutputMatrices();
 };

--- a/tdms/include/output_matrices/output_matrix_pointers.h
+++ b/tdms/include/output_matrices/output_matrix_pointers.h
@@ -1,28 +1,34 @@
 /**
  * @file output_matrix_pointers.h
- * @brief Declares a class that allows for memory-management of pointers to the output arrays (OutputMatrixPointers)
+ * @brief Declares a class that allows for memory-management of pointers to the
+ * output arrays (OutputMatrixPointers)
  */
 #pragma once
 
-#include <vector>
-#include <string>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "input_output_names.h"
 #include "matrix.h"
 
 /**
- * @brief Provides human-readable and safe management of the pointers to the output arrays, and the associated memory.
+ * @brief Provides human-readable and safe management of the pointers to the
+ * output arrays, and the associated memory.
  *
- * Instances can be referred using instance[matrix_name] to obtain the pointer to the output matrix matrix_name. However, memory management checks exist to prevent us from leaking memory through blase assignment.
+ * Instances can be referred using instance[matrix_name] to obtain the pointer
+ * to the output matrix matrix_name. However, memory management checks exist to
+ * prevent us from leaking memory through blase assignment.
  */
 class OutputMatrixPointers {
 private:
-  // Pointers to arrays in C++ that will be populated by pointers to the output data
+  // Pointers to arrays in C++ that will be populated by pointers to the output
+  // data
   mxArray *matrix_pointers[NOUTMATRICES_WRITE_ALL] = {nullptr};
 
   /**
-   * @brief Fetches the index of matrix_name in the tdms_matrix_names::matrixnames array
+   * @brief Fetches the index of matrix_name in the
+   * tdms_matrix_names::matrixnames array
    *
    * @param matrix_name The matrix name to locate
    * @return int The corresponding index
@@ -41,36 +47,45 @@ public:
   }
 
   /**
-   * @brief Return true if the matrix_pointer corresponding to any one of the matrix names passed already points to allocated memory.
+   * @brief Return true if the matrix_pointer corresponding to any one of the
+   * matrix names passed already points to allocated memory.
    *
    * @param matrix_names List of output matrices to check.
    */
-  bool memory_already_assigned(const std::vector<std::string>& matrix_names);
+  bool memory_already_assigned(const std::vector<std::string> &matrix_names);
 
   /**
-   * @brief Throw an error if the matrix_pointer corresponding to any one of the matrix names passed already points to allocated memory.
+   * @brief Throw an error if the matrix_pointer corresponding to any one of the
+   * matrix names passed already points to allocated memory.
    *
-   * This function exists to avoid memory leaks - it is possible for us to reassign the matrix_pointers after mxCreate-ing arrays. To avoid this, we always validate we have not done this before attempting to assign memory.
+   * This function exists to avoid memory leaks - it is possible for us to
+   * reassign the matrix_pointers after mxCreate-ing arrays. To avoid this, we
+   * always validate we have not done this before attempting to assign memory.
    *
    * @param matrix_names List of output matrices to check.
    */
-  void error_on_memory_assigned(const std::vector<std::string>& matrix_names) {
+  void error_on_memory_assigned(const std::vector<std::string> &matrix_names) {
     if (memory_already_assigned(matrix_names)) {
-      throw std::runtime_error("Reassigning output pointer will cause memory leak - aborting.");
+      throw std::runtime_error(
+              "Reassigning output pointer will cause memory leak - aborting.");
     }
   }
 
   /**
    * @brief Assign the matrices provided as empty arrays.
    *
-   * Outputs are typically set to empty arrays when the user has requested the simulation be run in such a way that the output is not generated, or not requested. We still check for memory leaks before assignment as creating an empty array can still leave MATLAB memory not-cleaned-up.
+   * Outputs are typically set to empty arrays when the user has requested the
+   * simulation be run in such a way that the output is not generated, or not
+   * requested. We still check for memory leaks before assignment as creating an
+   * empty array can still leave MATLAB memory not-cleaned-up.
    *
    * @param matrix_names The list of matrix names to set to be empty.
-   * @param data_type The data type to assign to the empty array (needed for compatibility issues)
+   * @param data_type The data type to assign to the empty array (needed for
+   * compatibility issues)
    * @param is_complex Whether the data is complex (mxCOMPLEX) or real (mxREAL)
    * @param ndims Number of dimensions in the empty array to assign
    */
-  void assign_empty_matrix(const std::vector<std::string>& matrix_names,
+  void assign_empty_matrix(const std::vector<std::string> &matrix_names,
                            mxClassID data_type = mxDOUBLE_CLASS,
                            mxComplexity complexity = mxCOMPLEX, int ndims = 2);
 

--- a/tdms/include/shapes.h
+++ b/tdms/include/shapes.h
@@ -2,12 +2,12 @@
 
 #include "mat_io.h"
 
-class Cuboid{
+class Cuboid {
 private:
   int array[6] = {0, 0, 0, 0, 0, 6};
 
 public:
   void initialise(const mxArray *ptr, int J_tot);
 
-  inline int operator[] (int value) const { return array[value]; };
+  inline int operator[](int value) const { return array[value]; };
 };

--- a/tdms/include/simulation_manager/fdtd_bootstrapper.h
+++ b/tdms/include/simulation_manager/fdtd_bootstrapper.h
@@ -2,7 +2,9 @@
  * @file fdtd_bootstrapper.h
  * @brief Handles the boostrapping variables used in the FDTD solver.
  *
- * NOTE: Can be deleted from codebase without altering functionality. See https://github.com/UCL/TDMS/issues/214#issue-1532363539 - holding off doing so until meeting clarification.
+ * NOTE: Can be deleted from codebase without altering functionality. See
+ * https://github.com/UCL/TDMS/issues/214#issue-1532363539 - holding off doing
+ * so until meeting clarification.
  */
 #pragma once
 
@@ -16,33 +18,38 @@
 /**
  * @brief Class that handles the FDTD bootstrapping variables.
  *
- * NOTE: Can be deleted from codebase without altering functionality. See https://github.com/UCL/TDMS/issues/214#issue-1532363539 - holding off doing so until meeting clarification.
+ * NOTE: Can be deleted from codebase without altering functionality. See
+ * https://github.com/UCL/TDMS/issues/214#issue-1532363539 - holding off doing
+ * so until meeting clarification.
  */
 class FDTDBootstrapper {
-    private:
-      // Electric and magnetic source phasors, used in bootstrapping
-      Matrix<std::complex<double>> Ex, Ey, Hx, Hy;
-    public:
-      FDTDBootstrapper() = default;
-      FDTDBootstrapper(const IJKDimensions& IJK_tot) { allocate_memory(IJK_tot); }
+private:
+  // Electric and magnetic source phasors, used in bootstrapping
+  Matrix<std::complex<double>> Ex, Ey, Hx, Hy;
 
-      /**
-       * @brief Allocate memory for the bootstrapping variables, given the number of Yee cells
-       *
-       * @param IJK_tot Number of Yee cells in each axial direction
-       */
-      void allocate_memory(const IJKDimensions& IJK_tot);
+public:
+  FDTDBootstrapper() = default;
+  FDTDBootstrapper(const IJKDimensions &IJK_tot) { allocate_memory(IJK_tot); }
 
-      /**
-       * @brief Extract phasors on the user-defined plane
-       *
-       * @param E_s,H_s Split-field values
-       * @param IJK_tot Number of Yee cells in each axial direction
-       * @param K1
-       * @param tind Current iteration number
-       * @param params Simulation parameters for this run of TDMS
-       */
-      void extract_phasors_in_plane(const ElectricSplitField &E_s, const MagneticSplitField &H_s,
-                                    const IJKDimensions &IJK_tot, int K1, int tind,
-                                    const SimulationParameters &params);
+  /**
+   * @brief Allocate memory for the bootstrapping variables, given the number of
+   * Yee cells
+   *
+   * @param IJK_tot Number of Yee cells in each axial direction
+   */
+  void allocate_memory(const IJKDimensions &IJK_tot);
+
+  /**
+   * @brief Extract phasors on the user-defined plane
+   *
+   * @param E_s,H_s Split-field values
+   * @param IJK_tot Number of Yee cells in each axial direction
+   * @param K1
+   * @param tind Current iteration number
+   * @param params Simulation parameters for this run of TDMS
+   */
+  void extract_phasors_in_plane(const ElectricSplitField &E_s,
+                                const MagneticSplitField &H_s,
+                                const IJKDimensions &IJK_tot, int K1, int tind,
+                                const SimulationParameters &params);
 };

--- a/tdms/include/simulation_manager/loop_timers.h
+++ b/tdms/include/simulation_manager/loop_timers.h
@@ -1,6 +1,7 @@
 /**
  * @file loop_timers.h
- * @brief Declares the class that handles the timing of the main loop and subprocesses of the main loop.
+ * @brief Declares the class that handles the timing of the main loop and
+ * subprocesses of the main loop.
  */
 #pragma once
 
@@ -9,18 +10,24 @@
 
 #include "timer.h"
 
-// There are two timers concerning the main loop: the internal timer that is tracking individual tasks, and the timer that is tracking how long the main iteration has actually taken.
+// There are two timers concerning the main loop: the internal timer that is
+// tracking individual tasks, and the timer that is tracking how long the main
+// iteration has actually taken.
 enum class TimersTrackingLoop { MAIN, INTERNAL };
 
 /**
- * @brief Class that handles the timers that monitor the performance of the program during the main loop, and providing information to be printed to the logger/debugger.
+ * @brief Class that handles the timers that monitor the performance of the
+ * program during the main loop, and providing information to be printed to the
+ * logger/debugger.
  */
 class LoopTimers {
 private:
   Timer main_loop_timer;//< Timer for the main iteration loops
   Timer internal_timer; //< Timer for tasks that are internal to one iteration
   // Error to throw when we try to use a timer that doesn't exist
-  void unrecognised_timer() { throw std::runtime_error("Didn't recognise that timer!"); }
+  void unrecognised_timer() {
+    throw std::runtime_error("Didn't recognise that timer!");
+  }
 
 public:
   void start_timer(TimersTrackingLoop timer) {
@@ -72,7 +79,8 @@ public:
         break;
       default:
         unrecognised_timer();
-        // return garbage just to make the compiler happy - the statement above will error so we'll never get here anyway
+        // return garbage just to make the compiler happy - the statement above
+        // will error so we'll never get here anyway
         return -1.;
         break;
     }

--- a/tdms/include/simulation_manager/loop_variables.h
+++ b/tdms/include/simulation_manager/loop_variables.h
@@ -1,7 +1,9 @@
 /**
  * @file loop_variables.h
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Class that handles the setup of variables whose scope is limited to the main simulation loop, but which require complex setup from the inputs and/or outputs.
+ * @brief Class that handles the setup of variables whose scope is limited to
+ * the main simulation loop, but which require complex setup from the inputs
+ * and/or outputs.
  */
 #pragma once
 
@@ -14,23 +16,29 @@
 #include "simulation_manager/objects_from_infile.h"
 
 /**
- * @brief Handles the setup of variables that will be scoped to the main iteration loop, however which require complicated setup from the input objects and potential linking to the output data.
+ * @brief Handles the setup of variables that will be scoped to the main
+ * iteration loop, however which require complicated setup from the input
+ * objects and potential linking to the output data.
  *
- * This setup is handled in the constructor, and the destructor tears down the MATLAB malloc'd memory that we will no longer need after the main loop.
+ * This setup is handled in the constructor, and the destructor tears down the
+ * MATLAB malloc'd memory that we will no longer need after the main loop.
  */
 class LoopVariables {
 private:
-  // Pointers to the MATLAB structure that underlies E_at_previous_iteration, the convergence checker
+  // Pointers to the MATLAB structure that underlies E_at_previous_iteration,
+  // the convergence checker
   mxArray *E_copy_MATLAB_data[3] = {nullptr};
 
   /**
-   * @brief Determine the dispersive properties and setup the corresponding arrays
+   * @brief Determine the dispersive properties and setup the corresponding
+   * arrays
    *
    * @param data The objects and data obtained from the input file
    */
   void setup_dispersive_properties(const ObjectsFromInfile &data);
   /**
-   * @brief Determine if we have a dispersive medium by searching for non-zero attenuation constants in gamma.
+   * @brief Determine if we have a dispersive medium by searching for non-zero
+   * attenuation constants in gamma.
    *
    * @param materials
    * @param IJK_tot Number of Yee cells in each axial direction
@@ -40,18 +48,22 @@ private:
    * @return true, we have a dispersive medium
    * @return false, we do not have a dispersive medium
    */
-  bool is_dispersive_medium(uint8_t ***materials, const IJKDimensions &IJK_tot, double *attenuation_constants,
-                     double dt, double non_zero_tol = 1e-15);
+  bool is_dispersive_medium(uint8_t ***materials, const IJKDimensions &IJK_tot,
+                            double *attenuation_constants, double dt,
+                            double non_zero_tol = 1e-15);
 
   /**
-   * @brief Performs an optimisation step in a 2D simulation (J_tot==0) when we have either TE or TM, but not both.
+   * @brief Performs an optimisation step in a 2D simulation (J_tot==0) when we
+   * have either TE or TM, but not both.
    *
-   * In the J_tot==0 2D version; the 'TE' case involves components Ey, Hx and Hz, whilst the 'TM' case involves components Ex, Ez and Hy.
+   * In the J_tot==0 2D version; the 'TE' case involves components Ey, Hx and
+   * Hz, whilst the 'TM' case involves components Ex, Ez and Hy.
    *
-   * The idea is to use an alternative upper limit to the loop over j when we have J_tot==0. As it stands, we are planning the loops listed below. We use the syntax (k k_min k_max : j j_min j_max : i i_min i_max) to represent the nested for loop:
-   *    for( k = k_min; k < k_max; k++) {
-   *        for( j = j_min; j < j_max; j++) {
-   *            for( i = i_min; i < i_max; i++) {
+   * The idea is to use an alternative upper limit to the loop over j when we
+   * have J_tot==0. As it stands, we are planning the loops listed below. We use
+   * the syntax (k k_min k_max : j j_min j_max : i i_min i_max) to represent the
+   * nested for loop: for( k = k_min; k < k_max; k++) { for( j = j_min; j <
+   * j_max; j++) { for( i = i_min; i < i_max; i++) {
    *            }
    *        }
    *    }
@@ -93,25 +105,34 @@ private:
    * @param data Data and objects obtained from the input file
    * @param non_zero_tol Tolerance at which doubles are considered "non-zero"
    */
-  void optimise_loop_J_range(const ObjectsFromInfile &data, double non_zero_tol = 1e-15);
+  void optimise_loop_J_range(const ObjectsFromInfile &data,
+                             double non_zero_tol = 1e-15);
 
 public:
-  DetectorSensitivityArrays Ex_t, Ey_t;//< temporary storage for detector sensitivity evaluation
+  DetectorSensitivityArrays Ex_t,
+          Ey_t;//< temporary storage for detector sensitivity evaluation
 
-  ElectricField E_at_previous_iteration;//< Stores the phasors at the previous iteration, to check for convergence
+  ElectricField E_at_previous_iteration;//< Stores the phasors at the previous
+                                        // iteration, to check for convergence
 
   ElectricSplitField E_nm1;
-  CurrentDensitySplitField
-          J_c;//< The per-cell ( current density or conductivity ? ) of the material
+  CurrentDensitySplitField J_c;//< The per-cell ( current density or
+                               // conductivity ? ) of the material
   CurrentDensitySplitField J_s, J_nm1;
 
-  bool is_conductive, is_dispersive;//< Whether the materials are dispersive / conductive respectively
+  bool is_conductive,
+          is_dispersive;//< Whether the materials are dispersive / conductive
+                        // respectively
 
-  double refind;//< refractive index of the first layer of the multilayer, or of the bulk of homogeneous
+  double refind;//< refractive index of the first layer of the multilayer, or of
+                // the bulk of homogeneous
 
-  int J_loop_upper_bound;//< Optimised upper bound for main loop over the j-index (see optimise_loop_J_range for details)
-  int J_loop_upper_bound_plus_1;//< One greater than the optimised upper bound for the main loop over the j-index
-  int n_non_pml_cells_in_K;//< Number of non-pml cells in the K-direction (K_tot - Dxl - Dxu)
+  int J_loop_upper_bound;//< Optimised upper bound for main loop over the
+                         // j-index (see optimise_loop_J_range for details)
+  int J_loop_upper_bound_plus_1;//< One greater than the optimised upper bound
+                                // for the main loop over the j-index
+  int n_non_pml_cells_in_K;//< Number of non-pml cells in the K-direction (K_tot
+                           //- Dxl - Dxu)
 
   LoopVariables(const ObjectsFromInfile &data, IJKDimensions E_field_dims);
 

--- a/tdms/include/simulation_manager/objects_from_infile.h
+++ b/tdms/include/simulation_manager/objects_from_infile.h
@@ -1,6 +1,7 @@
 /**
  * @file objects_from_infile.h
- * @brief Classes that unpack variables from the input files the TDMS executable recieves and initalise fields.h and array.h datatypes to store this data.
+ * @brief Classes that unpack variables from the input files the TDMS executable
+ * recieves and initalise fields.h and array.h datatypes to store this data.
  */
 #pragma once
 
@@ -9,9 +10,9 @@
 #include "matrix.h"
 
 #include "arrays.h"
+#include "cell_coordinate.h"
 #include "field.h"
 #include "fieldsample.h"
-#include "cell_coordinate.h"
 #include "globals.h"
 #include "grid_labels.h"
 #include "input_matrices.h"
@@ -22,58 +23,68 @@
 #include "vertex_phasors.h"
 
 /**
- * @brief Class that constructs C++ arrays from an InputMatrices object and the SolverMethod enum.
+ * @brief Class that constructs C++ arrays from an InputMatrices object and the
+ * SolverMethod enum.
  *
- * Arrays that are constructed by this class are independent of one another and other setup parameters - they can simply be read from the InputMatrices object.
+ * Arrays that are constructed by this class are independent of one another and
+ * other setup parameters - they can simply be read from the InputMatrices
+ * object.
  *
- * The ObjectsFromInfile class handles the additional matrices in InputMatrices that are inter-dependent.
+ * The ObjectsFromInfile class handles the additional matrices in InputMatrices
+ * that are inter-dependent.
  *
  */
 class IndependentObjectsFromInfile {
 public:
-  SolverMethod solver_method;//< Either PSTD (default) or FDTD, the solver method
-  int skip_tdf;                //< Either 1 if we are using PSTD, or 6 if using FDTD
+  SolverMethod
+          solver_method;//< Either PSTD (default) or FDTD, the solver method
+  int skip_tdf;         //< Either 1 if we are using PSTD, or 6 if using FDTD
   PreferredInterpolationMethods interpolation_methods =
-          BandLimited;         //< Either band_limited or cubic, the preferred interpolation methods
+          BandLimited;//< Either band_limited or cubic, the preferred
+                      // interpolation methods
 
-  SimulationParameters params; //< The parameters for this simulation
+  SimulationParameters params;//< The parameters for this simulation
 
-  ElectricSplitField E_s;      //< The split electric-field values
-  MagneticSplitField H_s;      //< The split magnetic-field values
+  ElectricSplitField E_s;//< The split electric-field values
+  MagneticSplitField H_s;//< The split magnetic-field values
 
-  uint8_t ***materials;        //< TODO
-  CMaterial Cmaterial;         //< TODO
-  DMaterial Dmaterial;         //< TODO
-  CCollection C;               //< TODO
-  DCollection D;               //< TODO
+  uint8_t ***materials;//< TODO
+  CMaterial Cmaterial; //< TODO
+  DMaterial Dmaterial; //< TODO
+  CCollection C;       //< TODO
+  DCollection D;       //< TODO
 
   double *freespace_Cbx;       //< freespace constants
   double *alpha, *beta, *gamma;//< dispersion parameters
 
-  InterfaceComponent I0, I1, J0, J1, K0, K1;//< user-defined interface components
-  Cuboid cuboid;                            //< user-defined surface to extract phasors over
+  InterfaceComponent I0, I1, J0, J1, K0,
+          K1;   //< user-defined interface components
+  Cuboid cuboid;//< user-defined surface to extract phasors over
 
-  XYZVectors rho_cond;                      //< conductive aux
-  DispersiveMultiLayer matched_layer;       //< dispersive aux
+  XYZVectors rho_cond;               //< conductive aux
+  DispersiveMultiLayer matched_layer;//< dispersive aux
 
-  IncidentField Ei;                         //< time-domain field
+  IncidentField Ei;//< time-domain field
 
-  FrequencyVectors f_vec;                   //< frequency vector
-  Pupil pupil;                              //< TODO
-  DTilde D_tilde;                           //< TODO
-  TDFieldExporter2D ex_td_field_exporter;   //< two-dimensional field exporter
+  FrequencyVectors f_vec;                //< frequency vector
+  Pupil pupil;                           //< TODO
+  DTilde D_tilde;                        //< TODO
+  TDFieldExporter2D ex_td_field_exporter;//< two-dimensional field exporter
 
   GridLabels input_grid_labels;//< cartesian labels of the Yee cells
 
   /* DERIVED VARIABLES FROM INDEPENDENT INPUTS */
 
-  IJKDimensions IJK_tot;//< total number of Yee cells in the x,y,z directions respectively
-  int Nsteps;//< Number of dfts to perform before checking for phasor convergence
+  IJKDimensions IJK_tot;//< total number of Yee cells in the x,y,z directions
+                        // respectively
+  int Nsteps;           //< Number of dfts to perform before checking for phasor
+                        // convergence
 
   IndependentObjectsFromInfile(
           InputMatrices matrices_from_input_file,
           SolverMethod _solver_method = SolverMethod::PseudoSpectral,
-          PreferredInterpolationMethods _pim = PreferredInterpolationMethods::BandLimited);
+          PreferredInterpolationMethods _pim =
+                  PreferredInterpolationMethods::BandLimited);
 
   /** Set the solver method (FDTD / PSTD) and update dependent variables */
   void set_solver_method(SolverMethod _sm) {
@@ -89,7 +100,8 @@ public:
     }
   }
 
-  /** Set the preferred method of interpolation, and update the fields about this change */
+  /** Set the preferred method of interpolation, and update the fields about
+   * this change */
   void set_interpolation_method(PreferredInterpolationMethods _pim) {
     interpolation_methods = _pim;
     E_s.set_preferred_interpolation_methods(interpolation_methods);
@@ -105,22 +117,28 @@ public:
 };
 
 /**
- * @brief Class that handles the creation of C++ arrays from the matrices passed in an InputMatrices object, but also handling interdependencies between inputs from this file.
+ * @brief Class that handles the creation of C++ arrays from the matrices passed
+ * in an InputMatrices object, but also handling interdependencies between
+ * inputs from this file.
  *
- * The Sources, GratingStructure, and FrequencyExtractVector can only be initalised after the other arrays in the input file have been parsed.
+ * The Sources, GratingStructure, and FrequencyExtractVector can only be
+ * initalised after the other arrays in the input file have been parsed.
  *
- * As such, this object inherits the setup of IndependentObjectsFromInfile, and then constructs the aforementioned arrays using a combination of information from the input file and previously mentioned setup.
+ * As such, this object inherits the setup of IndependentObjectsFromInfile, and
+ * then constructs the aforementioned arrays using a combination of information
+ * from the input file and previously mentioned setup.
  */
 class ObjectsFromInfile : public IndependentObjectsFromInfile {
 public:
-    Source Isource, Jsource, Ksource;//< TODO
-    GratingStructure structure;//< TODO
-    FrequencyExtractVector f_ex_vec;//< Vector of frequencies to extract field & phasors at
+  Source Isource, Jsource, Ksource;//< TODO
+  GratingStructure structure;      //< TODO
+  FrequencyExtractVector
+          f_ex_vec;//< Vector of frequencies to extract field & phasors at
 
-    ObjectsFromInfile(
-            InputMatrices matrices_from_input_file,
-            SolverMethod _solver_method = SolverMethod::PseudoSpectral,
-            PreferredInterpolationMethods _pim = PreferredInterpolationMethods::BandLimited);
+  ObjectsFromInfile(InputMatrices matrices_from_input_file,
+                    SolverMethod _solver_method = SolverMethod::PseudoSpectral,
+                    PreferredInterpolationMethods _pim =
+                            PreferredInterpolationMethods::BandLimited);
 
-    ~ObjectsFromInfile();
+  ~ObjectsFromInfile();
 };

--- a/tdms/include/simulation_manager/pstd_variables.h
+++ b/tdms/include/simulation_manager/pstd_variables.h
@@ -1,6 +1,7 @@
 /**
  * @file pstd_variables.h
- * @brief Declares the PSTDVariables class, which handles variables exclusively used in the PSTD solver method
+ * @brief Declares the PSTDVariables class, which handles variables exclusively
+ * used in the PSTD solver method
  */
 #pragma once
 
@@ -10,7 +11,9 @@
 #include "cell_coordinate.h"
 
 /**
- * @brief Handles allocation and tear-down of memory/variables required when running a PSTD simulation. If running an FDTD simulation, none of the member variables of this class are needed.
+ * @brief Handles allocation and tear-down of memory/variables required when
+ * running a PSTD simulation. If running an FDTD simulation, none of the member
+ * variables of this class are needed.
  */
 class PSTDVariables {
 private:
@@ -20,18 +23,22 @@ private:
 public:
   CCoefficientMatrix ca, cb;//< TODO
 
-  // The number of complex fourier coefficients in the derivative-shift operator, for each field component ( N_ex = # coeffs for Ex, for example)
+  // The number of complex fourier coefficients in the derivative-shift
+  // operator, for each field component ( N_ex = # coeffs for Ex, for example)
   int N_ex, N_ey, N_ez, N_hx, N_hy, N_hz;
-  // The coefficients of the PSTD derivative shift operator, for each field component ( dk_ex = coeffs for Ex, for example )
+  // The coefficients of the PSTD derivative shift operator, for each field
+  // component ( dk_ex = coeffs for Ex, for example )
   fftw_complex *dk_ex, *dk_ey, *dk_ez, *dk_hx, *dk_hy, *dk_hz;
 
   PSTDVariables() = default;
   PSTDVariables(const IJKDimensions &IJK_tot) { set_using_dimensions(IJK_tot); }
 
   /**
-   * @brief Allocate memory for PSTD method, for a simulation with the provided number of Yee cells in each dimension.
+   * @brief Allocate memory for PSTD method, for a simulation with the provided
+   * number of Yee cells in each dimension.
    *
-   * @param IJK_tot Triple containing the number of Yee cells in the I,J,K directions
+   * @param IJK_tot Triple containing the number of Yee cells in the I,J,K
+   * directions
    */
   void set_using_dimensions(const IJKDimensions &IJK_tot);
 

--- a/tdms/include/simulation_manager/simulation_manager.h
+++ b/tdms/include/simulation_manager/simulation_manager.h
@@ -1,12 +1,14 @@
 /**
  * @file simulation_manager.h
- * @brief Class that runs the physics of the TDMS executable, and produces an output. Implementation is split between simulation_manager.cpp and execute_simulation.cpp.
+ * @brief Class that runs the physics of the TDMS executable, and produces an
+ * output. Implementation is split between simulation_manager.cpp and
+ * execute_simulation.cpp.
  */
 #pragma once
 
 #include <complex>
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "arrays.h"
 #include "cell_coordinate.h"
@@ -20,24 +22,31 @@
 /**
  * @brief Manages the physics of TDMS and the simulation loop itself.
  *
- * Takes in the contents of the input file and produces the output in the outputs member, so that it can be written to the specified output file.
+ * Takes in the contents of the input file and produces the output in the
+ * outputs member, so that it can be written to the specified output file.
  *
- * Attributes are private to avoid external alterations to their content and potential reassignment of MATLAB pointers, resulting in leaking memory. The outputs can be accessed through a fetch-method within main.cpp if necessary.
+ * Attributes are private to avoid external alterations to their content and
+ * potential reassignment of MATLAB pointers, resulting in leaking memory. The
+ * outputs can be accessed through a fetch-method within main.cpp if necessary.
  */
 class SimulationManager {
 private:
-  ObjectsFromInfile inputs; //< The input objects that are generated from an input file
-  LoopTimers timers;        //< Timers for tracking the execution of the simulation
-  PSTDVariables PSTD;       //< PSTD-solver-specific variables
-  FDTDBootstrapper FDTD;    //< FDTD bootstrapping variables
-  OutputMatrices outputs;   //< Output object that will contain the results of this simulation, given the input file
+  ObjectsFromInfile
+          inputs;    //< The input objects that are generated from an input file
+  LoopTimers timers; //< Timers for tracking the execution of the simulation
+  PSTDVariables PSTD;//< PSTD-solver-specific variables
+  FDTDBootstrapper FDTD; //< FDTD bootstrapping variables
+  OutputMatrices outputs;//< Output object that will contain the results of this
+                         // simulation, given the input file
 
-  PreferredInterpolationMethods pim; //< The interpolation methods to use in this simulation
-  SolverMethod solver_method;        //< The solver method to use in this simulation
+  PreferredInterpolationMethods
+          pim;//< The interpolation methods to use in this simulation
+  SolverMethod solver_method;//< The solver method to use in this simulation
 
   EHVec eh_vec;//< TODO
 
-  double ramp_width = 4.;//< Width of the ramp when introducing the waveform in steady state mode
+  double ramp_width = 4.;//< Width of the ramp when introducing the waveform in
+                         // steady state mode
   /**
    * @brief Evaluates the linear ramp function r(t)
    *
@@ -56,27 +65,32 @@ private:
     return std::min(1., t / (ramp_width * period));
   }
 
-  std::vector<std::complex<double>> E_norm;//< Holds the E-field phasors norm at each extraction frequency
-  std::vector<std::complex<double>> H_norm;//< Holds the H-field phasors norm at each extraction frequency
+  std::vector<std::complex<double>>
+          E_norm;//< Holds the E-field phasors norm at each extraction frequency
+  std::vector<std::complex<double>>
+          H_norm;//< Holds the H-field phasors norm at each extraction frequency
   /**
    * @brief Extracts the phasors norms at the given frequency (index)
    *
-   * @param frequency_index The index of the frequency (in inputs.f_ex_vec) to extract at
+   * @param frequency_index The index of the frequency (in inputs.f_ex_vec) to
+   * extract at
    * @param tind The current timestep
    * @param Nt The number of timesteps in a sinusoidal period
    */
   void extract_phasor_norms(int frequency_index, int tind, int Nt);
 
   /**
-   * @brief Creates MATLAB memory blocks that will be iteratively updated in the execute() method, and assigns array sizes for writing purposes later.
+   * @brief Creates MATLAB memory blocks that will be iteratively updated in the
+   * execute() method, and assigns array sizes for writing purposes later.
    *
    * @param fieldsample The fieldsample input from the input file
    * @param campssample The complex amplitude sample input from the input file
    */
-  void prepare_output(const mxArray *fieldsample, const mxArray* campssample);
+  void prepare_output(const mxArray *fieldsample, const mxArray *campssample);
 
 public:
-  SimulationManager(InputMatrices in_matrices, SolverMethod _solver_method, PreferredInterpolationMethods _pim);
+  SimulationManager(InputMatrices in_matrices, SolverMethod _solver_method,
+                    PreferredInterpolationMethods _pim);
 
   /** @brief Fetch the number of Yee cells in each dimension */
   IJKDimensions n_Yee_cells() { return inputs.IJK_tot; }
@@ -85,19 +99,23 @@ public:
   void execute();
 
   /**
-   * @brief Perform additional (mostly conditional) computations on the outputs, depending on the simulation inputs and run specifications.
+   * @brief Perform additional (mostly conditional) computations on the outputs,
+   * depending on the simulation inputs and run specifications.
    *
    * This should only be run AFTER a successful run of the execute() method.
    */
   void post_loop_processing();
 
   /**
-   * @brief Write the outputs to the file provided. Wrapper for outputs.save_outputs
+   * @brief Write the outputs to the file provided. Wrapper for
+   * outputs.save_outputs
    *
    * @param output_file The filename to write the outputs to
-   * @param compressed_format If true, write compressed output (do not write facets and vertices)
+   * @param compressed_format If true, write compressed output (do not write
+   * facets and vertices)
    */
-  void write_outputs_to_file(std::string output_file, bool compressed_format = false) {
+  void write_outputs_to_file(std::string output_file,
+                             bool compressed_format = false) {
     outputs.save_outputs(output_file, compressed_format);
   }
 };

--- a/tdms/include/simulation_parameters.h
+++ b/tdms/include/simulation_parameters.h
@@ -9,7 +9,8 @@
 #include "arrays.h"
 #include "input_matrices.h"
 
-// Stores the thickness in each axial direction of the Perfectly Matched Layer (pml)
+// Stores the thickness in each axial direction of the Perfectly Matched Layer
+// (pml)
 struct PerfectlyMatchedLayer {
   int Dxl = 0;//< Thickness of lower pml in the x direction
   int Dxu = 0;//< Thickness of upper pml in the x direction
@@ -26,104 +27,109 @@ struct YeeCellDimensions {
   double dz = 0.;//< Yee cell width in the z direction
 };
 
-// Tracks whether the light source is pulsed or the simulation is at steady state
-enum SourceMode{
-  steadystate,
-  pulsed
-};
+// Tracks whether the light source is pulsed or the simulation is at steady
+// state
+enum SourceMode { steadystate, pulsed };
 
-enum RunMode{
-  complete,
-  analyse
-};
+enum RunMode { complete, analyse };
 
 enum Dimension {
   THREE,              //< Full dimensionality - compute all H and E components
-  TRANSVERSE_ELECTRIC,//< Transverse electric - only compute Ex, Ey, and Hz components
-  TRANSVERSE_MAGNETIC //< Transverse magnetic - only compute Hx, Hy, and Ez components
+  TRANSVERSE_ELECTRIC,//< Transverse electric - only compute Ex, Ey, and Hz
+                      // components
+  TRANSVERSE_MAGNETIC //< Transverse magnetic - only compute Hx, Hy, and Ez
+                      // components
 };
 
-// TODO: Reconcile this with the interpolation method toggle! This is already something we can read in from the input file
-enum InterpolationMethod{
-  null,
-  cubic,
-  band_limited
-};
+// TODO: Reconcile this with the interpolation method toggle! This is already
+// something we can read in from the input file
+enum InterpolationMethod { null, cubic, band_limited };
 
 /**
  * A three-tuple of integers that contain the stride in each direction
  * to extract the phasors on. the surface i.e. x = 2 means extract from
  * every 2nd Yee cell.
  */
-struct SurfaceSpacingStride{
+struct SurfaceSpacingStride {
   int x = 1;
   int y = 1;
   int z = 1;
 };
 
 /**
- * @brief Class storing the various constants and behaviour flags for one executation of the tdms executable.
+ * @brief Class storing the various constants and behaviour flags for one
+ * executation of the tdms executable.
  *
- * Stores physical constants like the angular frequency, and Yee cell dimensions.
- * Stores flags like whether the material is dispersive, or whether we want to extract phasors on a predefined surface.
- * Stores numerical method constants like number of timesteps, length of timesteps.
+ * Stores physical constants like the angular frequency, and Yee cell
+ * dimensions. Stores flags like whether the material is dispersive, or whether
+ * we want to extract phasors on a predefined surface. Stores numerical method
+ * constants like number of timesteps, length of timesteps.
  *
  */
-class SimulationParameters{
+class SimulationParameters {
 
 public:
-    SimulationParameters();
+  SimulationParameters();
 
-    double       omega_an      = 0.0;       //< Angular ω
-    unsigned int Nt            = 0;         //< Number of simulation steps
-    unsigned int Np            = 0;         //< Number of times to extract the phasors
-    unsigned int Npe           = 0;         //< Extract the phasors every this number of iterations
-    unsigned int start_tind    = 0;         //< Starting iteration number for the time steps
-    double       dt            = 0.0;       //< Time step
-    bool         has_tdfdir    = false;     //< Is the tdfdir (time domain field directory) defined?
-    bool         is_multilayer = false;     //< Is this simulation of a multilayer?
-    bool         is_disp_ml    = false;     //< Is the material dispersive?
-    double       to_l          = 0.0;       //< Time delay of pulse
-    double       hwhm          = 0.0;       //< Half width at half max of pulse
-    PerfectlyMatchedLayer pml;              //< Perfectly matched layer struct with size attributes
-    bool         exphasorsvolume = false;   //< Should phasors be extracted in the whole volume?
-    bool         exphasorssurface = false;  //< Should phasors be extracted on a surface?
-    bool         intphasorssurface = false; //< Should phasors be extracted/interpolated?
-    RunMode      run_mode     = complete;   //< Run mode
-    SourceMode   source_mode  = pulsed;     //< Source mode
-    Dimension    dimension    = THREE;      //< Dimensions to calculate in
-    bool         is_structure = false;      //< Has a grating structure been defined?
-    bool         exdetintegral = false;     //< TODO: detector sensitivity evaluation ?
-    int          k_det_obs    = 0;          //< TODO: no idea what this is?!
-    double       z_obs        = 0.0;        //< Value of the input grid_labels_z at k_det_obs
-    bool         air_interface_present = false;
-    double       air_interface = 0.0;       //< TODO: what is this?!
-    bool         interp_mat_props = false;  //< Should the material properties be interpolated?
-    InterpolationMethod interp_method = cubic; //< Type of surface field interpolation to do
-    bool         exi_present = false;       //< Is the time dependent x incident field present?
-    bool         eyi_present = false;       //< Is the time dependent y incident field present?
-    SurfaceSpacingStride spacing_stride;    //< Surface stride for extracting phasors (in matlab this is called 'phasorinc')
-    YeeCellDimensions delta;                //< Yee cell dimensions (dx, dy, dz)
+  double omega_an = 0.0;//< Angular ω
+  unsigned int Nt = 0;  //< Number of simulation steps
+  unsigned int Np = 0;  //< Number of times to extract the phasors
+  unsigned int Npe = 0; //< Extract the phasors every this number of iterations
+  unsigned int start_tind = 0;//< Starting iteration number for the time steps
+  double dt = 0.0;            //< Time step
+  bool has_tdfdir =
+          false;//< Is the tdfdir (time domain field directory) defined?
+  bool is_multilayer = false;//< Is this simulation of a multilayer?
+  bool is_disp_ml = false;   //< Is the material dispersive?
+  double to_l = 0.0;         //< Time delay of pulse
+  double hwhm = 0.0;         //< Half width at half max of pulse
+  PerfectlyMatchedLayer
+          pml;//< Perfectly matched layer struct with size attributes
+  bool exphasorsvolume =
+          false;//< Should phasors be extracted in the whole volume?
+  bool exphasorssurface = false;  //< Should phasors be extracted on a surface?
+  bool intphasorssurface = false; //< Should phasors be extracted/interpolated?
+  RunMode run_mode = complete;    //< Run mode
+  SourceMode source_mode = pulsed;//< Source mode
+  Dimension dimension = THREE;    //< Dimensions to calculate in
+  bool is_structure = false;      //< Has a grating structure been defined?
+  bool exdetintegral = false;     //< TODO: detector sensitivity evaluation ?
+  int k_det_obs = 0;              //< TODO: no idea what this is?!
+  double z_obs = 0.0;//< Value of the input grid_labels_z at k_det_obs
+  bool air_interface_present = false;
+  double air_interface = 0.0;//< TODO: what is this?!
+  bool interp_mat_props =
+          false;//< Should the material properties be interpolated?
+  InterpolationMethod interp_method =
+          cubic;           //< Type of surface field interpolation to do
+  bool exi_present = false;//< Is the time dependent x incident field present?
+  bool eyi_present = false;//< Is the time dependent y incident field present?
+  SurfaceSpacingStride spacing_stride;//< Surface stride for extracting phasors
+                                      //(in matlab this is called 'phasorinc')
+  YeeCellDimensions delta;            //< Yee cell dimensions (dx, dy, dz)
 
-    void set_run_mode(std::string mode_string);
+  void set_run_mode(std::string mode_string);
 
-    void set_source_mode(std::string mode_string);
+  void set_source_mode(std::string mode_string);
 
-    void set_dimension(std::string mode_string);
+  void set_dimension(std::string mode_string);
 
-    /**
-     * @brief Set the surface spacing stride.
-     * The x, y, z step size for extracting phasors (in matlab this is called 'phasorinc')
-     * @param vector the x, y, z steps (i.e. x = 2 means extract from every 2nd Yee cell.)
-     */
-    void set_spacing_stride(const double* vector);
+  /**
+   * @brief Set the surface spacing stride.
+   * The x, y, z step size for extracting phasors (in matlab this is called
+   * 'phasorinc')
+   * @param vector the x, y, z steps (i.e. x = 2 means extract from every 2nd
+   * Yee cell.)
+   */
+  void set_spacing_stride(const double *vector);
 
-    void set_Np(FrequencyExtractVector &f_ex_vec);
+  void set_Np(FrequencyExtractVector &f_ex_vec);
 
-    /**
-     * @brief Unpacks all simulation parameters and flags from the matrix inputs the executable recieved.
-     *
-     * @param in_matrices The input arrays from the input file(s) to tdms
-     */
-    void unpack_from_input_matrices(InputMatrices in_matrices);
+  /**
+   * @brief Unpacks all simulation parameters and flags from the matrix inputs
+   * the executable recieved.
+   *
+   * @param in_matrices The input arrays from the input file(s) to tdms
+   */
+  void unpack_from_input_matrices(InputMatrices in_matrices);
 };

--- a/tdms/include/source.h
+++ b/tdms/include/source.h
@@ -7,10 +7,10 @@
 
 #include "mat_io.h"
 
-class Source{
+class Source {
 public:
-  double*** real = nullptr;
-  double*** imag = nullptr;
+  double ***real = nullptr;
+  double ***imag = nullptr;
 
   Source(const mxArray *ptr, int dim1, int dim2, const std::string &name);
 };

--- a/tdms/include/surface_phasors.h
+++ b/tdms/include/surface_phasors.h
@@ -9,7 +9,8 @@
 #include "grid_labels.h"
 
 /**
- * @brief A class that handles the extraction of the phasors on the user-specified surface.
+ * @brief A class that handles the extraction of the phasors on the
+ * user-specified surface.
  *
  * This class stores:
  * - The number of vertices on the surface,
@@ -23,38 +24,48 @@ private:
   int **surface_vertices = nullptr;//< Pointer to the vertices on the surface
   int n_surface_vertices = 0;      //< Number of vertices on the surface
 
-  mxArray *vertex_list = nullptr;         //< List of vertices
-  double **vertex_list_data_ptr = nullptr;//< Buffer to place vertex data into MATLAB array
+  mxArray *vertex_list = nullptr;//< List of vertices
+  double **vertex_list_data_ptr =
+          nullptr;//< Buffer to place vertex data into MATLAB array
 
   mxArray *mx_surface_amplitudes = nullptr;//< Complex surface amplitudes
-  int f_ex_vector_size = 0; //< Number of elements in the frequency extraction vector
+  int f_ex_vector_size =
+          0;//< Number of elements in the frequency extraction vector
 
-  /* Storage for real and imag parts of mx_surface_amplitudes (these can be f_ex_vector_size * n_surface_vertices arrays of FullFieldSnapshots when MATLAB is removed!)
+  /* Storage for real and imag parts of mx_surface_amplitudes (these can be
+  f_ex_vector_size * n_surface_vertices arrays of FullFieldSnapshots when MATLAB
+  is removed!)
 
-  Arrays are index by [frequency_index][field component][vertex_id/number]. Frequency index corresponds to the frequencies at which the user has requested we extract the amplitudes.
+  Arrays are index by [frequency_index][field component][vertex_id/number].
+  Frequency index corresponds to the frequencies at which the user has requested
+  we extract the amplitudes.
   */
   double ***surface_EHr = nullptr, ***surface_EHi = nullptr;
 
 public:
   SurfacePhasors() = default;
   /**
-   * @brief Construct a new Surface Phasors object, using the set_from_matlab_array() method
+   * @brief Construct a new Surface Phasors object, using the
+   * set_from_matlab_array() method
    */
   SurfacePhasors(mxArray *mx_surface_vertices, int _f_ex_vector_size);
   /**
-   * @brief Sets the surface_vertices pointer and number of surface vertices tracker from the MATLAB array passed in
+   * @brief Sets the surface_vertices pointer and number of surface vertices
+   * tracker from the MATLAB array passed in
    *
    * @param mx_surface_vertices MATLAB array containing the vertex information
-   * @param _f_ex_vector_size The FrequencyExtractionVector size, which we need to reserve sufficient memory
+   * @param _f_ex_vector_size The FrequencyExtractionVector size, which we need
+   * to reserve sufficient memory
    */
-  void set_from_matlab_array(mxArray *mx_surface_vertices, int f_ex_vector_size);
+  void set_from_matlab_array(mxArray *mx_surface_vertices,
+                             int f_ex_vector_size);
 
   /**
    * @brief Zeros the surface_EH{r,i} arrays
    */
   void zero_surface_EH() {
     for (int k = 0; k < f_ex_vector_size; k++) {
-      for(int j = 0; j < 6; j++) { // 6 field components: Ex, y, z, and Hx, y, z
+      for (int j = 0; j < 6; j++) {// 6 field components: Ex, y, z, and Hx, y, z
         for (int i = 0; i < n_surface_vertices; i++) {
           surface_EHr[k][j][i] = 0.;
           surface_EHi[k][j][i] = 0.;
@@ -79,52 +90,63 @@ public:
   mxArray *get_mx_surface_amplitudes() { return mx_surface_amplitudes; };
 
   /**
-   * @brief Normalise the surface amplitudes at frequency_vector_index by the E- and H-norms provided.
+   * @brief Normalise the surface amplitudes at frequency_vector_index by the E-
+   * and H-norms provided.
    *
    * E-field components in surface_EH are divided by the (complex) Enorm.
    * H-field components in surface_EH are divided by the (complex) Hnorm.
    *
-   * @param frequency_vector_index Frequency index, surface_EH{r,i}[frequency_vector_index] will be normalised
+   * @param frequency_vector_index Frequency index,
+   * surface_EH{r,i}[frequency_vector_index] will be normalised
    * @param Enorm,Hnorm The {E,H}-norm to normalise the {E,H}-components by
    */
-  void normalise_surface(int frequency_index, std::complex<double> Enorm, std::complex<double> Hnorm);
+  void normalise_surface(int frequency_index, std::complex<double> Enorm,
+                         std::complex<double> Hnorm);
 
   /**
-   * @brief Extract the phasor values at the vertices on the surface, for the given frequency index
+   * @brief Extract the phasor values at the vertices on the surface, for the
+   * given frequency index
    *
-   * @param frequency_index The entries in surface_EH{r,i}[frequency_index] will be written to
+   * @param frequency_index The entries in surface_EH{r,i}[frequency_index] will
+   * be written to
    * @param E,H The electric,magnetic field
    * @param n Current timestep index
    * @param omega Angular frequency
    * @param Nt The number of timesteps in a sinusoidal period
    * @param params The parameters for this simulation
-   * @param interpolate If true, perform interpolation on the fields when extracting phasors
+   * @param interpolate If true, perform interpolation on the fields when
+   * extracting phasors
    */
   void extractPhasorsSurface(int frequency_index, ElectricSplitField &E,
                              MagneticSplitField &H, int n, double omega, int Nt,
-                             SimulationParameters &params, bool interpolate = true);
+                             SimulationParameters &params,
+                             bool interpolate = true);
 
   /**
-   * @brief Pulls the GridLabels information of vertices on the surface into vertex_list, a continuous block of memory.
+   * @brief Pulls the GridLabels information of vertices on the surface into
+   * vertex_list, a continuous block of memory.
    *
-   * The vertex_list attribute will consist only of vertices that lie on the surface that the given class instance defines.
+   * The vertex_list attribute will consist only of vertices that lie on the
+   * surface that the given class instance defines.
    *
    * @param input_grid_labels
    */
   void create_vertex_list(GridLabels input_grid_labels);
 
   /**
-   * @brief Incriments surface_EH{r,i} at the given index by the field values provided.
+   * @brief Incriments surface_EH{r,i} at the given index by the field values
+   * provided.
    *
-   * If we allow element-wise assignment, we are essentially performing the operations:
-   * surface_EHr[frequency_vector_index][:][vertex_index] += F.real(),
-   * surface_EHi[frequency_vector_index][:][vertex_index] += F.imag().
+   * If we allow element-wise assignment, we are essentially performing the
+   * operations: surface_EHr[frequency_vector_index][:][vertex_index] +=
+   * F.real(), surface_EHi[frequency_vector_index][:][vertex_index] += F.imag().
    *
    * @param frequency_index Frequency vector index (k) to assign to
    * @param vertex_index Vertex index (i) to assign to
    * @param F Field values to assign
    */
-  void update_surface_EH(int frequency_index, int vertex_index, FullFieldSnapshot F);
+  void update_surface_EH(int frequency_index, int vertex_index,
+                         FullFieldSnapshot F);
 
   ~SurfacePhasors();
 };

--- a/tdms/include/timer.h
+++ b/tdms/include/timer.h
@@ -6,18 +6,18 @@
 /**
  * @brief Stopwatch class.
  */
-class Timer{
+class Timer {
 
-    double start_time; //< start time in seconds
-    double end_time;   //< end time in seconds
+  double start_time;//< start time in seconds
+  double end_time;  //< end time in seconds
 
 public:
-    /** Starts the stopwatch */
-    void start();
-    /** Stops the stopwatch */
-    void end();
-    /** Log the difference in time and reset the timer */
-    void click();
-    /** Time difference */
-    double delta_seconds() const;
+  /** Starts the stopwatch */
+  void start();
+  /** Stops the stopwatch */
+  void end();
+  /** Log the difference in time and reset the timer */
+  void click();
+  /** Time difference */
+  double delta_seconds() const;
 };

--- a/tdms/include/utils.h
+++ b/tdms/include/utils.h
@@ -10,7 +10,7 @@
  * @param filename The name of the file to check.
  * @param mode The mode to try and open with.
  */
-void assert_can_open_file(const char* filename, const char* mode);
+void assert_can_open_file(const char *filename, const char *mode);
 
 /**
  * @brief Check two strings are equal
@@ -20,7 +20,7 @@ void assert_can_open_file(const char* filename, const char* mode);
  * @return true if the strings are the same
  * @return false otherwise
  */
-bool are_equal(const char* a, const char* b);
+bool are_equal(const char *a, const char *b);
 
 std::string to_string(char c);
 

--- a/tdms/include/vertex_phasors.h
+++ b/tdms/include/vertex_phasors.h
@@ -1,6 +1,7 @@
 /**
  * @file vertex_phasors.h
- * @brief Contains a class that handles the complex amplitude extraction at the vertices.
+ * @brief Contains a class that handles the complex amplitude extraction at the
+ * vertices.
  */
 #pragma once
 
@@ -11,33 +12,46 @@
 #include "grid_labels.h"
 
 /**
- * Class container for handling complex amplitude samples at the vertices, and their extraction.
+ * Class container for handling complex amplitude samples at the vertices, and
+ * their extraction.
  *
  * Abbreviated to CAmpSample in MATLAB code
  */
 class VertexPhasors {
 private:
   /* n_vertices()-by-3 int array.
-  Each "row" corresponds to the index of a vertex at which to extract the field components requested.
+  Each "row" corresponds to the index of a vertex at which to extract the field
+  components requested.
   */
   Vertices vertices;
-  /* An int array containing the MATLAB indices of the field components we want to extract at the vertices.
+  /* An int array containing the MATLAB indices of the field components we want
+  to extract at the vertices.
 
-  The ints in this array correspond to the underlying values of the FieldComponents enum:
-  components = [1, 2, 6] corresponds to extracting Ex, Ey, and Hz at the vertices, for example.
+  The ints in this array correspond to the underlying values of the
+  FieldComponents enum: components = [1, 2, 6] corresponds to extracting Ex, Ey,
+  and Hz at the vertices, for example.
   */
   FieldComponentsVector components;
 
   mxArray *mx_camplitudes = nullptr;//< Complex amplitudes at the vertices
-  int f_ex_vector_size = 0;         //< Number of elements in the frequency extraction vector
+  int f_ex_vector_size =
+          0;//< Number of elements in the frequency extraction vector
 
-  /* Storage for real and imag parts of mx_surface_amplitudes (these can be f_ex_vector_size * n_surface_vertices arrays of FullFieldSnapshots when MATLAB is removed!)
+  /* Storage for real and imag parts of mx_surface_amplitudes (these can be
+  f_ex_vector_size * n_surface_vertices arrays of FullFieldSnapshots when MATLAB
+  is removed!)
 
-  Arrays are index by [frequency_index][field_component_position][vertex_id/number].
+  Arrays are index by
+  [frequency_index][field_component_position][vertex_id/number].
 
-  frequency_index corresponds to the frequencies at which the user has requested we extract the amplitudes.
+  frequency_index corresponds to the frequencies at which the user has requested
+  we extract the amplitudes.
 
-  field_component_position corresponds to components.index(field_component) of the field_component we are interested it. Since the user might not request consecutive components for extraction (EG [Ex, Ey, Hz] would correspond to [1, 2, 6]) we need to be able to convert these MATLAB indices -> consecutive indices for storage here.
+  field_component_position corresponds to components.index(field_component) of
+  the field_component we are interested it. Since the user might not request
+  consecutive components for extraction (EG [Ex, Ey, Hz] would correspond to [1,
+  2, 6]) we need to be able to convert these MATLAB indices -> consecutive
+  indices for storage here.
   */
   double ***camplitudesR = nullptr, ***camplitudesI = nullptr;
 
@@ -48,7 +62,8 @@ public:
   /**
    * @brief Setup using data from an input file
    *
-   * @param ptr Pointer to the struct containing the list of vertices and components to extract phasors at/for
+   * @param ptr Pointer to the struct containing the list of vertices and
+   * components to extract phasors at/for
    */
   void set_from(const mxArray *ptr);
 
@@ -57,9 +72,12 @@ public:
   /**
    * @brief Allocate memory for the camplitude{R,I} arrays.
    *
-   * Provided there are vertices for us to extract at, allocates the memory for the camplitude{R,I} arrays and creates the mx_camplitudes pointer to the output data.
+   * Provided there are vertices for us to extract at, allocates the memory for
+   * the camplitude{R,I} arrays and creates the mx_camplitudes pointer to the
+   * output data.
    *
-   * @param n_frequencies The number of frequencies at which we need to extract phasors
+   * @param n_frequencies The number of frequencies at which we need to extract
+   * phasors
    */
   void setup_complex_amplitude_arrays(int n_frequencies);
 
@@ -69,47 +87,58 @@ public:
   int n_components() { return components.size(); }
   // Returns true/false based on whether there are/aren't vertices to extract at
   bool there_are_vertices_to_extract_at() { return (n_vertices() > 0); }
-  // Returns true/false based on whether there are/aren't elements in BOTH the vertices and components arrays
-  bool there_are_elements_in_arrays() { return (vertices.has_elements() && components.has_elements()); }
+  // Returns true/false based on whether there are/aren't elements in BOTH the
+  // vertices and components arrays
+  bool there_are_elements_in_arrays() {
+    return (vertices.has_elements() && components.has_elements());
+  }
 
   /**
-   * @brief Normalise the surface amplitudes at frequency_vector_index by the E- and H-norms provided.
+   * @brief Normalise the surface amplitudes at frequency_vector_index by the E-
+   * and H-norms provided.
    *
    * E-field components in camplitudes{R,I} are divided by the (complex) Enorm.
    * H-field components in camplitudes{R,I} are divided by the (complex) Hnorm.
    *
-   * @param frequency_index Frequency index, camplitudes{R,I}[frequency_index] will be normalised
+   * @param frequency_index Frequency index, camplitudes{R,I}[frequency_index]
+   * will be normalised
    * @param Enorm,Hnorm The {E,H}-norm to normalise the {E,H}-components by
    */
   void normalise_vertices(int frequency_index, std::complex<double> Enorm,
                           std::complex<double> Hnorm);
 
   /**
-   * @brief Extract the phasor values at the vertices on the surface, for the given frequency index
+   * @brief Extract the phasor values at the vertices on the surface, for the
+   * given frequency index
    *
-   * @param frequency_index The entries in camplitudes{R,I}[frequency_index] will be written to
+   * @param frequency_index The entries in camplitudes{R,I}[frequency_index]
+   * will be written to
    * @param E,H The electric,magnetic split field
    * @param n Current timestep index
    * @param omega Angular frequency
    * @param params The parameters for this simulation
    */
-  void extractPhasorsVertices(int frequency_index, ElectricSplitField &E, MagneticSplitField &H,
-                              int n, double omega, SimulationParameters &params);
+  void extractPhasorsVertices(int frequency_index, ElectricSplitField &E,
+                              MagneticSplitField &H, int n, double omega,
+                              SimulationParameters &params);
 
   /**
-   * @brief Incriments camplitudes{R,I} at the given index by the field values provided.
+   * @brief Incriments camplitudes{R,I} at the given index by the field values
+   * provided.
    *
-   * If we allow element-wise assignment, we are essentially performing the operations:
-   * camplitudesR[frequency_index][:][vertex_index] += F.real(),
+   * If we allow element-wise assignment, we are essentially performing the
+   * operations: camplitudesR[frequency_index][:][vertex_index] += F.real(),
    * camplitudesI[frequency_index][:][vertex_index] += F.imag().
    *
-   * Only field components that we are extracting at the vertices are pulled out of F.
+   * Only field components that we are extracting at the vertices are pulled out
+   * of F.
    *
    * @param frequency_index Frequency index
    * @param vertex_index Vertex index
    * @param F Field values to assign
    */
-  void update_vertex_camplitudes(int frequency_index, int vertex_index, FullFieldSnapshot F);
+  void update_vertex_camplitudes(int frequency_index, int vertex_index,
+                                 FullFieldSnapshot F);
 
   ~VertexPhasors();
 };

--- a/tdms/matlab/.clang-format
+++ b/tdms/matlab/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/tdms/matlabio/matlabio.cpp
+++ b/tdms/matlabio/matlabio.cpp
@@ -2,102 +2,110 @@
 
 using namespace std;
 
-double****cast_matlab_4D_array(double *array, int nrows, int ncols, int nlayers, int nblocks){
+double ****cast_matlab_4D_array(double *array, int nrows, int ncols,
+                                int nlayers, int nblocks) {
   double ****p;
-  int j,k,l;
+  int j, k, l;
 
-  if( nlayers==0 )
-	  nlayers++;
+  if (nlayers == 0) nlayers++;
 
-  if( nblocks==0 )
-	  nblocks++;
+  if (nblocks == 0) nblocks++;
 
-  p = (double ****)malloc((unsigned) (nblocks*sizeof(double ***)));
-  for(l=0; l<nblocks; l++)
-    p[l] = (double ***)malloc((unsigned) (nlayers*sizeof(double **)));
+  p = (double ****) malloc((unsigned) (nblocks * sizeof(double ***)));
+  for (l = 0; l < nblocks; l++)
+    p[l] = (double ***) malloc((unsigned) (nlayers * sizeof(double **)));
 
-  for(l=0; l<nblocks; l++)
-    for(k =0; k<nlayers;k++)
-      p[l][k] = (double **)malloc((unsigned) (ncols*sizeof(double *)));
+  for (l = 0; l < nblocks; l++)
+    for (k = 0; k < nlayers; k++)
+      p[l][k] = (double **) malloc((unsigned) (ncols * sizeof(double *)));
 
-  for(l=0; l<nblocks; l++)
-    for(k =0; k<nlayers;k++)
-      for(j =0; j<ncols;j++)
-	p[l][k][j] = (array + l*nrows*ncols*nlayers + k*nrows*ncols + j*nrows);
+  for (l = 0; l < nblocks; l++)
+    for (k = 0; k < nlayers; k++)
+      for (j = 0; j < ncols; j++)
+        p[l][k][j] = (array + l * nrows * ncols * nlayers + k * nrows * ncols +
+                      j * nrows);
   return p;
-
 }
 
-void free_cast_matlab_4D_array(double ****castArray, int nlayers, int nblocks){
-  for(int l =0; l<nblocks; l++)
-    for(int k =0; k<nlayers;k++)
-      free(castArray[l][k]);
+void free_cast_matlab_4D_array(double ****castArray, int nlayers, int nblocks) {
+  for (int l = 0; l < nblocks; l++)
+    for (int k = 0; k < nlayers; k++) free(castArray[l][k]);
 
-  for(int l =0; l<nblocks; l++)
-    free(castArray[l]);
+  for (int l = 0; l < nblocks; l++) free(castArray[l]);
   free(castArray);
 }
 
-void assert_is_struct(const mxArray* ptr, const std::string &name){
+void assert_is_struct(const mxArray *ptr, const std::string &name) {
   if (!mxIsStruct(ptr)) {
-    throw runtime_error("Pointer " + name + " was expected to be a structure but was not");
+    throw runtime_error("Pointer " + name +
+                        " was expected to be a structure but was not");
   }
 }
 
-void assert_num_fields_equals(int num, const mxArray* ptr, const std::string &name){
+void assert_num_fields_equals(int num, const mxArray *ptr,
+                              const std::string &name) {
 
   auto num_fields = mxGetNumberOfFields(ptr);
 
   if (num_fields != num) {
-    throw runtime_error(name + " should have " + to_string(num) + " members, it has "
-                        + to_string(num_fields));
+    throw runtime_error(name + " should have " + to_string(num) +
+                        " members, it has " + to_string(num_fields));
   }
 }
 
-void assert_is_struct_with_n_fields(const mxArray* ptr, int num, const std::string &name){
+void assert_is_struct_with_n_fields(const mxArray *ptr, int num,
+                                    const std::string &name) {
   assert_is_struct(ptr, name);
   assert_num_fields_equals(num, ptr, name);
 }
 
-mxArray* ptr_to_nd_array_in(const mxArray* ptr, int n, const std::string &name, const std::string &struct_name){
+mxArray *ptr_to_nd_array_in(const mxArray *ptr, int n, const std::string &name,
+                            const std::string &struct_name) {
   auto element = mxGetField((mxArray *) ptr, 0, name.c_str());
 
-  // mxGetField returns NULL if the field does not exist. Prevent SEG faults by catching and throwing
+  // mxGetField returns NULL if the field does not exist. Prevent SEG faults by
+  // catching and throwing
   if (element == NULL) {
-    throw runtime_error("Field " + name + " does not exist in struct " + struct_name);
+    throw runtime_error("Field " + name + " does not exist in struct " +
+                        struct_name);
   } else if (mxGetNumberOfDimensions(element) != n) {
-    throw runtime_error("Incorrect dimension on " + struct_name + "." + name + ". Required " +
-                        to_string(n) + "D");
+    throw runtime_error("Incorrect dimension on " + struct_name + "." + name +
+                        ". Required " + to_string(n) + "D");
   }
   return element;
 }
 
-mxArray* ptr_to_matrix_in(const mxArray* ptr, const string &name, const string &struct_name){
+mxArray *ptr_to_matrix_in(const mxArray *ptr, const string &name,
+                          const string &struct_name) {
   return ptr_to_nd_array_in(ptr, 2, name, struct_name);
 }
 
-mxArray* ptr_to_vector_in(const mxArray* ptr, const string &name, const string &struct_name){
+mxArray *ptr_to_vector_in(const mxArray *ptr, const string &name,
+                          const string &struct_name) {
 
   auto element = ptr_to_matrix_in(ptr, name, struct_name);
 
   if (mxGetDimensions(element)[0] != 1) {
-    throw runtime_error("Incorrect dimension " + struct_name + "." + name + ". Required 1D");
+    throw runtime_error("Incorrect dimension " + struct_name + "." + name +
+                        ". Required 1D");
   }
   return element;
 }
 
-mxArray* ptr_to_vector_or_empty_in(const mxArray* ptr, const string &name, const string &struct_name){
+mxArray *ptr_to_vector_or_empty_in(const mxArray *ptr, const string &name,
+                                   const string &struct_name) {
 
   auto element = ptr_to_matrix_in(ptr, name, struct_name);
   auto n = mxGetDimensions(element)[0];
 
   if (!(n == 1 || n == 0)) {
-    throw runtime_error("Incorrect dimension on " + struct_name + "." + name + ". Required 1D or 0D");
+    throw runtime_error("Incorrect dimension on " + struct_name + "." + name +
+                        ". Required 1D or 0D");
   }
   return element;
 }
 
-double double_in(const mxArray* ptr, const string &name){
+double double_in(const mxArray *ptr, const string &name) {
 
   if (mxIsDouble(ptr) && mxGetNumberOfElements(ptr) == 1) {
     return *mxGetPr(ptr);
@@ -105,17 +113,17 @@ double double_in(const mxArray* ptr, const string &name){
   throw runtime_error(name + " was expected to be a double but was not");
 }
 
-int int_cast_from_double_in(const mxArray* ptr, const std::string &name){
+int int_cast_from_double_in(const mxArray *ptr, const std::string &name) {
   return (int) double_in(ptr, name);
 }
 
-bool bool_cast_from_double_in(const mxArray* ptr, const std::string &name){
+bool bool_cast_from_double_in(const mxArray *ptr, const std::string &name) {
   return !mxIsEmpty(ptr) && (bool) double_in(ptr, name);
 }
 
 string string_in(const mxArray *ptr, const string &name) {
 
-  if (mxIsChar(ptr)){
+  if (mxIsChar(ptr)) {
     auto n = 1 + (int) mxGetNumberOfElements(ptr);
     auto c_str = (char *) malloc(n * sizeof(char));
     mxGetString(ptr, c_str, n);

--- a/tdms/matlabio/matlabio.h
+++ b/tdms/matlabio/matlabio.h
@@ -12,7 +12,8 @@
 #include "mat_io.h"
 
 /**
- * Casts a 4-dimensional array such that it may be indexed according to the usual array indexing
+ * Casts a 4-dimensional array such that it may be indexed according to the
+ usual array indexing
  * scheme array[l,k,j,i].
  * @param array is a pointer to a matlab 4 dimensional array
 
@@ -21,7 +22,8 @@
  * @param nlayers the number of layers, each of dimension nrows*ncols
  * @param nblocks the number of blocks, each of dimension nrows*ncols*nlayers
  */
-double**** cast_matlab_4D_array(double *array, int nrows, int ncols, int nlayers, int nblocks);
+double ****cast_matlab_4D_array(double *array, int nrows, int ncols,
+                                int nlayers, int nblocks);
 
 /**
  * Frees the memory of a 4-dimensional array cast using cast_matlab_4D_array
@@ -29,7 +31,8 @@ double**** cast_matlab_4D_array(double *array, int nrows, int ncols, int nlayers
 void free_cast_matlab_4D_array(double ****castArray, int nlayers, int nblocks);
 
 /**
- * Casts a 3-dimensional array such that it may be indexed according to the usual array indexing
+ * Casts a 3-dimensional array such that it may be indexed according to the
+ usual array indexing
  * scheme array[k,j,i].
  * @param array is a pointer to a matlab 3 dimensional array
 
@@ -38,17 +41,17 @@ void free_cast_matlab_4D_array(double ****castArray, int nlayers, int nblocks);
  * @param nlayers the number of layers, each of dimension nrows*ncols
  */
 template<typename T, typename S>
-T*** cast_matlab_3D_array(T *array, S nrows, S ncols, S nlayers){
+T ***cast_matlab_3D_array(T *array, S nrows, S ncols, S nlayers) {
   T ***p;
   nlayers = std::max(nlayers, S(1));
-  p = (T ***)malloc((unsigned) (nlayers*sizeof(T **)));
+  p = (T ***) malloc((unsigned) (nlayers * sizeof(T **)));
 
-  for(S k =0; k<nlayers; k++){
-    p[k] = (T **)malloc((unsigned) (ncols*sizeof(T *)));
+  for (S k = 0; k < nlayers; k++) {
+    p[k] = (T **) malloc((unsigned) (ncols * sizeof(T *)));
   }
-  for(S k =0; k<nlayers; k++)
-    for(S j =0; j<ncols; j++){
-      p[k][j] = (array + k*nrows*ncols+ j*nrows);
+  for (S k = 0; k < nlayers; k++)
+    for (S j = 0; j < ncols; j++) {
+      p[k][j] = (array + k * nrows * ncols + j * nrows);
     }
 
   return p;
@@ -58,14 +61,14 @@ T*** cast_matlab_3D_array(T *array, S nrows, S ncols, S nlayers){
  * Frees the memory of a 3-dimensional array cast using cast_matlab_3D_array
  */
 template<typename T, typename S>
-void free_cast_matlab_3D_array(T ***castArray, S nlayers){
-  for(S k=0; k<nlayers; k++)
-    free(castArray[k]);
+void free_cast_matlab_3D_array(T ***castArray, S nlayers) {
+  for (S k = 0; k < nlayers; k++) free(castArray[k]);
   free(castArray);
 }
 
 /**
- * Casts a 2-dimensional array such that it may be indexed according to the usual array indexing
+ * Casts a 2-dimensional array such that it may be indexed according to the
+ usual array indexing
  * scheme array[j,i].
  * @param array is a pointer to a matlab 4 dimensional array
 
@@ -73,56 +76,61 @@ void free_cast_matlab_3D_array(T ***castArray, S nlayers){
  * @param ncols the number of columns in the array
  */
 template<typename T, typename S>
-T** cast_matlab_2D_array(T *array, S nrows, S ncols){
+T **cast_matlab_2D_array(T *array, S nrows, S ncols) {
 
   T **p;
-  p = (T **)malloc((unsigned) (ncols*sizeof(T *)));
+  p = (T **) malloc((unsigned) (ncols * sizeof(T *)));
 
-  for(S j =0; j<ncols;j++){
-    p[j] = (array + j*nrows);
-  }
+  for (S j = 0; j < ncols; j++) { p[j] = (array + j * nrows); }
   return p;
 };
 
 template<typename T>
-void free_cast_matlab_2D_array(T **castArray){
+void free_cast_matlab_2D_array(T **castArray) {
   free(castArray);
 }
 
-void assert_is_struct(const mxArray* ptr, const std::string &name);
+void assert_is_struct(const mxArray *ptr, const std::string &name);
 
-void assert_num_fields_equals(int num, const mxArray* ptr, const std::string &name);
+void assert_num_fields_equals(int num, const mxArray *ptr,
+                              const std::string &name);
 
-void assert_is_struct_with_n_fields(const mxArray* ptr, int num, const std::string &name);
+void assert_is_struct_with_n_fields(const mxArray *ptr, int num,
+                                    const std::string &name);
 
 /**
- * Get a pointer to a tensor/array within a struct with a given name. Throws a runtime error if the
- * resulting tensor is not n dimensional.
+ * Get a pointer to a tensor/array within a struct with a given name. Throws a
+ * runtime error if the resulting tensor is not n dimensional.
  * @param ptr Pointer to the struct
  * @param n Dimensionality of the tensor
  * @param name Name of the attribute
  * @param struct_name Name of the struct
  * @return Pointer to the matrix
  */
-mxArray* ptr_to_nd_array_in(const mxArray* ptr, int n, const std::string &name, const std::string &struct_name);
+mxArray *ptr_to_nd_array_in(const mxArray *ptr, int n, const std::string &name,
+                            const std::string &struct_name);
 
-mxArray* ptr_to_matrix_in(const mxArray* ptr, const std::string &name, const std::string &struct_name);
+mxArray *ptr_to_matrix_in(const mxArray *ptr, const std::string &name,
+                          const std::string &struct_name);
 
-mxArray* ptr_to_vector_in(const mxArray* ptr, const std::string &name, const std::string &struct_name);
+mxArray *ptr_to_vector_in(const mxArray *ptr, const std::string &name,
+                          const std::string &struct_name);
 
-mxArray* ptr_to_vector_or_empty_in(const mxArray* ptr, const std::string &name, const std::string &struct_name);
+mxArray *ptr_to_vector_or_empty_in(const mxArray *ptr, const std::string &name,
+                                   const std::string &struct_name);
 
 /**
  * Get a double defined in a matlab array given as a pointer
  * @param ptr Pointer to a matlab array
- * @param name Name of the value, for helpful thrown exceptions if the pointer is not to a double
+ * @param name Name of the value, for helpful thrown exceptions if the pointer
+ * is not to a double
  * @return Value of the double
  */
-double double_in(const mxArray* ptr, const std::string &name);
+double double_in(const mxArray *ptr, const std::string &name);
 
-int int_cast_from_double_in(const mxArray* ptr, const std::string &name);
+int int_cast_from_double_in(const mxArray *ptr, const std::string &name);
 
-bool bool_cast_from_double_in(const mxArray* ptr, const std::string &name);
+bool bool_cast_from_double_in(const mxArray *ptr, const std::string &name);
 
 /**
  * Get the (C++) string defined in a matlab array given as a pointer
@@ -130,4 +138,4 @@ bool bool_cast_from_double_in(const mxArray* ptr, const std::string &name);
  * @param name Name of the field which this pointer corresponds to
  * @return The string
  */
-std::string string_in(const mxArray* ptr, const std::string &name);
+std::string string_in(const mxArray *ptr, const std::string &name);

--- a/tdms/src/argument_parser.cpp
+++ b/tdms/src/argument_parser.cpp
@@ -13,62 +13,68 @@ ArgumentNamespace ArgumentParser::parse_args(int n_args, char *arg_ptrs[]) {
 
   auto args = ArgumentNamespace(n_args, arg_ptrs);
 
-  if (args.have_flag("-h")){
+  if (args.have_flag("-h")) {
     print_help_message();
     exit(0);
   }
 
-  if (args.have_flag("-q")){  // quiet operation
+  if (args.have_flag("-q")) {// quiet operation
     spdlog::set_level(spdlog::level::off);
   }
 
-  if (!args.have_correct_number_of_filenames()){
-    fprintf(stderr,"Incorrect number of arguments. See below for help\n\n");
+  if (!args.have_correct_number_of_filenames()) {
+    fprintf(stderr, "Incorrect number of arguments. See below for help\n\n");
     print_help_message();
     exit(-1);
   }
 
-  // write name of output file to log - input files will be logged when read from
+  // write name of output file to log - input files will be logged when read
+  // from
   spdlog::info("Output file specified: {0:s}", args.output_filename());
 
   spdlog::debug("Finished parsing arguments");
   return args;
 }
 
-void ArgumentParser::print_help_message(){
-  fprintf(stdout,"Usage:\n"
-                 "tdms [options] infile outfile\n"
-                 "tdms [options] infile gridfile outfile\n"
-                 "Options:\n"
-                 "-h:\tDisplay this help message\n"
-                 "-fd, --finite-difference:\tUse the finite-difference solver, instead of the pseudo-spectral method.\n"
-                 "-c, --cubic-interpolation:\tUse cubic interpolation to determine field values at Yee cell centres, as opposed to band-limited interpolation.\n"
-                 "-q:\tQuiet operation. Silence all logging\n"
-                 "-m:\tMinimise output file size by not saving vertex and facet information\n\n");
+void ArgumentParser::print_help_message() {
+  fprintf(stdout,
+          "Usage:\n"
+          "tdms [options] infile outfile\n"
+          "tdms [options] infile gridfile outfile\n"
+          "Options:\n"
+          "-h:\tDisplay this help message\n"
+          "-fd, --finite-difference:\tUse the finite-difference solver, "
+          "instead of the "
+          "pseudo-spectral method.\n"
+          "-c, --cubic-interpolation:\tUse cubic interpolation to determine "
+          "field values "
+          "at Yee cell centres, as opposed to band-limited interpolation.\n"
+          "-q:\tQuiet operation. Silence all logging\n"
+          "-m:\tMinimise output file size by not saving vertex and facet "
+          "information\n\n");
 }
 
 ArgumentNamespace::ArgumentNamespace(int n_args, char *arg_ptrs[]) {
 
   arguments = std::vector<std::string>(arg_ptrs + 1, arg_ptrs + n_args);
 
-  for (const auto& arg: arguments){
+  for (const auto &arg : arguments) {
 
-    if (!is_a_flag_argument(arg)){
+    if (!is_a_flag_argument(arg)) {
       non_flag_arguments.push_back(arg);
       num_non_flag++;
     }
   }
-
 }
 
-bool ArgumentNamespace::is_a_flag_argument(std::string arg){
+bool ArgumentNamespace::is_a_flag_argument(std::string arg) {
   return arg[0] == '-';
 }
 
 bool ArgumentNamespace::have_flag(std::string const &flag) const {
 
-  for (const auto& arg : arguments){
-    if(arg == flag) return true;
+  for (const auto &arg : arguments) {
+    if (arg == flag) return true;
   }
 
   return false;
@@ -82,54 +88,49 @@ bool ArgumentNamespace::cubic_interpolation() const {
   return this->have_flag("-c") || this->have_flag("--cubic-interpolation");
 }
 
-const char* ArgumentNamespace::output_filename() {
+const char *ArgumentNamespace::output_filename() {
 
-  if (has_grid_filename()){
+  if (has_grid_filename()) {
     return non_flag_arguments[2].c_str();
-  } else if (num_non_flag == 2){
+  } else if (num_non_flag == 2) {
     return non_flag_arguments[1].c_str();
   }
 
-  throw std::runtime_error("Failed to determine the output file from arguments");
+  throw std::runtime_error(
+          "Failed to determine the output file from arguments");
 }
 
-const char* ArgumentNamespace::grid_filename() {
+const char *ArgumentNamespace::grid_filename() {
 
-  if (num_non_flag == 3){
-    return non_flag_arguments[1].c_str();
-  }
+  if (num_non_flag == 3) { return non_flag_arguments[1].c_str(); }
 
   throw std::runtime_error("Failed to determine the grid file from arguments");
 }
 
-const char* ArgumentNamespace::input_filename() {
+const char *ArgumentNamespace::input_filename() {
 
-  if (num_non_flag > 0){
-    return non_flag_arguments[0].c_str();
-  }
+  if (num_non_flag > 0) { return non_flag_arguments[0].c_str(); }
 
   throw std::runtime_error("Failed to determine the input file from arguments");
 }
 
-bool ArgumentNamespace::has_grid_filename() const {
-  return num_non_flag == 3;
-}
+bool ArgumentNamespace::has_grid_filename() const { return num_non_flag == 3; }
 
 vector<string> ArgumentNamespace::input_filenames() {
 
   vector<string> filenames;
 
   filenames.emplace_back(input_filename());
-  if (has_grid_filename()){
-    filenames.emplace_back(grid_filename());
-  }
+  if (has_grid_filename()) { filenames.emplace_back(grid_filename()); }
 
   return filenames;
 }
 
 void ArgumentNamespace::check_files_can_be_accessed() {
   // check input files can be read from
-  for (const auto &filename : input_filenames()) { assert_can_open_file(filename.c_str(), "r"); }
+  for (const auto &filename : input_filenames()) {
+    assert_can_open_file(filename.c_str(), "r");
+  }
   // check output file can be written to
   assert_can_open_file(output_filename(), "a+");
 }

--- a/tdms/src/array_init.cpp
+++ b/tdms/src/array_init.cpp
@@ -7,14 +7,17 @@
 using namespace std;
 
 
-void init_grid_arrays(const mxArray *ptr, SplitField &E_s, SplitField &H_s, uint8_t*** &materials){
+void init_grid_arrays(const mxArray *ptr, SplitField &E_s, SplitField &H_s,
+                      uint8_t ***&materials) {
 
-  const char elements[][15] = {"Exy", "Exz", "Eyx", "Eyz", "Ezx", "Ezy",
-                               "Hxy", "Hxz", "Hyx", "Hyz", "Hzx", "Hzy", "materials"};
+  const char elements[][15] = {"Exy", "Exz", "Eyx",      "Eyz", "Ezx",
+                               "Ezy", "Hxy", "Hxz",      "Hyx", "Hyz",
+                               "Hzx", "Hzy", "materials"};
 
   auto num_fields = mxGetNumberOfFields(ptr);
   if (num_fields != 13) {
-    throw runtime_error("fdtdgrid should have 13 members, it only has " + to_string(num_fields));
+    throw runtime_error("fdtdgrid should have 13 members, it only has " +
+                        to_string(num_fields));
   }
 
   for (int i = 0; i < num_fields; i++) {
@@ -26,29 +29,48 @@ void init_grid_arrays(const mxArray *ptr, SplitField &E_s, SplitField &H_s, uint
     }
 
     auto ndims = mxGetNumberOfDimensions(element);
-    if (ndims != 2 && ndims != 3){
-      throw runtime_error("field matrix %s should be 2- or 3-dimensional " + element_name);
+    if (ndims != 2 && ndims != 3) {
+      throw runtime_error("field matrix %s should be 2- or 3-dimensional " +
+                          element_name);
     }
 
     auto dims = Dimensions(element);
-    auto tensor = cast_matlab_3D_array(mxGetPr(element), dims[0], dims[1], dims[2]);
+    auto tensor =
+            cast_matlab_3D_array(mxGetPr(element), dims[0], dims[1], dims[2]);
 
-    if (are_equal(elements[i], "Exy")) { E_s.xy.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Exz")) { E_s.xz.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Eyx")) { E_s.yx.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Eyz")) { E_s.yz.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Ezx")) { E_s.zx.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Ezy")) { E_s.zy.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hxy")) { H_s.xy.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hxz")) { H_s.xz.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hyx")) { H_s.yx.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hyz")) { H_s.yz.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hzx")) { H_s.zx.initialise_from_matlab(tensor, dims);
-    } else if (are_equal(elements[i], "Hzy")) { H_s.zy.initialise_from_matlab(tensor, dims);
+    if (are_equal(elements[i], "Exy")) {
+      E_s.xy.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Exz")) {
+      E_s.xz.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Eyx")) {
+      E_s.yx.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Eyz")) {
+      E_s.yz.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Ezx")) {
+      E_s.zx.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Ezy")) {
+      E_s.zy.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hxy")) {
+      H_s.xy.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hxz")) {
+      H_s.xz.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hyx")) {
+      H_s.yx.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hyz")) {
+      H_s.yz.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hzx")) {
+      H_s.zx.initialise_from_matlab(tensor, dims);
+    } else if (are_equal(elements[i], "Hzy")) {
+      H_s.zy.initialise_from_matlab(tensor, dims);
     } else if (are_equal(elements[i], "materials")) {
-      materials = cast_matlab_3D_array((uint8_t *) mxGetPr(element), dims[0], dims[1], dims[2]);
-      E_s.tot.i = H_s.tot.i = dims[0] - 1; // The _tot variables do NOT include the additional cell
-      E_s.tot.j = H_s.tot.j = dims[1] - 1; // at the edge of the grid which is only partially used
+      materials = cast_matlab_3D_array((uint8_t *) mxGetPr(element), dims[0],
+                                       dims[1], dims[2]);
+      E_s.tot.i = H_s.tot.i =
+              dims[0] -
+              1;// The _tot variables do NOT include the additional cell
+      E_s.tot.j = H_s.tot.j =
+              dims[1] -
+              1;// at the edge of the grid which is only partially used
       E_s.tot.k = H_s.tot.k = dims[2] - 1;
     } else {
       throw runtime_error("element fdtdgrid.%s not handled " + element_name);

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -1,7 +1,7 @@
 #include "arrays.h"
 
-#include <spdlog/spdlog.h>
 #include <iostream>
+#include <spdlog/spdlog.h>
 #include <utility>
 
 #include "globals.h"
@@ -10,25 +10,47 @@
 using namespace std;
 using namespace tdms_math_constants;
 
-void XYZVectors::set_ptr(const char c, double* ptr){
+void XYZVectors::set_ptr(const char c, double *ptr) {
   switch (c) {
-    case 'x': {x = ptr; break;}
-    case 'y': {y = ptr; break;}
-    case 'z': {z = ptr; break;}
-    default: throw std::runtime_error("Have no element " + to_string(c));
+    case 'x': {
+      x = ptr;
+      break;
+    }
+    case 'y': {
+      y = ptr;
+      break;
+    }
+    case 'z': {
+      z = ptr;
+      break;
+    }
+    default:
+      throw std::runtime_error("Have no element " + to_string(c));
   }
 }
-void XYZVectors::set_ptr(AxialDirection d, double* ptr){
+void XYZVectors::set_ptr(AxialDirection d, double *ptr) {
   switch (d) {
-    case AxialDirection::X: {x = ptr; break;}
-    case AxialDirection::Y: {y = ptr; break;}
-    case AxialDirection::Z: {z = ptr; break;}
-    default: throw std::runtime_error("Have no element " + to_string(d));
+    case AxialDirection::X: {
+      x = ptr;
+      break;
+    }
+    case AxialDirection::Y: {
+      y = ptr;
+      break;
+    }
+    case AxialDirection::Z: {
+      z = ptr;
+      break;
+    }
+    default:
+      throw std::runtime_error("Have no element " + to_string(d));
   }
 }
 
-bool XYZVectors::all_elements_less_than(double comparison_value, int vector_length,
-                                        AxialDirection component, int buffer_start) const {
+bool XYZVectors::all_elements_less_than(double comparison_value,
+                                        int vector_length,
+                                        AxialDirection component,
+                                        int buffer_start) const {
   double *component_pointer;
   switch (component) {
     case AxialDirection::X:
@@ -45,14 +67,23 @@ bool XYZVectors::all_elements_less_than(double comparison_value, int vector_leng
       break;
   }
   for (int index = buffer_start; index < vector_length; index++) {
-    if (component_pointer[buffer_start + index] > comparison_value) { return false; }
+    if (component_pointer[buffer_start + index] > comparison_value) {
+      return false;
+    }
   }
   return true;
 }
-bool XYZVectors::all_elements_less_than(double comparison_value, int nx, int ny, int nz) const {
-  if (!all_elements_less_than(comparison_value, nx, AxialDirection::X)) { return false; }
-  if (!all_elements_less_than(comparison_value, ny, AxialDirection::Y)) { return false; }
-  if (!all_elements_less_than(comparison_value, nz, AxialDirection::Z)) { return false; }
+bool XYZVectors::all_elements_less_than(double comparison_value, int nx, int ny,
+                                        int nz) const {
+  if (!all_elements_less_than(comparison_value, nx, AxialDirection::X)) {
+    return false;
+  }
+  if (!all_elements_less_than(comparison_value, ny, AxialDirection::Y)) {
+    return false;
+  }
+  if (!all_elements_less_than(comparison_value, nz, AxialDirection::Z)) {
+    return false;
+  }
   return true;
 }
 
@@ -65,7 +96,9 @@ CMaterial::CMaterial(const mxArray *ptr) {
   init_xyz_vectors(ptr, c, "Cc");
 }
 
-void MaterialCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const string &prefix) {
+void MaterialCollection::init_xyz_vectors(const mxArray *ptr,
+                                          XYZVectors &arrays,
+                                          const string &prefix) {
 
   for (char component : {'x', 'y', 'z'}) {
     auto element = ptr_to_vector_in(ptr, prefix + component, "material");
@@ -73,12 +106,16 @@ void MaterialCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays
   }
 }
 
-void CCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const string &prefix) {
+void CCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays,
+                                   const string &prefix) {
 
   for (char component : {'x', 'y', 'z'}) {
 
     auto element = ptr_to_matrix_in(ptr, prefix + component, "C");
-    is_multilayer = mxGetDimensions(element)[0] != 1; // this only matters when we check the 'z' component right? No point re-setting it each time when it's not used? TODO: check this.
+    is_multilayer = mxGetDimensions(element)[0] !=
+                    1;// this only matters when we check the 'z' component
+                      // right? No point re-setting it each time when it's not
+                      // used? TODO: check this.
     arrays.set_ptr(component, mxGetPr(element));
   }
 }
@@ -87,7 +124,8 @@ CCollection::CCollection(const mxArray *ptr) {
 
   auto num_fields = mxGetNumberOfFields(ptr);
   if (num_fields != 6 && num_fields != 9) {
-    throw runtime_error("C should have 6 or 9 members, it has " + to_string(num_fields));
+    throw runtime_error("C should have 6 or 9 members, it has " +
+                        to_string(num_fields));
   }
 
   init_xyz_vectors(ptr, a, "Ca");
@@ -115,7 +153,8 @@ DCollection::DCollection(const mxArray *ptr) {
   init_xyz_vectors(ptr, b, "Db");
 }
 
-void DCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const string &prefix) {
+void DCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays,
+                                   const string &prefix) {
 
   for (char component : {'x', 'y', 'z'}) {
     auto element = ptr_to_matrix_in(ptr, prefix + component, "D");
@@ -125,9 +164,7 @@ void DCollection::init_xyz_vectors(const mxArray *ptr, XYZVectors &arrays, const
 
 DispersiveMultiLayer::DispersiveMultiLayer(const mxArray *ptr) {
 
-  if (mxIsEmpty(ptr)) {
-    return;
-  }
+  if (mxIsEmpty(ptr)) { return; }
   assert_is_struct_with_n_fields(ptr, 9, "dispersive_aux");
 
   alpha = mxGetPr(ptr_to_vector_in(ptr, "alpha", "dispersive_aux"));
@@ -141,7 +178,8 @@ DispersiveMultiLayer::DispersiveMultiLayer(const mxArray *ptr) {
   sigma.z = mxGetPr(ptr_to_matrix_in(ptr, "sigma_z", "dispersive_aux"));
 }
 
-bool DispersiveMultiLayer::is_dispersive(int K_tot, double near_zero_tolerance) {
+bool DispersiveMultiLayer::is_dispersive(int K_tot,
+                                         double near_zero_tolerance) {
   for (int i = 0; i < K_tot; i++) {
     if (fabs(gamma[i]) > near_zero_tolerance) {
       // non-zero attenuation constant of a Yee cell implies media is dispersive
@@ -153,12 +191,11 @@ bool DispersiveMultiLayer::is_dispersive(int K_tot, double near_zero_tolerance) 
 
 GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
 
-  if (mxIsEmpty(ptr)) {
-    return;
-  }
+  if (mxIsEmpty(ptr)) { return; }
 
   auto dims = mxGetDimensions(ptr);
-  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != 2 || dims[1] != (I_tot + 1)){
+  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != 2 ||
+      dims[1] != (I_tot + 1)) {
     throw runtime_error("structure should have dimension 2 x (I_tot+1) ");
   }
 
@@ -171,7 +208,8 @@ GratingStructure::~GratingStructure() {
   matrix = nullptr;
 }
 
-FrequencyExtractVector::FrequencyExtractVector(const mxArray *ptr, double omega_an) {
+FrequencyExtractVector::FrequencyExtractVector(const mxArray *ptr,
+                                               double omega_an) {
 
   if (mxIsEmpty(ptr)) {
     n = 1;
@@ -182,7 +220,7 @@ FrequencyExtractVector::FrequencyExtractVector(const mxArray *ptr, double omega_
     auto dims = mxGetDimensions(ptr);
     auto n_dims = mxGetNumberOfDimensions(ptr);
 
-    if (n_dims != 2 || !(dims[0] == 1 || dims[1] == 1)){
+    if (n_dims != 2 || !(dims[0] == 1 || dims[1] == 1)) {
       throw runtime_error("f_ex_vec should be a vector with N>0 elements");
     }
     // compute the number of elements prior to displaying
@@ -194,17 +232,13 @@ FrequencyExtractVector::FrequencyExtractVector(const mxArray *ptr, double omega_
 
 double FrequencyExtractVector::max() {
   double tmp = -DBL_MAX;
-  for (int i = 0; i < n; i++){
-    tmp = std::max(tmp, vector[i]);
-  }
+  for (int i = 0; i < n; i++) { tmp = std::max(tmp, vector[i]); }
   return tmp;
 }
 
-void FrequencyVectors::initialise(const mxArray *ptr){
+void FrequencyVectors::initialise(const mxArray *ptr) {
 
-  if (mxIsEmpty(ptr)) {
-    return;
-  }
+  if (mxIsEmpty(ptr)) { return; }
 
   assert_is_struct_with_n_fields(ptr, 2, "f_vec");
   x = Vector<double>(ptr_to_vector_in(ptr, "fx_vec", "f_vec"));
@@ -213,15 +247,14 @@ void FrequencyVectors::initialise(const mxArray *ptr){
 
 void Pupil::initialise(const mxArray *ptr, int n_rows, int n_cols) {
 
-  if (mxIsEmpty(ptr)){
-    return;
-  }
+  if (mxIsEmpty(ptr)) { return; }
 
-  auto dims = (int *)mxGetDimensions(ptr);
+  auto dims = (int *) mxGetDimensions(ptr);
 
-  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != n_rows || dims[1] != n_cols){
-    throw runtime_error("Pupil has dimension "+ to_string(dims[0]) + "x"
-                        + to_string(dims[1]) + " but it needed to be " +
+  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != n_rows ||
+      dims[1] != n_cols) {
+    throw runtime_error("Pupil has dimension " + to_string(dims[0]) + "x" +
+                        to_string(dims[1]) + " but it needed to be " +
                         to_string(n_rows) + "x" + to_string(n_cols));
   }
 
@@ -235,30 +268,35 @@ Pupil::~Pupil() {
   matrix = nullptr;
 }
 
-void DTilde::set_component(Tensor3D<complex<double>> &tensor, const mxArray *ptr, const string &name,
-                           int n_rows, int n_cols){
+void DTilde::set_component(Tensor3D<complex<double>> &tensor,
+                           const mxArray *ptr, const string &name, int n_rows,
+                           int n_cols) {
 
   auto element = ptr_to_nd_array_in(ptr, 3, name, "D_tilde");
 
-  auto dims = (int *)mxGetDimensions(element);
+  auto dims = (int *) mxGetDimensions(element);
   int n_det_modes = dims[0];
 
-  if (dims[1] != n_rows || dims[2] != n_cols){
-    throw runtime_error("D_tilde.{x, y} has final dimensions "+ to_string(dims[1]) + "x"
-                        + to_string(dims[2]) + " but it needed to be " +
-                        to_string(n_rows) + "x" + to_string(n_cols));
+  if (dims[1] != n_rows || dims[2] != n_cols) {
+    throw runtime_error("D_tilde.{x, y} has final dimensions " +
+                        to_string(dims[1]) + "x" + to_string(dims[2]) +
+                        " but it needed to be " + to_string(n_rows) + "x" +
+                        to_string(n_cols));
   }
 
   auto p = (complex<double> ***) malloc(sizeof(complex<double> **) * n_cols);
   for (int j = 0; j < n_cols; j++) {
     p[j] = (complex<double> **) malloc(sizeof(complex<double> *) * n_rows);
     for (int i = 0; i < n_rows; i++) {
-      p[j][i] = (complex<double> *) malloc(sizeof(complex<double>) * n_det_modes);
+      p[j][i] =
+              (complex<double> *) malloc(sizeof(complex<double>) * n_det_modes);
     }
   }
 
-  auto temp_re = cast_matlab_3D_array(mxGetPr(element), dims[0], dims[1], dims[2]);
-  auto temp_im = cast_matlab_3D_array(mxGetPi(element), dims[0], dims[1], dims[2]);
+  auto temp_re =
+          cast_matlab_3D_array(mxGetPr(element), dims[0], dims[1], dims[2]);
+  auto temp_im =
+          cast_matlab_3D_array(mxGetPi(element), dims[0], dims[1], dims[2]);
 
   for (int k = 0; k < n_det_modes; k++)
     for (int j = 0; j < n_cols; j++)
@@ -273,17 +311,17 @@ void DTilde::set_component(Tensor3D<complex<double>> &tensor, const mxArray *ptr
 
 void DTilde::initialise(const mxArray *ptr, int n_rows, int n_cols) {
 
-  if (mxIsEmpty(ptr)){
-    return;
-  }
+  if (mxIsEmpty(ptr)) { return; }
 
   assert_is_struct_with_n_fields(ptr, 2, "D_tilde");
   set_component(x, ptr, "Dx_tilde", n_rows, n_cols);
   set_component(y, ptr, "Dy_tilde", n_rows, n_cols);
-  n_det_modes = mxGetDimensions(ptr_to_nd_array_in(ptr, 3, "Dx_tilde", "D_tilde"))[0];
+  n_det_modes =
+          mxGetDimensions(ptr_to_nd_array_in(ptr, 3, "Dx_tilde", "D_tilde"))[0];
 }
 
-void IncidentField::set_component(Tensor3D<double> &component, const mxArray *ptr, const std::string &name){
+void IncidentField::set_component(Tensor3D<double> &component,
+                                  const mxArray *ptr, const std::string &name) {
 
   if (mxIsEmpty(mxGetField(ptr, 0, name.c_str()))) {
     spdlog::info("{} not present", name);
@@ -293,13 +331,16 @@ void IncidentField::set_component(Tensor3D<double> &component, const mxArray *pt
   auto element = ptr_to_nd_array_in(ptr, 3, name, "tdfield");
   auto dims = mxGetDimensions(element);
   int N = dims[0], M = dims[1], O = dims[2];
-  component.initialise(cast_matlab_3D_array(mxGetPr(element), N, M, O), O, M, N);
+  component.initialise(cast_matlab_3D_array(mxGetPr(element), N, M, O), O, M,
+                       N);
   component.is_matlab_initialised = true;
 
-  cerr << "Got tdfield, dims=("+to_string(N)+","+to_string(M)+","+to_string(O)+")" << endl;
+  cerr << "Got tdfield, dims=(" + to_string(N) + "," + to_string(M) + "," +
+                  to_string(O) + ")"
+       << endl;
 }
 
-IncidentField::IncidentField(const mxArray *ptr){
+IncidentField::IncidentField(const mxArray *ptr) {
 
   assert_is_struct_with_n_fields(ptr, 2, "tdfield");
   set_component(x, ptr, "exi");
@@ -309,9 +350,7 @@ IncidentField::IncidentField(const mxArray *ptr){
 void FieldComponentsVector::initialise(const mxArray *ptr) {
 
   auto element = ptr_to_matrix_in(ptr, "components", "campssample");
-  if (mxIsEmpty(element)){
-    return;
-  }
+  if (mxIsEmpty(element)) { return; }
 
   auto dims = mxGetDimensions(element);
   vector = (int *) mxGetPr((mxArray *) element);
@@ -320,7 +359,7 @@ void FieldComponentsVector::initialise(const mxArray *ptr) {
 
 int FieldComponentsVector::index(int value) {
 
-  for (int i = 0; i < n; i++){
+  for (int i = 0; i < n; i++) {
     if (vector[i] == value) return i;
   }
 
@@ -330,25 +369,21 @@ int FieldComponentsVector::index(int value) {
 void Vertices::initialise(const mxArray *ptr) {
 
   auto element = ptr_to_matrix_in(ptr, "vertices", "campssample");
-  if (mxIsEmpty(element)){
-    return;
-  }
+  if (mxIsEmpty(element)) { return; }
 
   auto dims = mxGetDimensions(element);
   int n_vertices = n_rows = dims[0];
   n_cols = dims[1];
 
-  if (n_cols != 3){
+  if (n_cols != 3) {
     throw runtime_error("Second dimension in campssample.vertices must be 3");
   }
 
   spdlog::info("Found vertices ({0:d} x 3)", n_vertices);
-  matrix = cast_matlab_2D_array((int *)mxGetPr(element), n_vertices, n_cols);
+  matrix = cast_matlab_2D_array((int *) mxGetPr(element), n_vertices, n_cols);
 
-  for (int j = 0; j < n_vertices; j++)   // decrement index for MATLAB->C indexing
-    for (int k = 0; k < n_cols; k++) {
-      matrix[k][j] -= 1;
-    }
+  for (int j = 0; j < n_vertices; j++)// decrement index for MATLAB->C indexing
+    for (int k = 0; k < n_cols; k++) { matrix[k][j] -= 1; }
 }
 
 void DetectorSensitivityArrays::initialise(int n_rows, int n_cols) {
@@ -369,7 +404,7 @@ DetectorSensitivityArrays::~DetectorSensitivityArrays() {
 }
 
 EHVec::~EHVec() {
-  if (has_elements()){
+  if (has_elements()) {
     for (int i = 0; i < n_rows; i++) fftw_free(matrix[i]);
     free(matrix);
   }

--- a/tdms/src/dimensions.cpp
+++ b/tdms/src/dimensions.cpp
@@ -8,10 +8,14 @@ using namespace std;
 
 int Dimensions::operator[](int value) const {
   switch (value) {
-    case 0: return i;
-    case 1: return j;
-    case 2: return k;
-    default: throw runtime_error("Have no element " + to_string(value));
+    case 0:
+      return i;
+    case 1:
+      return j;
+    case 2:
+      return k;
+    default:
+      throw runtime_error("Have no element " + to_string(value));
   }
 }
 
@@ -20,14 +24,16 @@ Dimensions::Dimensions(const mxArray *ptr) {
   auto n_dims = mxGetNumberOfDimensions(ptr);
   auto raw_dims = mxGetDimensions(ptr);
 
-  if (n_dims > 3){
-    throw runtime_error("Cannot initialise more than 3D");
-  }
+  if (n_dims > 3) { throw runtime_error("Cannot initialise more than 3D"); }
 
   switch (n_dims) {
-    case 3: k = raw_dims[2];
-    case 2: j = raw_dims[1];
-    case 1: i = raw_dims[0];
-    default: break;
+    case 3:
+      k = raw_dims[2];
+    case 2:
+      j = raw_dims[1];
+    case 1:
+      i = raw_dims[0];
+    default:
+      break;
   }
 }

--- a/tdms/src/fdtd_grid_initialiser.cpp
+++ b/tdms/src/fdtd_grid_initialiser.cpp
@@ -1,12 +1,13 @@
 #include "fdtd_grid_initialiser.h"
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
 using namespace std;
 
 
-fdtdGridInitialiser::fdtdGridInitialiser(const mxArray *fdtd_pointer, const char* fdtd_filename) {
+fdtdGridInitialiser::fdtdGridInitialiser(const mxArray *fdtd_pointer,
+                                         const char *fdtd_filename) {
   pointer = fdtd_pointer;
   mat_filename = fdtd_filename;
 
@@ -18,32 +19,33 @@ fdtdGridInitialiser::fdtdGridInitialiser(const mxArray *fdtd_pointer, const char
 /**
  * Get a value from a integer attribute of fdtdgrid defined in a .mat file
  */
-mwSize fdtdGridInitialiser::value_of_attribute(const string& key){
+mwSize fdtdGridInitialiser::value_of_attribute(const string &key) {
 
 
-  if( mxGetFieldNumber( (mxArray *)pointer, key.c_str()) == -1 ){
-    throw runtime_error(string(mat_filename)+" missing field fdtdgrid."+key);
+  if (mxGetFieldNumber((mxArray *) pointer, key.c_str()) == -1) {
+    throw runtime_error(string(mat_filename) + " missing field fdtdgrid." +
+                        key);
   }
-  auto element = mxGetField( (mxArray *)pointer, 0, key.c_str());
+  auto element = mxGetField((mxArray *) pointer, 0, key.c_str());
 
-  if (element == nullptr){
-    throw runtime_error("Failed to find "+key+" in fdtdgrid");
+  if (element == nullptr) {
+    throw runtime_error("Failed to find " + key + " in fdtdgrid");
   }
 
   auto value = (mwSize) (*mxGetPr(element));
-  mxRemoveField((mxArray *)pointer, mxGetFieldNumber(pointer, key.c_str()));
+  mxRemoveField((mxArray *) pointer, mxGetFieldNumber(pointer, key.c_str()));
 
   return value;
 }
 
-void fdtdGridInitialiser::add_tensor(const string &name){
+void fdtdGridInitialiser::add_tensor(const string &name) {
 
-  mxAddField((mxArray *)pointer, name.c_str());
+  mxAddField((mxArray *) pointer, name.c_str());
 
-  auto element = mxGetField((mxArray *)pointer, 0, name.c_str());
-  element = mxCreateNumericArray((const mwSize)dimensions.size(),
-                                 (const mwSize *)&dimensions.front(),
+  auto element = mxGetField((mxArray *) pointer, 0, name.c_str());
+  element = mxCreateNumericArray((const mwSize) dimensions.size(),
+                                 (const mwSize *) &dimensions.front(),
                                  mxDOUBLE_CLASS, mxREAL);
 
-  mxSetField(( mxArray *)pointer, 0, name.c_str(), element);
+  mxSetField((mxArray *) pointer, 0, name.c_str(), element);
 }

--- a/tdms/src/fields/electric.cpp
+++ b/tdms/src/fields/electric.cpp
@@ -6,29 +6,31 @@
 using namespace std;
 using namespace tdms_math_constants;
 
-double ElectricField::phase(int n, double omega, double dt){
+double ElectricField::phase(int n, double omega, double dt) {
   return omega * ((double) n + 1) * dt;
 }
 
-void ElectricField::interpolate_transverse_electric_components(CellCoordinate cell, complex<double> *x_at_centre,
-                                              complex<double> *y_at_centre,
-                                              complex<double> *z_at_centre) {
+void ElectricField::interpolate_transverse_electric_components(
+        CellCoordinate cell, complex<double> *x_at_centre,
+        complex<double> *y_at_centre, complex<double> *z_at_centre) {
   *x_at_centre = interpolate_to_centre_of(AxialDirection::X, cell);
   *y_at_centre = interpolate_to_centre_of(AxialDirection::Y, cell);
   *z_at_centre = complex<double>(0., 0.);
 }
-void ElectricField::interpolate_transverse_magnetic_components(CellCoordinate cell, complex<double> *x_at_centre,
-                                              complex<double> *y_at_centre,
-                                              complex<double> *z_at_centre) {
+void ElectricField::interpolate_transverse_magnetic_components(
+        CellCoordinate cell, complex<double> *x_at_centre,
+        complex<double> *y_at_centre, complex<double> *z_at_centre) {
   *x_at_centre = complex<double>(0., 0.);
   *y_at_centre = complex<double>(0., 0.);
   *z_at_centre = interpolate_to_centre_of(AxialDirection::Z, cell);
 }
 
-complex<double> ElectricField::interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) {
+complex<double> ElectricField::interpolate_to_centre_of(AxialDirection d,
+                                                        CellCoordinate cell) {
   const InterpolationScheme *scheme;
   int i = cell.i, j = cell.j, k = cell.k;
-  // prepare input data - if using a cubic scheme we have reserved more memory than necessary but nevermind
+  // prepare input data - if using a cubic scheme we have reserved more memory
+  // than necessary but nevermind
   complex<double> interp_data[8];
 
   switch (d) {
@@ -36,27 +38,36 @@ complex<double> ElectricField::interpolate_to_centre_of(AxialDirection d, CellCo
       // determine the interpolation scheme to use
       scheme = &(best_scheme(tot.i, i, pim));
       // now fill the interpolation data
-      // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell that plays the role of v0 in the interpolation
-      for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
+      // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell
+      // that plays the role of v0 in the interpolation
+      for (int ind = scheme->first_nonzero_coeff;
+           ind <= scheme->last_nonzero_coeff; ind++) {
         interp_data[ind] =
                 real.x[k][j][i - scheme->number_of_datapoints_to_left + ind] +
-                IMAGINARY_UNIT * imag.x[k][j][i - scheme->number_of_datapoints_to_left + ind];
+                IMAGINARY_UNIT *
+                        imag.x[k][j]
+                              [i - scheme->number_of_datapoints_to_left + ind];
       }
       break;
     case Y:
-      // if we are in a 2D simulation, we just return the field value at cell (i, 0, k) since there is no y-dimension to interpolate in.
+      // if we are in a 2D simulation, we just return the field value at cell
+      // (i, 0, k) since there is no y-dimension to interpolate in.
       if (tot.j <= 1) {
         return complex<double>(real.y[k][0][i], imag.y[k][0][i]);
-      } else { // 3D simulation, interpolation is as normal
+      } else {// 3D simulation, interpolation is as normal
         // determine the interpolation scheme to use
         scheme = &(best_scheme(tot.j, j, pim));
 
         // now fill the interpolation data
-        // j - scheme.number_of_datapoints_to_left is the index of the Yee cell that plays the role of v0 in the interpolation
-        for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
+        // j - scheme.number_of_datapoints_to_left is the index of the Yee cell
+        // that plays the role of v0 in the interpolation
+        for (int ind = scheme->first_nonzero_coeff;
+             ind <= scheme->last_nonzero_coeff; ind++) {
           interp_data[ind] =
                   real.y[k][j - scheme->number_of_datapoints_to_left + ind][i] +
-                  IMAGINARY_UNIT * imag.y[k][j - scheme->number_of_datapoints_to_left + ind][i];
+                  IMAGINARY_UNIT *
+                          imag.y[k][j - scheme->number_of_datapoints_to_left +
+                                    ind][i];
         }
       }
       break;
@@ -65,50 +76,64 @@ complex<double> ElectricField::interpolate_to_centre_of(AxialDirection d, CellCo
       scheme = &(best_scheme(tot.k, k, pim));
 
       // now fill the interpolation data
-      // k - scheme.number_of_datapoints_to_left is the index of the Yee cell that plays the role of v0 in the interpolation
-      for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
+      // k - scheme.number_of_datapoints_to_left is the index of the Yee cell
+      // that plays the role of v0 in the interpolation
+      for (int ind = scheme->first_nonzero_coeff;
+           ind <= scheme->last_nonzero_coeff; ind++) {
         interp_data[ind] =
                 real.z[k - scheme->number_of_datapoints_to_left + ind][j][i] +
-                IMAGINARY_UNIT * imag.z[k - scheme->number_of_datapoints_to_left + ind][j][i];
+                IMAGINARY_UNIT *
+                        imag.z[k - scheme->number_of_datapoints_to_left + ind]
+                              [j][i];
       }
       break;
     default:
-      throw runtime_error("Invalid axial direction selected for interpolation!\n");
+      throw runtime_error(
+              "Invalid axial direction selected for interpolation!\n");
       break;
   }
   // now run the interpolation scheme and place the result into the output
   return scheme->interpolate(interp_data);
 }
 
-double ElectricSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) {
+double ElectricSplitField::interpolate_to_centre_of(AxialDirection d,
+                                                    CellCoordinate cell) {
   const InterpolationScheme *scheme;
   int i = cell.i, j = cell.j, k = cell.k;
-  // prepare input data - if using a cubic scheme we have reserved more memory than necessary but nevermind
+  // prepare input data - if using a cubic scheme we have reserved more memory
+  // than necessary but nevermind
   double interp_data[8];
 
   switch (d) {
     case X:
       scheme = &(best_scheme(tot.i, i, pim));
       // now fill the interpolation data
-      // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell that plays the role of v0 in the interpolation
-      for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
-        interp_data[ind] = xy[k][j][i - scheme->number_of_datapoints_to_left + ind] +
-                           xz[k][j][i - scheme->number_of_datapoints_to_left + ind];
+      // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell
+      // that plays the role of v0 in the interpolation
+      for (int ind = scheme->first_nonzero_coeff;
+           ind <= scheme->last_nonzero_coeff; ind++) {
+        interp_data[ind] =
+                xy[k][j][i - scheme->number_of_datapoints_to_left + ind] +
+                xz[k][j][i - scheme->number_of_datapoints_to_left + ind];
       }
       // now run the interpolation scheme and place the result into the output
       return scheme->interpolate(interp_data);
       break;
     case Y:
-      // if we are in a 2D simulation, we just return the field value at cell (i, 0, k) since there is no y-dimension to interpolate in.
+      // if we are in a 2D simulation, we just return the field value at cell
+      // (i, 0, k) since there is no y-dimension to interpolate in.
       if (tot.j <= 1) {
         return yx[k][0][i] + yz[k][0][i];
       } else {// 3D simulation, interpolation is as normal
         scheme = &(best_scheme(tot.j, j, pim));
         // now fill the interpolation data
-        // j - scheme.number_of_datapoints_to_left is the index of the Yee cell that plays the role of v0 in the interpolation
-        for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
-          interp_data[ind] = yx[k][j - scheme->number_of_datapoints_to_left + ind][i] +
-                             yz[k][j - scheme->number_of_datapoints_to_left + ind][i];
+        // j - scheme.number_of_datapoints_to_left is the index of the Yee cell
+        // that plays the role of v0 in the interpolation
+        for (int ind = scheme->first_nonzero_coeff;
+             ind <= scheme->last_nonzero_coeff; ind++) {
+          interp_data[ind] =
+                  yx[k][j - scheme->number_of_datapoints_to_left + ind][i] +
+                  yz[k][j - scheme->number_of_datapoints_to_left + ind][i];
         }
         // now run the interpolation scheme and place the result into the output
         return scheme->interpolate(interp_data);
@@ -116,17 +141,22 @@ double ElectricSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordi
         case Z:
           scheme = &(best_scheme(tot.k, k, pim));
           // now fill the interpolation data
-          // k - scheme.number_of_datapoints_to_left is the index of the Yee cell that plays the role of v0 in the interpolation
-          for (int ind = scheme->first_nonzero_coeff; ind <= scheme->last_nonzero_coeff; ind++) {
-            interp_data[ind] = zx[k - scheme->number_of_datapoints_to_left + ind][j][i] +
-                               zy[k - scheme->number_of_datapoints_to_left + ind][j][i];
+          // k - scheme.number_of_datapoints_to_left is the index of the Yee
+          // cell that plays the role of v0 in the interpolation
+          for (int ind = scheme->first_nonzero_coeff;
+               ind <= scheme->last_nonzero_coeff; ind++) {
+            interp_data[ind] =
+                    zx[k - scheme->number_of_datapoints_to_left + ind][j][i] +
+                    zy[k - scheme->number_of_datapoints_to_left + ind][j][i];
           }
-          // now run the interpolation scheme and place the result into the output
+          // now run the interpolation scheme and place the result into the
+          // output
           return scheme->interpolate(interp_data);
       }
       break;
-        default:
-          throw runtime_error("Invalid axial direction selected for interpolation!\n");
-          break;
-      }
+    default:
+      throw runtime_error(
+              "Invalid axial direction selected for interpolation!\n");
+      break;
+  }
 }

--- a/tdms/src/fields/magnetic.cpp
+++ b/tdms/src/fields/magnetic.cpp
@@ -1,28 +1,27 @@
 #include "field.h"
 
 #include "cell_coordinate.h"
-#include "interpolation_methods.h"
 #include "globals.h"
+#include "interpolation_methods.h"
 
 using namespace std;
 using namespace tdms_math_constants;
 
-double MagneticField::phase(int n, double omega, double dt){
-  return omega * ((double) n + 0.5) * dt;  // 0.5 added because it's known half a time step after E
+double MagneticField::phase(int n, double omega, double dt) {
+  return omega * ((double) n + 0.5) *
+         dt;// 0.5 added because it's known half a time step after E
 }
 
-void MagneticField::interpolate_transverse_electric_components(CellCoordinate cell,
-                                                               complex<double> *x_at_centre,
-                                                               complex<double> *y_at_centre,
-                                                               complex<double> *z_at_centre) {
+void MagneticField::interpolate_transverse_electric_components(
+        CellCoordinate cell, complex<double> *x_at_centre,
+        complex<double> *y_at_centre, complex<double> *z_at_centre) {
   *x_at_centre = complex<double>(0., 0.);
   *y_at_centre = complex<double>(0., 0.);
   *z_at_centre = interpolate_to_centre_of(AxialDirection::Z, cell);
 }
-void MagneticField::interpolate_transverse_magnetic_components(CellCoordinate cell,
-                                                               complex<double> *x_at_centre,
-                                                               complex<double> *y_at_centre,
-                                                               complex<double> *z_at_centre) {
+void MagneticField::interpolate_transverse_magnetic_components(
+        CellCoordinate cell, complex<double> *x_at_centre,
+        complex<double> *y_at_centre, complex<double> *z_at_centre) {
   *x_at_centre = interpolate_to_centre_of(AxialDirection::X, cell);
   *y_at_centre = interpolate_to_centre_of(AxialDirection::Y, cell);
   *z_at_centre = complex<double>(0., 0.);
@@ -30,46 +29,66 @@ void MagneticField::interpolate_transverse_magnetic_components(CellCoordinate ce
 
 /* 2D INTERPOLATION SCHEMES (FOR THE MAGNETIC FIELD IN 3D SIMULATIONS)
 
-Unlike the E-field, the H-field components associated with Yee cell i,j,k are _not_ aligned with the centre of the Yee cells.
-Instead, the position of the field components (relative to the Yee cell centre is):
+Unlike the E-field, the H-field components associated with Yee cell i,j,k are
+_not_ aligned with the centre of the Yee cells. Instead, the position of the
+field components (relative to the Yee cell centre is):
 
 Hx  | (0.0, 0.5, 0.5) .* (Dx, Dy, Dx)
 Hy  | (0.5, 0.0, 0.5) .* (Dx, Dy, Dz)
 Hz  | (0.5, 0.5, 0.0) .* (Dx, Dy, Dz)
 
 where Dx, Dy, Dz are the dimensions of the Yee cell.
-This requires us to interpolate twice to recover (any of the) field components at the centre of Yee cell i,j,k, when running a 3D simulation.
+This requires us to interpolate twice to recover (any of the) field components
+at the centre of Yee cell i,j,k, when running a 3D simulation.
 
-Henceforth, let {a,b,c} = {x,y,z} be some 1-to-1 assignment of the co-ordinate axes to the labels a,b,c.
-The values Da, Db, Dc are the corresponding permutation of Dx, Dy, Dz.
-Suppose that we wish to interpolate the Ha field component to the centre a particular Yee cell.
+Henceforth, let {a,b,c} = {x,y,z} be some 1-to-1 assignment of the co-ordinate
+axes to the labels a,b,c. The values Da, Db, Dc are the corresponding
+permutation of Dx, Dy, Dz. Suppose that we wish to interpolate the Ha field
+component to the centre a particular Yee cell.
 
-We will use the notation (a_i,b_j,c_k) for the Yee cell indices, although bear in mind that this does not reflect the order the indices appear in the code.
-For example; if a = y, b = x, c = z, then the value of Ha at cell (a_i,b_j,c_k) is accessed via Ha[c_k][a_i][b_j], due to the interchanging of the x and y directions.
-Similarly; we will write Ha[a_i, b_j, c_k] to refer to the value of Ha associated to cell (a_i,b_j,c_k).
+We will use the notation (a_i,b_j,c_k) for the Yee cell indices, although bear
+in mind that this does not reflect the order the indices appear in the code. For
+example; if a = y, b = x, c = z, then the value of Ha at cell (a_i,b_j,c_k) is
+accessed via Ha[c_k][a_i][b_j], due to the interchanging of the x and y
+directions. Similarly; we will write Ha[a_i, b_j, c_k] to refer to the value of
+Ha associated to cell (a_i,b_j,c_k).
 
-Suppose now that we have selected cell a_i,b_j,c_k to interpolate to the centre of.
-We must interpolate in the b-direction, then c-direction, or vice-versa.
-For optimal accuracy we must determine the best interpolation scheme we can use in each direction at cell (a_i,b_j,c_k), and use the WORSE scheme second.
+Suppose now that we have selected cell a_i,b_j,c_k to interpolate to the centre
+of. We must interpolate in the b-direction, then c-direction, or vice-versa. For
+optimal accuracy we must determine the best interpolation scheme we can use in
+each direction at cell (a_i,b_j,c_k), and use the WORSE scheme second.
 
-Let us assume WLOG that the b-direction interpolation scheme (b_scheme) is inferior to that of the c-direction (c_scheme).
-We now need to interpolate Ha in the c-direction to obtain the value of Ha at the spatial positions (a_i, cell_b + Db, c_k) where
-b_j - b_scheme.number_of_datapoints_to_left + b_scheme.first_nonzero_coeff <= cell_b <= b_j - b_scheme.number_of_datapoints_to_left + b_scheme.last_nonzero_coeff.
+Let us assume WLOG that the b-direction interpolation scheme (b_scheme) is
+inferior to that of the c-direction (c_scheme). We now need to interpolate Ha in
+the c-direction to obtain the value of Ha at the spatial positions (a_i, cell_b
++ Db, c_k) where b_j - b_scheme.number_of_datapoints_to_left +
+b_scheme.first_nonzero_coeff <= cell_b <= b_j -
+b_scheme.number_of_datapoints_to_left + b_scheme.last_nonzero_coeff.
 
     Let cell_b be one particular index in this range.
-    To apply c_scheme to obtain the value of Ha at (a_i, cell_b + Db, c_k), we require the values Ha[a_i, cell_b, cell_c] where
-    c_k - c_scheme.number_of_datapoints_to_left + c_scheme.first_nonzero_coeff <= cell_c <= c_k - c_scheme.number_of_datapoints_to_left + c_scheme.last_nonzero_coeff.
-    These values are fed to c_scheme.interpolate, which provides us with Ha at the spatial position (a_i, cell_b + Db, c_k).
+    To apply c_scheme to obtain the value of Ha at (a_i, cell_b + Db, c_k), we
+require the values Ha[a_i, cell_b, cell_c] where c_k -
+c_scheme.number_of_datapoints_to_left + c_scheme.first_nonzero_coeff <= cell_c
+<= c_k - c_scheme.number_of_datapoints_to_left + c_scheme.last_nonzero_coeff.
+These values are fed to c_scheme.interpolate, which provides us with Ha at the
+spatial position (a_i, cell_b + Db, c_k).
 
-Now with approximations of Ha at each (a_i, cell_b + Db, c_k), we can pass this information to b_scheme.interpolate to recover the value of Ha at the centre of Yee cell (a_i, b_j, c_k).
+Now with approximations of Ha at each (a_i, cell_b + Db, c_k), we can pass this
+information to b_scheme.interpolate to recover the value of Ha at the centre of
+Yee cell (a_i, b_j, c_k).
 
-In a 2D simulation, tot.j = 0. This means we cannot interpolate in two directions for the Hx and Hz fields, since there is no y-direction to interpolate in. As a result, we only interpolate in the z-direction for Hx and x-direction for Hz when running a two-dimensional simulation.
+In a 2D simulation, tot.j = 0. This means we cannot interpolate in two
+directions for the Hx and Hz fields, since there is no y-direction to
+interpolate in. As a result, we only interpolate in the z-direction for Hx and
+x-direction for Hz when running a two-dimensional simulation.
 */
 
-complex<double> MagneticField::interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) {
+complex<double> MagneticField::interpolate_to_centre_of(AxialDirection d,
+                                                        CellCoordinate cell) {
   // this data will be passed to the second interpolation scheme
   complex<double> data_for_second_scheme[8];
-  // this data will hold values for the interpolation in the first interpolation scheme
+  // this data will hold values for the interpolation in the first interpolation
+  // scheme
   complex<double> data_for_first_scheme[8];
   // the interpolation schemes that are to be used
   const InterpolationScheme *b_scheme, *c_scheme;
@@ -78,57 +97,77 @@ complex<double> MagneticField::interpolate_to_centre_of(AxialDirection d, CellCo
   switch (d) {
     case X:
       // Associations: a = x, b = y, c = z
-      if (tot.j <=1) {
+      if (tot.j <= 1) {
         // this is a 2D simulation
-        // we simply interpolate the Hx field in the z-direction to get the field value at the centre
+        // we simply interpolate the Hx field in the z-direction to get the
+        // field value at the centre
         c_scheme = &(best_scheme(tot.k, k, pim));
-        for(int kk = c_scheme->first_nonzero_coeff; kk <= c_scheme->last_nonzero_coeff; kk++) {
+        for (int kk = c_scheme->first_nonzero_coeff;
+             kk <= c_scheme->last_nonzero_coeff; kk++) {
           int cell_k = k - c_scheme->number_of_datapoints_to_left + kk;
-          data_for_first_scheme[kk] = real.x[cell_k][0][i] + IMAGINARY_UNIT * imag.x[cell_k][0][i];
+          data_for_first_scheme[kk] =
+                  real.x[cell_k][0][i] + IMAGINARY_UNIT * imag.x[cell_k][0][i];
         }
         return c_scheme->interpolate(data_for_first_scheme);
-      }
-      else {
+      } else {
         c_scheme = &(best_scheme(tot.k, k, pim));
         b_scheme = &(best_scheme(tot.j, j, pim));
 
         if (c_scheme->is_better_than(*b_scheme)) {
           // we will be interpolating in the z-direction first, then in y
-          for (int jj = b_scheme->first_nonzero_coeff; jj <= b_scheme->last_nonzero_coeff; jj++) {
+          for (int jj = b_scheme->first_nonzero_coeff;
+               jj <= b_scheme->last_nonzero_coeff; jj++) {
             // this is the j-index of the cell we are looking at
             int cell_j = j - b_scheme->number_of_datapoints_to_left + jj;
-            // determine the Hx values of cells (i, cell_j, k-z_scheme.index-1) through (i, cell_j, k-z_scheme.index-1+7), and interpolate them via z_scheme
-            for (int kk = c_scheme->first_nonzero_coeff; kk <= c_scheme->last_nonzero_coeff; kk++) {
-              // the k-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hx values of cells (i, cell_j, k-z_scheme.index-1)
+            // through (i, cell_j, k-z_scheme.index-1+7), and interpolate them
+            // via z_scheme
+            for (int kk = c_scheme->first_nonzero_coeff;
+                 kk <= c_scheme->last_nonzero_coeff; kk++) {
+              // the k-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_k = k - c_scheme->number_of_datapoints_to_left + kk;
               // gather the data for interpolating in the z dimension
               data_for_first_scheme[kk] =
-                      real.x[cell_k][cell_j][i] + IMAGINARY_UNIT * imag.x[cell_k][cell_j][i];
+                      real.x[cell_k][cell_j][i] +
+                      IMAGINARY_UNIT * imag.x[cell_k][cell_j][i];
             }
-            // interpolate in z to obtain a value for the Hx field at position (i, cell_j+Dy, k)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[jj] = c_scheme->interpolate(data_for_first_scheme);
+            // interpolate in z to obtain a value for the Hx field at position
+            // (i, cell_j+Dy, k) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[jj] =
+                    c_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the y-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the y-direction to the centre of Yee cell
+          // (i,j,k)
           return b_scheme->interpolate(data_for_second_scheme);
         } else {
           // we will be interpolating in the y-direction first, then in z
-          for (int kk = c_scheme->first_nonzero_coeff; kk <= c_scheme->last_nonzero_coeff; kk++) {
+          for (int kk = c_scheme->first_nonzero_coeff;
+               kk <= c_scheme->last_nonzero_coeff; kk++) {
             // this is the k-index of the cell we are looking at
             int cell_k = k - c_scheme->number_of_datapoints_to_left + kk;
-            // determine the Hx values of cells (i, j - y_scheme.index-1, cell_k) through (i, j - y_scheme.index-1+7, cell_k), and interpolate them via y_scheme
-            for (int jj = b_scheme->first_nonzero_coeff; jj <= b_scheme->last_nonzero_coeff; jj++) {
-              // the j-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hx values of cells (i, j - y_scheme.index-1,
+            // cell_k) through (i, j - y_scheme.index-1+7, cell_k), and
+            // interpolate them via y_scheme
+            for (int jj = b_scheme->first_nonzero_coeff;
+                 jj <= b_scheme->last_nonzero_coeff; jj++) {
+              // the j-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_j = j - b_scheme->number_of_datapoints_to_left + jj;
               // gather the data for interpolating in the y dimension
               data_for_first_scheme[jj] =
-                      real.x[cell_k][cell_j][i] + IMAGINARY_UNIT * imag.x[cell_k][cell_j][i];
+                      real.x[cell_k][cell_j][i] +
+                      IMAGINARY_UNIT * imag.x[cell_k][cell_j][i];
             }
-            // interpolate in y to obtain a value for the Hx field at position (i, j, cell_k+Dz)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[kk] = b_scheme->interpolate(data_for_first_scheme);
+            // interpolate in y to obtain a value for the Hx field at position
+            // (i, j, cell_k+Dz) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[kk] =
+                    b_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the z-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the z-direction to the centre of Yee cell
+          // (i,j,k)
           return c_scheme->interpolate(data_for_second_scheme);
         }
       }
@@ -140,39 +179,55 @@ complex<double> MagneticField::interpolate_to_centre_of(AxialDirection d, CellCo
 
       if (b_scheme->is_better_than(*c_scheme)) {
         // we will be interpolating in the z-direction first, then in x
-        for (int ii = c_scheme->first_nonzero_coeff; ii <= c_scheme->last_nonzero_coeff; ii++) {
+        for (int ii = c_scheme->first_nonzero_coeff;
+             ii <= c_scheme->last_nonzero_coeff; ii++) {
           // this is the i-index of the cell we are looking at
           int cell_i = i - c_scheme->number_of_datapoints_to_left + ii;
-          // determine the Hy values of cells (cell_i, j, k-z_scheme.index-1) through (cell_i, j, k-z_scheme.index-1+7), and interpolate them via z_scheme
-          for (int kk = b_scheme->first_nonzero_coeff; kk <= b_scheme->last_nonzero_coeff; kk++) {
-            // the k-index of the current cell we are looking at (readability, don't need to define this here)
+          // determine the Hy values of cells (cell_i, j, k-z_scheme.index-1)
+          // through (cell_i, j, k-z_scheme.index-1+7), and interpolate them via
+          // z_scheme
+          for (int kk = b_scheme->first_nonzero_coeff;
+               kk <= b_scheme->last_nonzero_coeff; kk++) {
+            // the k-index of the current cell we are looking at (readability,
+            // don't need to define this here)
             int cell_k = k - b_scheme->number_of_datapoints_to_left + kk;
             // gather the data for interpolating in the z dimension
             data_for_first_scheme[kk] =
-                    real.y[cell_k][j][cell_i] + IMAGINARY_UNIT * imag.y[cell_k][j][cell_i];
+                    real.y[cell_k][j][cell_i] +
+                    IMAGINARY_UNIT * imag.y[cell_k][j][cell_i];
           }
-          // interpolate in z to obtain a value for the Hy field at position (cell_i+Dx, j, k)
-          // place this into the appropriate index in the data being passed to the x_scheme
-          data_for_second_scheme[ii] = b_scheme->interpolate(data_for_first_scheme);
+          // interpolate in z to obtain a value for the Hy field at position
+          // (cell_i+Dx, j, k) place this into the appropriate index in the data
+          // being passed to the x_scheme
+          data_for_second_scheme[ii] =
+                  b_scheme->interpolate(data_for_first_scheme);
         }
         // now interpolate in the x-direction to the centre of Yee cell (i,j,k)
         return c_scheme->interpolate(data_for_second_scheme);
       } else {
         // we will be interpolating in the x-direction first, then in z
-        for (int kk = b_scheme->first_nonzero_coeff; kk <= b_scheme->last_nonzero_coeff; kk++) {
+        for (int kk = b_scheme->first_nonzero_coeff;
+             kk <= b_scheme->last_nonzero_coeff; kk++) {
           // this is the k-index of the cell we are looking at
           int cell_k = k - b_scheme->number_of_datapoints_to_left + kk;
-          // determine the Hy values of cells (i - x_scheme.index-1, j, cell_k) through (i- x_scheme.index-1+7, j, cell_k), and interpolate them via x_scheme
-          for (int ii = c_scheme->first_nonzero_coeff; ii <= c_scheme->last_nonzero_coeff; ii++) {
-            // the i-index of the current cell we are looking at (readability, don't need to define this here)
+          // determine the Hy values of cells (i - x_scheme.index-1, j, cell_k)
+          // through (i- x_scheme.index-1+7, j, cell_k), and interpolate them
+          // via x_scheme
+          for (int ii = c_scheme->first_nonzero_coeff;
+               ii <= c_scheme->last_nonzero_coeff; ii++) {
+            // the i-index of the current cell we are looking at (readability,
+            // don't need to define this here)
             int cell_i = i - c_scheme->number_of_datapoints_to_left + ii;
             // gather the data for interpolating in the x dimension
             data_for_first_scheme[ii] =
-                    real.y[cell_k][j][cell_i] + IMAGINARY_UNIT * imag.y[cell_k][j][cell_i];
+                    real.y[cell_k][j][cell_i] +
+                    IMAGINARY_UNIT * imag.y[cell_k][j][cell_i];
           }
-          // interpolate in x to obtain a value for the Hy field at position (i, j, cell_k+Dz)
-          // place this into the appropriate index in the data being passed to the y_scheme
-          data_for_second_scheme[kk] = c_scheme->interpolate(data_for_first_scheme);
+          // interpolate in x to obtain a value for the Hy field at position (i,
+          // j, cell_k+Dz) place this into the appropriate index in the data
+          // being passed to the y_scheme
+          data_for_second_scheme[kk] =
+                  c_scheme->interpolate(data_for_first_scheme);
         }
         // now interpolate in the z-direction to the centre of Yee cell (i,j,k)
         return b_scheme->interpolate(data_for_second_scheme);
@@ -182,83 +237,109 @@ complex<double> MagneticField::interpolate_to_centre_of(AxialDirection d, CellCo
       // Associations: a = z, b = x, c = y
       if (tot.j <= 1) {
         // this is a 2D simulation
-        // we simply interpolate the Hx field in the z-direction to get the field value at the centre
+        // we simply interpolate the Hx field in the z-direction to get the
+        // field value at the centre
         b_scheme = &(best_scheme(tot.i, i, pim));
-        for (int ii = b_scheme->first_nonzero_coeff; ii <= b_scheme->last_nonzero_coeff; ii++) {
+        for (int ii = b_scheme->first_nonzero_coeff;
+             ii <= b_scheme->last_nonzero_coeff; ii++) {
           int cell_i = i - b_scheme->number_of_datapoints_to_left + ii;
-          data_for_first_scheme[ii] = real.z[k][0][cell_i] + IMAGINARY_UNIT * imag.z[k][0][cell_i];
+          data_for_first_scheme[ii] =
+                  real.z[k][0][cell_i] + IMAGINARY_UNIT * imag.z[k][0][cell_i];
         }
         return b_scheme->interpolate(data_for_first_scheme);
-      }
-      else {
+      } else {
         b_scheme = &(best_scheme(tot.i, i, pim));
         c_scheme = &(best_scheme(tot.j, j, pim));
 
         if (c_scheme->is_better_than(*b_scheme)) {
           // we will be interpolating in the y-direction first, then in x
-          for (int ii = b_scheme->first_nonzero_coeff; ii <= b_scheme->last_nonzero_coeff; ii++) {
+          for (int ii = b_scheme->first_nonzero_coeff;
+               ii <= b_scheme->last_nonzero_coeff; ii++) {
             // this is the i-index of the cell we are looking at
             int cell_i = i - b_scheme->number_of_datapoints_to_left + ii;
-            // determine the Hz values of cells (cell_i, j-y_scheme.index-1, k) through (cell_i, j-y_scheme.index-1+7, k), and interpolate them via y_scheme
-            for (int jj = c_scheme->first_nonzero_coeff; jj <= c_scheme->last_nonzero_coeff; jj++) {
-              // the j-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hz values of cells (cell_i, j-y_scheme.index-1, k)
+            // through (cell_i, j-y_scheme.index-1+7, k), and interpolate them
+            // via y_scheme
+            for (int jj = c_scheme->first_nonzero_coeff;
+                 jj <= c_scheme->last_nonzero_coeff; jj++) {
+              // the j-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_j = j - c_scheme->number_of_datapoints_to_left + jj;
               // gather the data for interpolating in the y dimension
               data_for_first_scheme[jj] =
-                      real.z[k][cell_j][cell_i] + IMAGINARY_UNIT * imag.z[k][cell_j][cell_i];
+                      real.z[k][cell_j][cell_i] +
+                      IMAGINARY_UNIT * imag.z[k][cell_j][cell_i];
             }
 
-            // interpolate in y to obtain a value for the Hz field at position (cell_i+Dx, j, k)
-            // place this into the appropriate index in the data being passed to the x_scheme
-            data_for_second_scheme[ii] = c_scheme->interpolate(data_for_first_scheme);
+            // interpolate in y to obtain a value for the Hz field at position
+            // (cell_i+Dx, j, k) place this into the appropriate index in the
+            // data being passed to the x_scheme
+            data_for_second_scheme[ii] =
+                    c_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the x-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the x-direction to the centre of Yee cell
+          // (i,j,k)
           return b_scheme->interpolate(data_for_second_scheme);
         } else {
           // we will be interpolating in the x-direction first, then in y
-          for (int jj = c_scheme->first_nonzero_coeff; jj <= c_scheme->last_nonzero_coeff; jj++) {
+          for (int jj = c_scheme->first_nonzero_coeff;
+               jj <= c_scheme->last_nonzero_coeff; jj++) {
             // this is the j-index of the cell we are looking at
             int cell_j = j - c_scheme->number_of_datapoints_to_left + jj;
-            // determine the Hz values of cells (i - x_scheme.index-1, cell_j, k) through (i- x_scheme.index-1+7, cell_j, k), and interpolate them via x_scheme
-            for (int ii = b_scheme->first_nonzero_coeff; ii <= b_scheme->last_nonzero_coeff; ii++) {
-              // the i-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hz values of cells (i - x_scheme.index-1, cell_j,
+            // k) through (i- x_scheme.index-1+7, cell_j, k), and interpolate
+            // them via x_scheme
+            for (int ii = b_scheme->first_nonzero_coeff;
+                 ii <= b_scheme->last_nonzero_coeff; ii++) {
+              // the i-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_i = i - b_scheme->number_of_datapoints_to_left + ii;
               // gather the data for interpolating in the x dimension
               data_for_first_scheme[ii] =
-                      real.z[k][cell_j][cell_i] + IMAGINARY_UNIT * imag.z[k][cell_j][cell_i];
+                      real.z[k][cell_j][cell_i] +
+                      IMAGINARY_UNIT * imag.z[k][cell_j][cell_i];
             }
 
-            // interpolate in x to obtain a value for the Hz field at position (i, j, cell_k+Dz)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[jj] = b_scheme->interpolate(data_for_first_scheme);
+            // interpolate in x to obtain a value for the Hz field at position
+            // (i, j, cell_k+Dz) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[jj] =
+                    b_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the y-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the y-direction to the centre of Yee cell
+          // (i,j,k)
           return c_scheme->interpolate(data_for_second_scheme);
         }
       }
       break;
     default:
-      throw runtime_error("Error: invalid axial direction selected for interpolation\n");
+      throw runtime_error(
+              "Error: invalid axial direction selected for interpolation\n");
       break;
   }
 }
 
-double MagneticSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordinate cell) {
+double MagneticSplitField::interpolate_to_centre_of(AxialDirection d,
+                                                    CellCoordinate cell) {
   const InterpolationScheme *b_scheme, *c_scheme;
   int i = cell.i, j = cell.j, k = cell.k;
   // this data will be passed to the second interpolation scheme
   double data_for_second_scheme[8];
-  // this data will hold values for the interpolation in the first interpolation scheme
+  // this data will hold values for the interpolation in the first interpolation
+  // scheme
   double data_for_first_scheme[8];
 
   switch (d) {
     case X:
       if (tot.j <= 1) {
-        // in a 2D simulation, we must interpolate in the z-direction to recover Hx, due to the magnetic-field offsets from the centre
+        // in a 2D simulation, we must interpolate in the z-direction to recover
+        // Hx, due to the magnetic-field offsets from the centre
         b_scheme = &(best_scheme(tot.k, k, pim));
         // now fill the interpolation data
-        // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell that plays the role of v0 in the interpolation
-        for (int ind = b_scheme->first_nonzero_coeff; ind <= b_scheme->last_nonzero_coeff; ind++) {
+        // i - (scheme.number_of_datapoints_to_left) is the index of the Yee
+        // cell that plays the role of v0 in the interpolation
+        for (int ind = b_scheme->first_nonzero_coeff;
+             ind <= b_scheme->last_nonzero_coeff; ind++) {
           data_for_first_scheme[ind] =
                   xy[k - b_scheme->number_of_datapoints_to_left + ind][j][i] +
                   xz[k - b_scheme->number_of_datapoints_to_left + ind][j][i];
@@ -273,82 +354,117 @@ double MagneticSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordi
 
         if (c_scheme->is_better_than(*b_scheme)) {
           // we will be interpolating in the z-direction first, then in y
-          for (int jj = b_scheme->first_nonzero_coeff; jj <= b_scheme->last_nonzero_coeff; jj++) {
+          for (int jj = b_scheme->first_nonzero_coeff;
+               jj <= b_scheme->last_nonzero_coeff; jj++) {
             // this is the j-index of the cell we are looking at
             int cell_j = j - b_scheme->number_of_datapoints_to_left + jj;
-            // determine the Hx values of cells (i, cell_j, k-z_scheme.index-1) through (i, cell_j, k-z_scheme.index-1+7), and interpolate them via z_scheme
-            for (int kk = c_scheme->first_nonzero_coeff; kk <= c_scheme->last_nonzero_coeff; kk++) {
-              // the k-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hx values of cells (i, cell_j, k-z_scheme.index-1)
+            // through (i, cell_j, k-z_scheme.index-1+7), and interpolate them
+            // via z_scheme
+            for (int kk = c_scheme->first_nonzero_coeff;
+                 kk <= c_scheme->last_nonzero_coeff; kk++) {
+              // the k-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_k = k - c_scheme->number_of_datapoints_to_left + kk;
               // gather the data for interpolating in the z dimension
-              data_for_first_scheme[kk] = xy[cell_k][cell_j][i] + xz[cell_k][cell_j][i];
+              data_for_first_scheme[kk] =
+                      xy[cell_k][cell_j][i] + xz[cell_k][cell_j][i];
             }
-            // interpolate in z to obtain a value for the Hx field at position (i, cell_j+Dy, k)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[jj] = c_scheme->interpolate(data_for_first_scheme);
+            // interpolate in z to obtain a value for the Hx field at position
+            // (i, cell_j+Dy, k) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[jj] =
+                    c_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the y-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the y-direction to the centre of Yee cell
+          // (i,j,k)
           return b_scheme->interpolate(data_for_second_scheme);
         } else {
           // we will be interpolating in the y-direction first, then in z
-          for (int kk = c_scheme->first_nonzero_coeff; kk <= c_scheme->last_nonzero_coeff; kk++) {
+          for (int kk = c_scheme->first_nonzero_coeff;
+               kk <= c_scheme->last_nonzero_coeff; kk++) {
             // this is the k-index of the cell we are looking at
             int cell_k = k - c_scheme->number_of_datapoints_to_left + kk;
-            // determine the Hx values of cells (i, j - y_scheme.index-1, cell_k) through (i, j - y_scheme.index-1+7, cell_k), and interpolate them via y_scheme
-            for (int jj = b_scheme->first_nonzero_coeff; jj <= b_scheme->last_nonzero_coeff; jj++) {
-              // the j-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hx values of cells (i, j - y_scheme.index-1,
+            // cell_k) through (i, j - y_scheme.index-1+7, cell_k), and
+            // interpolate them via y_scheme
+            for (int jj = b_scheme->first_nonzero_coeff;
+                 jj <= b_scheme->last_nonzero_coeff; jj++) {
+              // the j-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_j = j - b_scheme->number_of_datapoints_to_left + jj;
               // gather the data for interpolating in the y dimension
-              data_for_first_scheme[jj] = xy[cell_k][cell_j][i] + xz[cell_k][cell_j][i];
+              data_for_first_scheme[jj] =
+                      xy[cell_k][cell_j][i] + xz[cell_k][cell_j][i];
             }
-            // interpolate in y to obtain a value for the Hx field at position (i, j, cell_k+Dz)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[kk] = b_scheme->interpolate(data_for_first_scheme);
+            // interpolate in y to obtain a value for the Hx field at position
+            // (i, j, cell_k+Dz) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[kk] =
+                    b_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the z-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the z-direction to the centre of Yee cell
+          // (i,j,k)
           return c_scheme->interpolate(data_for_second_scheme);
         }
       }
       break;
     case Y:
-      // we can always interpolate in two directions for Hy, since even in a 2D simulation the x- and z-directions still exist
-      // Associations: a = y, b = z, c = x
+      // we can always interpolate in two directions for Hy, since even in a 2D
+      // simulation the x- and z-directions still exist Associations: a = y, b =
+      // z, c = x
       c_scheme = &(best_scheme(tot.i, i, pim));
       b_scheme = &(best_scheme(tot.k, k, pim));
 
       if (b_scheme->is_better_than(*c_scheme)) {
         // we will be interpolating in the z-direction first, then in x
-        for (int ii = c_scheme->first_nonzero_coeff; ii <= c_scheme->last_nonzero_coeff; ii++) {
+        for (int ii = c_scheme->first_nonzero_coeff;
+             ii <= c_scheme->last_nonzero_coeff; ii++) {
           // this is the i-index of the cell we are looking at
           int cell_i = i - c_scheme->number_of_datapoints_to_left + ii;
-          // determine the Hy values of cells (cell_i, j, k-z_scheme.index-1) through (cell_i, j, k-z_scheme.index-1+7), and interpolate them via z_scheme
-          for (int kk = b_scheme->first_nonzero_coeff; kk <= b_scheme->last_nonzero_coeff; kk++) {
-            // the k-index of the current cell we are looking at (readability, don't need to define this here)
+          // determine the Hy values of cells (cell_i, j, k-z_scheme.index-1)
+          // through (cell_i, j, k-z_scheme.index-1+7), and interpolate them via
+          // z_scheme
+          for (int kk = b_scheme->first_nonzero_coeff;
+               kk <= b_scheme->last_nonzero_coeff; kk++) {
+            // the k-index of the current cell we are looking at (readability,
+            // don't need to define this here)
             int cell_k = k - b_scheme->number_of_datapoints_to_left + kk;
             // gather the data for interpolating in the z dimension
-            data_for_first_scheme[kk] = yx[cell_k][j][cell_i] + yz[cell_k][j][cell_i];
+            data_for_first_scheme[kk] =
+                    yx[cell_k][j][cell_i] + yz[cell_k][j][cell_i];
           }
-          // interpolate in z to obtain a value for the Hy field at position (cell_i+Dx, j, k)
-          // place this into the appropriate index in the data being passed to the x_scheme
-          data_for_second_scheme[ii] = b_scheme->interpolate(data_for_first_scheme);
+          // interpolate in z to obtain a value for the Hy field at position
+          // (cell_i+Dx, j, k) place this into the appropriate index in the data
+          // being passed to the x_scheme
+          data_for_second_scheme[ii] =
+                  b_scheme->interpolate(data_for_first_scheme);
         }
         // now interpolate in the x-direction to the centre of Yee cell (i,j,k)
         return c_scheme->interpolate(data_for_second_scheme);
       } else {
         // we will be interpolating in the x-direction first, then in z
-        for (int kk = b_scheme->first_nonzero_coeff; kk <= b_scheme->last_nonzero_coeff; kk++) {
+        for (int kk = b_scheme->first_nonzero_coeff;
+             kk <= b_scheme->last_nonzero_coeff; kk++) {
           // this is the k-index of the cell we are looking at
           int cell_k = k - b_scheme->number_of_datapoints_to_left + kk;
-          // determine the Hy values of cells (i - x_scheme.index-1, j, cell_k) through (i- x_scheme.index-1+7, j, cell_k), and interpolate them via x_scheme
-          for (int ii = c_scheme->first_nonzero_coeff; ii <= c_scheme->last_nonzero_coeff; ii++) {
-            // the i-index of the current cell we are looking at (readability, don't need to define this here)
+          // determine the Hy values of cells (i - x_scheme.index-1, j, cell_k)
+          // through (i- x_scheme.index-1+7, j, cell_k), and interpolate them
+          // via x_scheme
+          for (int ii = c_scheme->first_nonzero_coeff;
+               ii <= c_scheme->last_nonzero_coeff; ii++) {
+            // the i-index of the current cell we are looking at (readability,
+            // don't need to define this here)
             int cell_i = i - c_scheme->number_of_datapoints_to_left + ii;
             // gather the data for interpolating in the x dimension
-            data_for_first_scheme[ii] = yx[cell_k][j][cell_i] + yz[cell_k][j][cell_i];
+            data_for_first_scheme[ii] =
+                    yx[cell_k][j][cell_i] + yz[cell_k][j][cell_i];
           }
-          // interpolate in x to obtain a value for the Hy field at position (i, j, cell_k+Dz)
-          // place this into the appropriate index in the data being passed to the y_scheme
-          data_for_second_scheme[kk] = c_scheme->interpolate(data_for_first_scheme);
+          // interpolate in x to obtain a value for the Hy field at position (i,
+          // j, cell_k+Dz) place this into the appropriate index in the data
+          // being passed to the y_scheme
+          data_for_second_scheme[kk] =
+                  c_scheme->interpolate(data_for_first_scheme);
         }
         // now interpolate in the z-direction to the centre of Yee cell (i,j,k)
         return b_scheme->interpolate(data_for_second_scheme);
@@ -356,11 +472,14 @@ double MagneticSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordi
       break;
     case Z:
       if (tot.j <= 1) {
-        // in a 2D simulation, we must interpolate in the x-direction to recover Hz, due to the magnetic-field offsets from the centre
+        // in a 2D simulation, we must interpolate in the x-direction to recover
+        // Hz, due to the magnetic-field offsets from the centre
         b_scheme = &(best_scheme(tot.i, i, pim));
         // now fill the interpolation data
-        // i - (scheme.number_of_datapoints_to_left) is the index of the Yee cell that plays the role of v0 in the interpolation
-        for (int ind = b_scheme->first_nonzero_coeff; ind <= b_scheme->last_nonzero_coeff; ind++) {
+        // i - (scheme.number_of_datapoints_to_left) is the index of the Yee
+        // cell that plays the role of v0 in the interpolation
+        for (int ind = b_scheme->first_nonzero_coeff;
+             ind <= b_scheme->last_nonzero_coeff; ind++) {
           data_for_first_scheme[ind] =
                   zx[k][j][i - b_scheme->number_of_datapoints_to_left + ind] +
                   zy[k][j][i - b_scheme->number_of_datapoints_to_left + ind];
@@ -375,44 +494,63 @@ double MagneticSplitField::interpolate_to_centre_of(AxialDirection d, CellCoordi
 
         if (c_scheme->is_better_than(*b_scheme)) {
           // we will be interpolating in the y-direction first, then in x
-          for (int ii = b_scheme->first_nonzero_coeff; ii <= b_scheme->last_nonzero_coeff; ii++) {
+          for (int ii = b_scheme->first_nonzero_coeff;
+               ii <= b_scheme->last_nonzero_coeff; ii++) {
             // this is the i-index of the cell we are looking at
             int cell_i = i - b_scheme->number_of_datapoints_to_left + ii;
-            // determine the Hz values of cells (cell_i, j-y_scheme.index-1, k) through (cell_i, j-y_scheme.index-1+7, k), and interpolate them via y_scheme
-            for (int jj = c_scheme->first_nonzero_coeff; jj <= c_scheme->last_nonzero_coeff; jj++) {
-              // the j-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hz values of cells (cell_i, j-y_scheme.index-1, k)
+            // through (cell_i, j-y_scheme.index-1+7, k), and interpolate them
+            // via y_scheme
+            for (int jj = c_scheme->first_nonzero_coeff;
+                 jj <= c_scheme->last_nonzero_coeff; jj++) {
+              // the j-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_j = j - c_scheme->number_of_datapoints_to_left + jj;
               // gather the data for interpolating in the y dimension
-              data_for_first_scheme[jj] = zx[k][cell_j][cell_i] + zy[k][cell_j][cell_i];
+              data_for_first_scheme[jj] =
+                      zx[k][cell_j][cell_i] + zy[k][cell_j][cell_i];
             }
-            // interpolate in y to obtain a value for the Hz field at position (cell_i+Dx, j, k)
-            // place this into the appropriate index in the data being passed to the x_scheme
-            data_for_second_scheme[ii] = c_scheme->interpolate(data_for_first_scheme);
+            // interpolate in y to obtain a value for the Hz field at position
+            // (cell_i+Dx, j, k) place this into the appropriate index in the
+            // data being passed to the x_scheme
+            data_for_second_scheme[ii] =
+                    c_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the x-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the x-direction to the centre of Yee cell
+          // (i,j,k)
           return b_scheme->interpolate(data_for_second_scheme);
         } else {
           // we will be interpolating in the x-direction first, then in y
-          for (int jj = c_scheme->first_nonzero_coeff; jj <= c_scheme->last_nonzero_coeff; jj++) {
+          for (int jj = c_scheme->first_nonzero_coeff;
+               jj <= c_scheme->last_nonzero_coeff; jj++) {
             // this is the j-index of the cell we are looking at
             int cell_j = j - c_scheme->number_of_datapoints_to_left + jj;
-            // determine the Hz values of cells (i - x_scheme.index-1, cell_j, k) through (i- x_scheme.index-1+7, cell_j, k), and interpolate them via x_scheme
-            for (int ii = b_scheme->first_nonzero_coeff; ii <= b_scheme->last_nonzero_coeff; ii++) {
-              // the i-index of the current cell we are looking at (readability, don't need to define this here)
+            // determine the Hz values of cells (i - x_scheme.index-1, cell_j,
+            // k) through (i- x_scheme.index-1+7, cell_j, k), and interpolate
+            // them via x_scheme
+            for (int ii = b_scheme->first_nonzero_coeff;
+                 ii <= b_scheme->last_nonzero_coeff; ii++) {
+              // the i-index of the current cell we are looking at (readability,
+              // don't need to define this here)
               int cell_i = i - b_scheme->number_of_datapoints_to_left + ii;
               // gather the data for interpolating in the x dimension
-              data_for_first_scheme[ii] = zx[k][cell_j][cell_i] + zy[k][cell_j][cell_i];
+              data_for_first_scheme[ii] =
+                      zx[k][cell_j][cell_i] + zy[k][cell_j][cell_i];
             }
-            // interpolate in x to obtain a value for the Hz field at position (i, j, cell_k+Dz)
-            // place this into the appropriate index in the data being passed to the y_scheme
-            data_for_second_scheme[jj] = b_scheme->interpolate(data_for_first_scheme);
+            // interpolate in x to obtain a value for the Hz field at position
+            // (i, j, cell_k+Dz) place this into the appropriate index in the
+            // data being passed to the y_scheme
+            data_for_second_scheme[jj] =
+                    b_scheme->interpolate(data_for_first_scheme);
           }
-          // now interpolate in the y-direction to the centre of Yee cell (i,j,k)
+          // now interpolate in the y-direction to the centre of Yee cell
+          // (i,j,k)
           return c_scheme->interpolate(data_for_second_scheme);
         }
       }
       break;
     default:
-      throw runtime_error("Error: invalid axial direction selected for interpolation\n");
+      throw runtime_error(
+              "Error: invalid axial direction selected for interpolation\n");
   }
 }

--- a/tdms/src/fields/split.cpp
+++ b/tdms/src/fields/split.cpp
@@ -7,19 +7,23 @@
 using namespace std;
 
 
-void SplitFieldComponent::initialise_fftw_plan(int n_threads, int size, EHVec &eh_vec) {
+void SplitFieldComponent::initialise_fftw_plan(int n_threads, int size,
+                                               EHVec &eh_vec) {
 
   this->n_threads = n_threads;
   plan_f = (fftw_plan *) malloc(sizeof(fftw_plan *) * n_threads);
   plan_b = (fftw_plan *) malloc(sizeof(fftw_plan *) * n_threads);
 
-  for (int i = 0; i < n_threads; i++){
-    plan_f[i] = fftw_plan_dft_1d(size, eh_vec[i], eh_vec[i], FFTW_FORWARD, FFTW_MEASURE);
-    plan_b[i] = fftw_plan_dft_1d(size, eh_vec[i], eh_vec[i], FFTW_BACKWARD, FFTW_MEASURE);
+  for (int i = 0; i < n_threads; i++) {
+    plan_f[i] = fftw_plan_dft_1d(size, eh_vec[i], eh_vec[i], FFTW_FORWARD,
+                                 FFTW_MEASURE);
+    plan_b[i] = fftw_plan_dft_1d(size, eh_vec[i], eh_vec[i], FFTW_BACKWARD,
+                                 FFTW_MEASURE);
   }
 }
 
-void SplitFieldComponent::initialise_from_matlab(double ***tensor, Dimensions &dims) {
+void SplitFieldComponent::initialise_from_matlab(double ***tensor,
+                                                 Dimensions &dims) {
   this->tensor = tensor;
   this->n_layers = dims[2];
   this->n_cols = dims[1];
@@ -29,12 +33,10 @@ void SplitFieldComponent::initialise_from_matlab(double ***tensor, Dimensions &d
 
 SplitFieldComponent::~SplitFieldComponent() {
 
-  for (auto plan : {plan_f, plan_b}){
+  for (auto plan : {plan_f, plan_b}) {
     if (plan == nullptr) continue;
 
-    for (int i = 0; i < n_threads; i++){
-      fftw_destroy_plan(plan[i]);
-    }
+    for (int i = 0; i < n_threads; i++) { fftw_destroy_plan(plan[i]); }
     free(plan);
   }
   // superclass Tensor3D destructor removes tensor memory
@@ -42,7 +44,7 @@ SplitFieldComponent::~SplitFieldComponent() {
 
 void SplitField::allocate() {
 
-  for (auto component : {&xy, &xz, &yx, &yz, &zx, &zy}){
+  for (auto component : {&xy, &xz, &yx, &yz, &zx, &zy}) {
     component->allocate(tot.k + 1, tot.j + 1, tot.i + 1);
   }
 }
@@ -55,9 +57,7 @@ SplitField::SplitField(int I_total, int J_total, int K_total) {
 
 void SplitField::zero() {
 
-  for (auto component : {&xy, &xz, &yx, &yz, &zx, &zy}){
-    component->zero();
-  }
+  for (auto component : {&xy, &xz, &yx, &yz, &zx, &zy}) { component->zero(); }
 }
 
 void SplitField::initialise_fftw_plan(int n_threads, EHVec &eh_vec) {

--- a/tdms/src/fields/td_field_exporter_2d.cpp
+++ b/tdms/src/fields/td_field_exporter_2d.cpp
@@ -9,29 +9,33 @@ void TDFieldExporter2D::allocate(int _nI, int _nK) {
   nI = _nI;
   nK = _nK;
   mwSize dimensions[2] = {_nI, _nK};
-  matlab_array = mxCreateNumericArray(2, (const mwSize *)dimensions, mxDOUBLE_CLASS, mxREAL);
+  matlab_array = mxCreateNumericArray(2, (const mwSize *) dimensions,
+                                      mxDOUBLE_CLASS, mxREAL);
   array = cast_matlab_2D_array(mxGetPr((mxArray *) matlab_array), _nI, _nK);
 }
 
-TDFieldExporter2D::~TDFieldExporter2D() { free_cast_matlab_2D_array(array);
-}
+TDFieldExporter2D::~TDFieldExporter2D() { free_cast_matlab_2D_array(array); }
 
-void TDFieldExporter2D::export_field(SplitField& F, int stride, int iteration) const{
+void TDFieldExporter2D::export_field(SplitField &F, int stride,
+                                     int iteration) const {
 
   // need to check that enough memory was allocated before we cast!
   if ((nI < F.tot.i) || (nK < F.tot.k)) {
-    throw std::runtime_error("Not enough memory to write this field! (" + to_string(nI) + " , " + to_string(nK) + ") but need (" + to_string(F.tot.i) + " , " + to_string(F.tot.k) + ")");
+    throw std::runtime_error("Not enough memory to write this field! (" +
+                             to_string(nI) + " , " + to_string(nK) +
+                             ") but need (" + to_string(F.tot.i) + " , " +
+                             to_string(F.tot.k) + ")");
   }
   // if we have enough memory, then we can write out
   int i = 0;
   while (i < F.tot.i) {
-      int k = 0;
-      while (k < F.tot.k){
-        array[k][i] = F.xy[k][0][i] + F.xz[k][0][i];
-        k += stride;
-      }
-      i += stride;
+    int k = 0;
+    while (k < F.tot.k) {
+      array[k][i] = F.xy[k][0][i] + F.xz[k][0][i];
+      k += stride;
     }
+    i += stride;
+  }
 
   char toutputfilename[512];
   snprintf(toutputfilename, 512, "%s/ex_%06d.mat", folder_name, iteration);

--- a/tdms/src/grid_labels.cpp
+++ b/tdms/src/grid_labels.cpp
@@ -2,15 +2,15 @@
 
 #include "matlabio.h"
 
-GridLabels::GridLabels(const mxArray *ptr){
+GridLabels::GridLabels(const mxArray *ptr) {
 
   x = mxGetPr(ptr_to_vector_in(ptr, "x_grid_labels", "grid_labels"));
   y = mxGetPr(ptr_to_vector_in(ptr, "y_grid_labels", "grid_labels"));
   z = mxGetPr(ptr_to_vector_in(ptr, "z_grid_labels", "grid_labels"));
 }
 
-void GridLabels::initialise_from(const GridLabels &labels_to_copy_from, int i_l, int i_u, int j_l,
-                                 int j_u, int k_l, int k_u) {
+void GridLabels::initialise_from(const GridLabels &labels_to_copy_from, int i_l,
+                                 int i_u, int j_l, int j_u, int k_l, int k_u) {
   for (int i = i_l; i <= i_u; i++) { x[i - i_l] = labels_to_copy_from.x[i]; }
   for (int j = j_l; j <= j_u; j++) { y[j - j_l] = labels_to_copy_from.y[j]; }
   for (int k = k_l; k <= k_u; k++) { z[k - k_l] = labels_to_copy_from.z[k]; }

--- a/tdms/src/input_matrices.cpp
+++ b/tdms/src/input_matrices.cpp
@@ -1,22 +1,24 @@
 #include "input_matrices.h"
 
-#include <string.h>
 #include <stdexcept>
+#include <string.h>
 
 #include <spdlog/spdlog.h>
 
 #include "fdtd_grid_initialiser.h"
-#include "utils.h"
 #include "matlabio.h"
+#include "utils.h"
 
 using namespace std;
 using namespace tdms_matrix_names;
 
 int InputMatrices::index_from_matrix_name(const string &matrix_name) {
-  auto position = find(matrixnames_input_with_grid.begin(), matrixnames_input_with_grid.end(), matrix_name);
+  auto position = find(matrixnames_input_with_grid.begin(),
+                       matrixnames_input_with_grid.end(), matrix_name);
   if (position == matrixnames_input_with_grid.end()) {
     // could not find the matrix name in the list of expected input matrices
-    throw runtime_error(matrix_name + " not found in matrixnames_input_with_grid");
+    throw runtime_error(matrix_name +
+                        " not found in matrixnames_input_with_grid");
   }
   return distance(matrixnames_input_with_grid.begin(), position);
 }
@@ -24,28 +26,35 @@ int InputMatrices::index_from_matrix_name(const string &matrix_name) {
 void InputMatrices::set_from_input_file(const char *mat_filename) {
   MatrixCollection infile_expected(matrixnames_input_with_grid);
   MatFileMatrixCollection infile_contains(mat_filename);
-  spdlog::info("Input file: " + string(mat_filename) + " | No gridfile supplied");
+  spdlog::info("Input file: " + string(mat_filename) +
+               " | No gridfile supplied");
 
-  // check that the input file actually has enough matrices for what we're expecting
+  // check that the input file actually has enough matrices for what we're
+  // expecting
   infile_contains.check_has_at_least_as_many_matrices_as(infile_expected);
   // assign the pointers to the matrices
   assign_matrix_pointers(infile_expected, infile_contains);
 
   // Add fields to fdtdgrid
-  auto initialiser =
-          fdtdGridInitialiser(matrix_pointers[index_from_matrix_name("fdtdgrid")], mat_filename);
-  const vector<string> fdtdgrid_element_names = {"Exy", "Exz", "Eyx", "Eyz", "Ezx", "Ezy",
-                                                  "Hxy", "Hxz", "Hyx", "Hyz", "Hzx", "Hzy"};
+  auto initialiser = fdtdGridInitialiser(
+          matrix_pointers[index_from_matrix_name("fdtdgrid")], mat_filename);
+  const vector<string> fdtdgrid_element_names = {"Exy", "Exz", "Eyx", "Eyz",
+                                                 "Ezx", "Ezy", "Hxy", "Hxz",
+                                                 "Hyx", "Hyz", "Hzx", "Hzy"};
 
-  for (const auto &name : fdtdgrid_element_names) { initialiser.add_tensor(name); }
+  for (const auto &name : fdtdgrid_element_names) {
+    initialiser.add_tensor(name);
+  }
 
   // validate the input arguments
   validate_assigned_pointers();
 }
-void InputMatrices::set_from_input_file(const char *mat_filename, const char *gridfile) {
+void InputMatrices::set_from_input_file(const char *mat_filename,
+                                        const char *gridfile) {
   MatrixCollection infile_expected(matrixnames_infile);
   MatFileMatrixCollection infile_contains(mat_filename);
-  spdlog::info("Input file: " + string(mat_filename) + " | Gridfile: " + string(gridfile));
+  spdlog::info("Input file: " + string(mat_filename) +
+               " | Gridfile: " + string(gridfile));
 
   // first extract fdtdgrid from the gridfile provided
   MatrixCollection gridfile_expected(matrixnames_gridfile);
@@ -55,31 +64,38 @@ void InputMatrices::set_from_input_file(const char *mat_filename, const char *gr
   // this is the matrix name we are searching for in the gridfile
   string fdtd_matrix_search_string = gridfile_expected.matrix_names[0];
   // check that the gridfile actually contains the fdtdgrid
-  auto position = find(gridfile_contains.matrix_names.begin(), gridfile_contains.matrix_names.end(),
-                       fdtd_matrix_search_string);
+  auto position =
+          find(gridfile_contains.matrix_names.begin(),
+               gridfile_contains.matrix_names.end(), fdtd_matrix_search_string);
   if (position == matrixnames_input_with_grid.end()) {
     throw runtime_error(fdtd_matrix_search_string + " not found in gridfile");
   }
   // attempt to set the pointer
-  auto pointer = matGetVariable(gridfile_contains.mat_file, fdtd_matrix_search_string.c_str());
+  auto pointer = matGetVariable(gridfile_contains.mat_file,
+                                fdtd_matrix_search_string.c_str());
   if (pointer == nullptr) {
-    throw runtime_error("Could not get pointer to " + fdtd_matrix_search_string);
+    throw runtime_error("Could not get pointer to " +
+                        fdtd_matrix_search_string);
   }
   set_matrix_pointer("fdtdgrid", pointer);
 
   // now pick up the other matrix inputs from the usual input file
-  // check that the input file actually has enough matrices for what we're expecting
+  // check that the input file actually has enough matrices for what we're
+  // expecting
   infile_contains.check_has_at_least_as_many_matrices_as(infile_expected);
   // assign the pointers to the matrices
   assign_matrix_pointers(infile_expected, infile_contains);
 
   // Add fields to fdtdgrid
-  auto initialiser =
-          fdtdGridInitialiser(matrix_pointers[index_from_matrix_name("fdtdgrid")], mat_filename);
-  const vector<string> fdtdgrid_element_names = {"Exy", "Exz", "Eyx", "Eyz", "Ezx", "Ezy",
-                                                  "Hxy", "Hxz", "Hyx", "Hyz", "Hzx", "Hzy"};
+  auto initialiser = fdtdGridInitialiser(
+          matrix_pointers[index_from_matrix_name("fdtdgrid")], mat_filename);
+  const vector<string> fdtdgrid_element_names = {"Exy", "Exz", "Eyx", "Eyz",
+                                                 "Ezx", "Ezy", "Hxy", "Hxz",
+                                                 "Hyx", "Hyz", "Hzx", "Hzy"};
 
-  for (const auto &name : fdtdgrid_element_names) { initialiser.add_tensor(name); }
+  for (const auto &name : fdtdgrid_element_names) {
+    initialiser.add_tensor(name);
+  }
 
   // validate the input arguments
   validate_assigned_pointers();
@@ -88,9 +104,11 @@ void InputMatrices::set_from_input_file(const char *mat_filename, const char *gr
 void InputMatrices::assign_matrix_pointers(MatrixCollection &expected,
                                            MatFileMatrixCollection &actual) {
   // for each matrix we expect to recieve
-  for(string &expected_matrix : expected.matrix_names) {
-    // look for this matrix name in the input file, throw an error if it is not present
-    auto position = find(actual.matrix_names.begin(), actual.matrix_names.end(), expected_matrix);
+  for (string &expected_matrix : expected.matrix_names) {
+    // look for this matrix name in the input file, throw an error if it is not
+    // present
+    auto position = find(actual.matrix_names.begin(), actual.matrix_names.end(),
+                         expected_matrix);
     if (position == actual.matrix_names.end()) {
       throw runtime_error(expected_matrix + " not found in input file");
     }
@@ -106,22 +124,29 @@ void InputMatrices::assign_matrix_pointers(MatrixCollection &expected,
 
 void InputMatrices::validate_assigned_pointers() {
   // certain arrays must be structure arrays
-  assert_is_struct(matrix_pointers[index_from_matrix_name("fdtdgrid")], "fdtdgrid");
-  assert_is_struct(matrix_pointers[index_from_matrix_name("Cmaterial")], "Cmaterial");
-  assert_is_struct(matrix_pointers[index_from_matrix_name("Dmaterial")], "Dmaterial");
+  assert_is_struct(matrix_pointers[index_from_matrix_name("fdtdgrid")],
+                   "fdtdgrid");
+  assert_is_struct(matrix_pointers[index_from_matrix_name("Cmaterial")],
+                   "Cmaterial");
+  assert_is_struct(matrix_pointers[index_from_matrix_name("Dmaterial")],
+                   "Dmaterial");
   assert_is_struct(matrix_pointers[index_from_matrix_name("C")], "C");
   assert_is_struct(matrix_pointers[index_from_matrix_name("D")], "D");
 
   // other arrays must contain a specific number of fieldnames
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("freespace")], 6,
-                                  "freespace");
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("disp_params")], 3,
-                                  "disp_params");
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("delta")], 3, "delta");
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("interface")], 6,
-                                  "interface");
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("grid_labels")], 3,
-                                  "grid_labels");
-  assert_is_struct_with_n_fields(matrix_pointers[index_from_matrix_name("conductive_aux")], 3,
-                                  "conductive_aux");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("freespace")], 6, "freespace");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("disp_params")], 3,
+          "disp_params");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("delta")], 3, "delta");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("interface")], 6, "interface");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("grid_labels")], 3,
+          "grid_labels");
+  assert_is_struct_with_n_fields(
+          matrix_pointers[index_from_matrix_name("conductive_aux")], 3,
+          "conductive_aux");
 }

--- a/tdms/src/interface.cpp
+++ b/tdms/src/interface.cpp
@@ -1,25 +1,26 @@
 #include "interface.h"
 
-#include <string>
 #include <algorithm>
+#include <string>
 
 #include "matlabio.h"
 
 using namespace std;
 
-InterfaceComponent::InterfaceComponent(const mxArray *ptr, const string &name){
+InterfaceComponent::InterfaceComponent(const mxArray *ptr, const string &name) {
 
   auto element = ptr_to_matrix_in(ptr, name, "interface");
   auto dims = mxGetDimensions(element);
 
   if (!(dims[0] == 1 && dims[1] == 2)) {
-    throw runtime_error("Incorrect dimension on interface." + name + " (" +
-                        to_string((int) dims[0]) + "," +
-                        to_string((int) dims[1]) + "," +
-                        to_string((int) mxGetNumberOfElements(element)) + ")\n");
+    throw runtime_error(
+            "Incorrect dimension on interface." + name + " (" +
+            to_string((int) dims[0]) + "," + to_string((int) dims[1]) + "," +
+            to_string((int) mxGetNumberOfElements(element)) + ")\n");
   }
 
   auto array = mxGetPr((mxArray *) element);
-  index = max((int)array[0] - 1, 0);   // convert matlab to C indexing, ensuring a min of at least 0
-  apply = (bool)array[1];
+  index = max((int) array[0] - 1,
+              0);// convert matlab to C indexing, ensuring a min of at least 0
+  apply = (bool) array[1];
 }

--- a/tdms/src/interpolation_methods.cpp
+++ b/tdms/src/interpolation_methods.cpp
@@ -7,193 +7,185 @@ using namespace std;
 
 InterpolationScheme::InterpolationScheme(scheme_value val) {
 
-    // set the value field
-    priority = val;
+  // set the value field
+  priority = val;
 
-    // set values for this method based on the scheme_value passed in
-    // these are all hard-coded values - there is no way around a long list of cases!
-    switch (val) {
-        case BAND_LIMITED_0:
-        {
-            scheme_coeffs[0] = 0.389880694606603;
-            scheme_coeffs[1] = 0.752494454088346;
-            scheme_coeffs[2] = -0.182115867658487;
-            scheme_coeffs[3] = 0.046235288061499;
-            scheme_coeffs[4] = -0.006777513830539;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 4;
-            number_of_datapoints_to_left = 1;
-            break;
-        }
-        case BAND_LIMITED_1:
-        {
-            scheme_coeffs[0] = -0.077297572626688;
-            scheme_coeffs[1] = 0.570378586429859;
-            scheme_coeffs[2] = 0.616613874491358;
-            scheme_coeffs[3] = -0.142658093427528;
-            scheme_coeffs[4] = 0.039457774230959;
-            scheme_coeffs[5] = -0.006777513830539;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 5;
-            number_of_datapoints_to_left = 2;
-            break;
-        }
-        case BAND_LIMITED_2:
-        {
-            scheme_coeffs[0] = 0.025902746569881;
-            scheme_coeffs[1] = -0.135880579596988;
-            scheme_coeffs[2] = 0.609836360660818;
-            scheme_coeffs[3] = 0.609836360660818;
-            scheme_coeffs[4] = -0.142658093427528;
-            scheme_coeffs[5] = 0.039457774230959;
-            scheme_coeffs[6] = -0.006777513830539;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 6;
-            number_of_datapoints_to_left = 3;
-            break;
-        }
-        case BAND_LIMITED_3:
-        {
-            scheme_coeffs[0] = -0.006777513830539;
-            scheme_coeffs[1] = 0.039457774230959;
-            scheme_coeffs[2] = -0.142658093427528;
-            scheme_coeffs[3] = 0.609836360660818;
-            scheme_coeffs[4] = 0.609836360660818;
-            scheme_coeffs[5] = -0.142658093427528;
-            scheme_coeffs[6] = 0.039457774230959;
-            scheme_coeffs[7] =  -0.006777513830539;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 7;
-            number_of_datapoints_to_left = 4;
-            break;
-        }
-        case BAND_LIMITED_4:
-        {
-            scheme_coeffs[1] = -0.006777513830539;
-            scheme_coeffs[2] = 0.039457774230959;
-            scheme_coeffs[3] = -0.142658093427528;
-            scheme_coeffs[4] = 0.609836360660818;
-            scheme_coeffs[5] = 0.609836360660818;
-            scheme_coeffs[6] = -0.135880579596988;
-            scheme_coeffs[7] = 0.025902746569881;
-            first_nonzero_coeff = 1;
-            last_nonzero_coeff = 7;
-            number_of_datapoints_to_left = 5;
-            break;
-        }
-        case BAND_LIMITED_5:
-        {
-            scheme_coeffs[2] = -0.006777513830539;
-            scheme_coeffs[3] = 0.039457774230959;
-            scheme_coeffs[4] = -0.142658093427528;
-            scheme_coeffs[5] = 0.616613874491358;
-            scheme_coeffs[6] = 0.570378586429859;
-            scheme_coeffs[7] = -0.077297572626688;
-            first_nonzero_coeff = 2;
-            last_nonzero_coeff = 7;
-            number_of_datapoints_to_left = 6;
-            break;
-        }
-        case BAND_LIMITED_6:
-        {
-            scheme_coeffs[3] = -0.006777513830539;
-            scheme_coeffs[4] = 0.046235288061499;
-            scheme_coeffs[5] = -0.182115867658487;
-            scheme_coeffs[6] = 0.752494454088346;
-            scheme_coeffs[7] = 0.389880694606603;
-            first_nonzero_coeff = 3;
-            last_nonzero_coeff = 7;
-            number_of_datapoints_to_left = 7;
-            break;
-        }
-        case BAND_LIMITED_7:
-        {
-            scheme_coeffs[3] = 0.006777513830539;
-            scheme_coeffs[4] = -0.046235288061499;
-            scheme_coeffs[5] = 0.182115867658487;
-            scheme_coeffs[6] = -0.752494454088346;
-            scheme_coeffs[7] = 1.609553415928240;
-            first_nonzero_coeff = 3;
-            last_nonzero_coeff = 7;
-            number_of_datapoints_to_left = 8;
-            break;
-        }
-        case BAND_LIMITED_CELL_ZERO:
-        {
-            // by symmetry, we can reflect the setup for BLi to position 7 in order to interpolate to the centre of Yee cell 0
-            scheme_coeffs[0] = 1.609553415928240;
-            scheme_coeffs[1] = -0.752494454088346;
-            scheme_coeffs[2] = 0.182115867658487;
-            scheme_coeffs[3] = -0.046235288061499;
-            scheme_coeffs[4] = 0.006777513830539;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 4;
-            number_of_datapoints_to_left = 0;
-            break;
-        }
-        case CUBIC_INTERP_FIRST:
-        {
-            scheme_coeffs[0] = 5. / 16.;
-            scheme_coeffs[1] = 15. / 16.;
-            scheme_coeffs[2] = -5. / 16.;
-            scheme_coeffs[3] = 1. / 16.;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 3;
-            number_of_datapoints_to_left = 1;
-            break;
-        }
-        case CUBIC_INTERP_MIDDLE:
-        {
-            scheme_coeffs[0] = -1. / 16.;
-            scheme_coeffs[1] = 9. / 16.;
-            scheme_coeffs[2] = 9. / 16.;
-            scheme_coeffs[3] = -1. / 16.;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 3;
-            number_of_datapoints_to_left = 2;
-            break;
-        }
-        case CUBIC_INTERP_LAST:
-        {
-            scheme_coeffs[0] = 1. / 16.;
-            scheme_coeffs[1] = -5. / 16.;
-            scheme_coeffs[2] = 15. / 16.;
-            scheme_coeffs[3] = 5. / 16.;
-            first_nonzero_coeff = 0;
-            last_nonzero_coeff = 3;
-            number_of_datapoints_to_left = 3;
-            break;
-        }
-        default:
-        {
-            // if we cannot identify the scheme from it's value, throw an error
-            throw runtime_error("Error: could not assign value " + std::to_string(val) + " to interpolation scheme.\n");
-            break;
-        }
+  // set values for this method based on the scheme_value passed in
+  // these are all hard-coded values - there is no way around a long list of
+  // cases!
+  switch (val) {
+    case BAND_LIMITED_0: {
+      scheme_coeffs[0] = 0.389880694606603;
+      scheme_coeffs[1] = 0.752494454088346;
+      scheme_coeffs[2] = -0.182115867658487;
+      scheme_coeffs[3] = 0.046235288061499;
+      scheme_coeffs[4] = -0.006777513830539;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 4;
+      number_of_datapoints_to_left = 1;
+      break;
     }
+    case BAND_LIMITED_1: {
+      scheme_coeffs[0] = -0.077297572626688;
+      scheme_coeffs[1] = 0.570378586429859;
+      scheme_coeffs[2] = 0.616613874491358;
+      scheme_coeffs[3] = -0.142658093427528;
+      scheme_coeffs[4] = 0.039457774230959;
+      scheme_coeffs[5] = -0.006777513830539;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 5;
+      number_of_datapoints_to_left = 2;
+      break;
+    }
+    case BAND_LIMITED_2: {
+      scheme_coeffs[0] = 0.025902746569881;
+      scheme_coeffs[1] = -0.135880579596988;
+      scheme_coeffs[2] = 0.609836360660818;
+      scheme_coeffs[3] = 0.609836360660818;
+      scheme_coeffs[4] = -0.142658093427528;
+      scheme_coeffs[5] = 0.039457774230959;
+      scheme_coeffs[6] = -0.006777513830539;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 6;
+      number_of_datapoints_to_left = 3;
+      break;
+    }
+    case BAND_LIMITED_3: {
+      scheme_coeffs[0] = -0.006777513830539;
+      scheme_coeffs[1] = 0.039457774230959;
+      scheme_coeffs[2] = -0.142658093427528;
+      scheme_coeffs[3] = 0.609836360660818;
+      scheme_coeffs[4] = 0.609836360660818;
+      scheme_coeffs[5] = -0.142658093427528;
+      scheme_coeffs[6] = 0.039457774230959;
+      scheme_coeffs[7] = -0.006777513830539;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 7;
+      number_of_datapoints_to_left = 4;
+      break;
+    }
+    case BAND_LIMITED_4: {
+      scheme_coeffs[1] = -0.006777513830539;
+      scheme_coeffs[2] = 0.039457774230959;
+      scheme_coeffs[3] = -0.142658093427528;
+      scheme_coeffs[4] = 0.609836360660818;
+      scheme_coeffs[5] = 0.609836360660818;
+      scheme_coeffs[6] = -0.135880579596988;
+      scheme_coeffs[7] = 0.025902746569881;
+      first_nonzero_coeff = 1;
+      last_nonzero_coeff = 7;
+      number_of_datapoints_to_left = 5;
+      break;
+    }
+    case BAND_LIMITED_5: {
+      scheme_coeffs[2] = -0.006777513830539;
+      scheme_coeffs[3] = 0.039457774230959;
+      scheme_coeffs[4] = -0.142658093427528;
+      scheme_coeffs[5] = 0.616613874491358;
+      scheme_coeffs[6] = 0.570378586429859;
+      scheme_coeffs[7] = -0.077297572626688;
+      first_nonzero_coeff = 2;
+      last_nonzero_coeff = 7;
+      number_of_datapoints_to_left = 6;
+      break;
+    }
+    case BAND_LIMITED_6: {
+      scheme_coeffs[3] = -0.006777513830539;
+      scheme_coeffs[4] = 0.046235288061499;
+      scheme_coeffs[5] = -0.182115867658487;
+      scheme_coeffs[6] = 0.752494454088346;
+      scheme_coeffs[7] = 0.389880694606603;
+      first_nonzero_coeff = 3;
+      last_nonzero_coeff = 7;
+      number_of_datapoints_to_left = 7;
+      break;
+    }
+    case BAND_LIMITED_7: {
+      scheme_coeffs[3] = 0.006777513830539;
+      scheme_coeffs[4] = -0.046235288061499;
+      scheme_coeffs[5] = 0.182115867658487;
+      scheme_coeffs[6] = -0.752494454088346;
+      scheme_coeffs[7] = 1.609553415928240;
+      first_nonzero_coeff = 3;
+      last_nonzero_coeff = 7;
+      number_of_datapoints_to_left = 8;
+      break;
+    }
+    case BAND_LIMITED_CELL_ZERO: {
+      // by symmetry, we can reflect the setup for BLi to position 7 in order to
+      // interpolate to the centre of Yee cell 0
+      scheme_coeffs[0] = 1.609553415928240;
+      scheme_coeffs[1] = -0.752494454088346;
+      scheme_coeffs[2] = 0.182115867658487;
+      scheme_coeffs[3] = -0.046235288061499;
+      scheme_coeffs[4] = 0.006777513830539;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 4;
+      number_of_datapoints_to_left = 0;
+      break;
+    }
+    case CUBIC_INTERP_FIRST: {
+      scheme_coeffs[0] = 5. / 16.;
+      scheme_coeffs[1] = 15. / 16.;
+      scheme_coeffs[2] = -5. / 16.;
+      scheme_coeffs[3] = 1. / 16.;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 3;
+      number_of_datapoints_to_left = 1;
+      break;
+    }
+    case CUBIC_INTERP_MIDDLE: {
+      scheme_coeffs[0] = -1. / 16.;
+      scheme_coeffs[1] = 9. / 16.;
+      scheme_coeffs[2] = 9. / 16.;
+      scheme_coeffs[3] = -1. / 16.;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 3;
+      number_of_datapoints_to_left = 2;
+      break;
+    }
+    case CUBIC_INTERP_LAST: {
+      scheme_coeffs[0] = 1. / 16.;
+      scheme_coeffs[1] = -5. / 16.;
+      scheme_coeffs[2] = 15. / 16.;
+      scheme_coeffs[3] = 5. / 16.;
+      first_nonzero_coeff = 0;
+      last_nonzero_coeff = 3;
+      number_of_datapoints_to_left = 3;
+      break;
+    }
+    default: {
+      // if we cannot identify the scheme from it's value, throw an error
+      throw runtime_error("Error: could not assign value " +
+                          std::to_string(val) + " to interpolation scheme.\n");
+      break;
+    }
+  }
 }
 
-scheme_value InterpolationScheme::get_priority() const {
-    return priority;
-}
+scheme_value InterpolationScheme::get_priority() const { return priority; }
 
 int InterpolationScheme::num_nonzero_coeffs() const {
-    return last_nonzero_coeff - first_nonzero_coeff + 1;
+  return last_nonzero_coeff - first_nonzero_coeff + 1;
 }
 
 bool InterpolationScheme::is_better_than(const InterpolationScheme &s) const {
-    return (priority > s.get_priority());
+  return (priority > s.get_priority());
 }
 
-const InterpolationScheme &best_scheme(int datapts_in_direction, int interpolation_position,
-                                       PreferredInterpolationMethods interpolation_methods) {
+const InterpolationScheme &
+best_scheme(int datapts_in_direction, int interpolation_position,
+            PreferredInterpolationMethods interpolation_methods) {
   // interpolation is impossible with fewer than 4 datapoints in a dimension
   if (datapts_in_direction < 4) {
-    throw out_of_range("Error: domain axis has <4 datapoints, cubic and bandlimited interpolation "
+    throw out_of_range("Error: domain axis has <4 datapoints, cubic and "
+                       "bandlimited interpolation "
                        "impossible.\n");
-  } else if ((datapts_in_direction < 8) || (interpolation_methods == PreferredInterpolationMethods::Cubic)) {
+  } else if ((datapts_in_direction < 8) ||
+             (interpolation_methods == PreferredInterpolationMethods::Cubic)) {
     // we are restricted to cubic interpolation
-    if (interpolation_position <= 0 || interpolation_position >= datapts_in_direction) {
+    if (interpolation_position <= 0 ||
+        interpolation_position >= datapts_in_direction) {
       throw out_of_range("Error: Cubic interpolation impossible to position " +
                          to_string(interpolation_position) + "\n");
     } else {
@@ -206,7 +198,8 @@ const InterpolationScheme &best_scheme(int datapts_in_direction, int interpolati
         return CBMid;
       }
     }
-  } else if (interpolation_position < 0 || interpolation_position > datapts_in_direction) {
+  } else if (interpolation_position < 0 ||
+             interpolation_position > datapts_in_direction) {
     // cannot interpolate to here using BLi, throw error
     throw out_of_range("Error: BLi interpolation impossible to position " +
                        to_string(interpolation_position) + "\n");
@@ -234,5 +227,6 @@ const InterpolationScheme &best_scheme(int datapts_in_direction, int interpolati
     }
   }
   // if we get to here we have, somehow, not returned a scheme. Raise an error
-  throw runtime_error("Error: could not identify scheme for unknown reasons, diagnose further.\n");
+  throw runtime_error("Error: could not identify scheme for unknown reasons, "
+                      "diagnose further.\n");
 }

--- a/tdms/src/main.cpp
+++ b/tdms/src/main.cpp
@@ -8,31 +8,32 @@
 
 using namespace tdms_matrix_names;
 
-int main(int nargs, char *argv[]){
+int main(int nargs, char *argv[]) {
 
-  // Set the logging level with a compile-time #define for debugging
-  #if SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_DEBUG
-    spdlog::set_level(spdlog::level::debug);
-  #elif SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_INFO
-    spdlog::set_level(spdlog::level::info);
-  #endif
+// Set the logging level with a compile-time #define for debugging
+#if SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_DEBUG
+  spdlog::set_level(spdlog::level::debug);
+#elif SPDLOG_ACTIVE_LEVEL == SPDLOG_LEVEL_INFO
+  spdlog::set_level(spdlog::level::info);
+#endif
 
   InputMatrices matrix_inputs;
 
   auto args = ArgumentParser::parse_args(nargs, argv);
   args.check_files_can_be_accessed();
 
-  //now it is safe to use matlab routines to open the file and order the matrices
+  // now it is safe to use matlab routines to open the file and order the
+  // matrices
   if (!args.has_grid_filename()) {
     matrix_inputs.set_from_input_file(args.input_filename());
   } else {
-    matrix_inputs.set_from_input_file(args.input_filename(), args.grid_filename());
+    matrix_inputs.set_from_input_file(args.input_filename(),
+                                      args.grid_filename());
   }
 
   // decide which derivative method to use (PSTD or FDTD)
-  SolverMethod solver_method = PseudoSpectral; // default
-  if (args.finite_difference())
-    solver_method = SolverMethod::FiniteDifference;
+  SolverMethod solver_method = PseudoSpectral;// default
+  if (args.finite_difference()) solver_method = SolverMethod::FiniteDifference;
 
   // decide whether to toggle off the band-limited interpolation methods
   PreferredInterpolationMethods preferred_interpolation_methods =
@@ -42,7 +43,8 @@ int main(int nargs, char *argv[]){
   }
 
   // Handles the running of the simulation, given the inputs to the executable.
-  SimulationManager simulation(matrix_inputs, solver_method, preferred_interpolation_methods);
+  SimulationManager simulation(matrix_inputs, solver_method,
+                               preferred_interpolation_methods);
 
   // now run the time propagation code
   simulation.execute();
@@ -51,7 +53,8 @@ int main(int nargs, char *argv[]){
   simulation.post_loop_processing();
 
   // save the outputs, possibly in compressed format
-  simulation.write_outputs_to_file(args.output_filename(), args.have_flag("-m"));
+  simulation.write_outputs_to_file(args.output_filename(),
+                                   args.have_flag("-m"));
 
   return 0;
 }

--- a/tdms/src/matrix_collection.cpp
+++ b/tdms/src/matrix_collection.cpp
@@ -1,7 +1,7 @@
 #include "matrix_collection.h"
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
 #include <spdlog/spdlog.h>
 
@@ -9,16 +9,17 @@
 
 using namespace std;
 
-MatFileMatrixCollection::MatFileMatrixCollection(const char *filename){
+MatFileMatrixCollection::MatFileMatrixCollection(const char *filename) {
 
   mat_file = matOpen(filename, "r");
-  if(mat_file == nullptr){
-    throw runtime_error("Error opening "+string(filename));
+  if (mat_file == nullptr) {
+    throw runtime_error("Error opening " + string(filename));
   }
 
   int tmp_n;
   char **matlab_file_contents = matGetDir(mat_file, &tmp_n);
-  matrix_names = vector<string>(matlab_file_contents, matlab_file_contents+tmp_n);
+  matrix_names =
+          vector<string>(matlab_file_contents, matlab_file_contents + tmp_n);
   n_matrices = tmp_n;
 }
 
@@ -28,18 +29,17 @@ MatrixCollection::MatrixCollection(vector<string> names) {
   n_matrices = names.size();
 }
 
-void MatrixCollection::check_has_at_least_as_many_matrices_as(MatrixCollection &other) {
+void MatrixCollection::check_has_at_least_as_many_matrices_as(
+        MatrixCollection &other) {
 
-  if(n_matrices < other.n_matrices){
-    throw runtime_error("Not enough matrices in mat file: " +
-                        to_string(n_matrices) + " " +
-                        to_string(other.n_matrices));
+  if (n_matrices < other.n_matrices) {
+    throw runtime_error(
+            "Not enough matrices in mat file: " + to_string(n_matrices) + " " +
+            to_string(other.n_matrices));
   }
 }
 
 MatFileMatrixCollection::~MatFileMatrixCollection() {
-  if (mat_file != nullptr){
-    matClose(mat_file);
-  }
+  if (mat_file != nullptr) { matClose(mat_file); }
   matrix_names.clear();
 }

--- a/tdms/src/mesh_base.cpp
+++ b/tdms/src/mesh_base.cpp
@@ -8,244 +8,255 @@
 
 using namespace std;
 
-void triangulatePlane(int I0, int I1, int J0, int J1, int K,int coordmap[], int order, mxArray **vertexMatrix){
+void triangulatePlane(int I0, int I1, int J0, int J1, int K, int coordmap[],
+                      int order, mxArray **vertexMatrix) {
   int i, j, ndims, dims[2], counter = 0;
-  int temp_res[] = {0,0,0};
+  int temp_res[] = {0, 0, 0};
   int **vertices;
   char buffer[100];
 
-  //first some basic error checks
+  // first some basic error checks
   /*  if( I1 <= I0 )
     mexErrMsgTxt("Error in triangulatePlane(), must have I1 > I0");
   if( J1 <= J0 )
     mexErrMsgTxt("Error in triangulatePlane(), must have J1 > J0");
   */
-  //now check that coordmap is correct, should be a permutation on {0,1,2}
-  for(i=0;i<=2;i++)
-    for(j=0;j<=2;j++)
-      temp_res[j] = temp_res[j] || coordmap[i]==j;
+  // now check that coordmap is correct, should be a permutation on {0,1,2}
+  for (i = 0; i <= 2; i++)
+    for (j = 0; j <= 2; j++) temp_res[j] = temp_res[j] || coordmap[i] == j;
 
-  //check all numbers are within range and none are equal
-  if( !(temp_res[0] && temp_res[1] && temp_res[2]) || (coordmap[0]==coordmap[1]) || (coordmap[1]==coordmap[2]) || (coordmap[0]==coordmap[2])){
-    snprintf(buffer, 100, "Error in triangulatePlane(), coordmap incorrect [%d %d %d], [%d %d %d]",coordmap[0],coordmap[1],coordmap[2],temp_res[0],temp_res[1],temp_res[2]);
+  // check all numbers are within range and none are equal
+  if (!(temp_res[0] && temp_res[1] && temp_res[2]) ||
+      (coordmap[0] == coordmap[1]) || (coordmap[1] == coordmap[2]) ||
+      (coordmap[0] == coordmap[2])) {
+    snprintf(buffer, 100,
+             "Error in triangulatePlane(), coordmap incorrect [%d %d %d], [%d "
+             "%d %d]",
+             coordmap[0], coordmap[1], coordmap[2], temp_res[0], temp_res[1],
+             temp_res[2]);
     mexErrMsgTxt(buffer);
-
   }
 
   ndims = 2;
 
-  dims[1] = 9;                //each triangle has 3 vertices and each vertex has three indices
-  dims[0] = 2*(I1-I0)*(J1-J0);//number of triangles
+  dims[1] = 9;// each triangle has 3 vertices and each vertex has three indices
+  dims[0] = 2 * (I1 - I0) * (J1 - J0);// number of triangles
 
 
-  *vertexMatrix =  mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
+  *vertexMatrix = mxCreateNumericArray(ndims, (const mwSize *) dims,
+                                       mxINT32_CLASS, mxREAL);
 
-  vertices = cast_matlab_2D_array((int *) mxGetPr(*vertexMatrix), dims[0], dims[1]);
+  vertices = cast_matlab_2D_array((int *) mxGetPr(*vertexMatrix), dims[0],
+                                  dims[1]);
 
-  if( !(order==1 || order==-1) )
-    mexErrMsgTxt("Error in triangulatePlane(), order can take the value of +1 or -1");
+  if (!(order == 1 || order == -1))
+    mexErrMsgTxt("Error in triangulatePlane(), order can take the value of +1 "
+                 "or -1");
 
-  if( order == 1)
-    for(j=J0;j<J1;j++)
-      for(i=I0;i<I1;i++){
-	//triangle 1
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+  if (order == 1)
+    for (j = J0; j < J1; j++)
+      for (i = I0; i < I1; i++) {
+        // triangle 1
+        // vertex 1
+        vertices[coordmap[0]][counter] = i;
+        vertices[coordmap[1]][counter] = j;
+        vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[3+coordmap[0]][counter]   =   i+1;
-	vertices[3+coordmap[1]][counter]   =   j;
-	vertices[3+coordmap[2]][counter]   =   K;
+        /// vertex 2
+        vertices[3 + coordmap[0]][counter] = i + 1;
+        vertices[3 + coordmap[1]][counter] = j;
+        vertices[3 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[6+coordmap[0]][counter]   =   i;
-	vertices[6+coordmap[1]][counter]   =   j+1;
-	vertices[6+coordmap[2]][counter++]   =   K;
+        /// vertex 3
+        vertices[6 + coordmap[0]][counter] = i;
+        vertices[6 + coordmap[1]][counter] = j + 1;
+        vertices[6 + coordmap[2]][counter++] = K;
 
-	//triangle 2
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i+1;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+        // triangle 2
+        // vertex 1
+        vertices[coordmap[0]][counter] = i + 1;
+        vertices[coordmap[1]][counter] = j;
+        vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[6+coordmap[0]][counter]   =   i;
-	vertices[6+coordmap[1]][counter]   =   j+1;
-	vertices[6+coordmap[2]][counter]   =   K;
+        /// vertex 2
+        vertices[6 + coordmap[0]][counter] = i;
+        vertices[6 + coordmap[1]][counter] = j + 1;
+        vertices[6 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[3+coordmap[0]][counter]   =   i+1;
-	vertices[3+coordmap[1]][counter]   =   j+1;
-	vertices[3+coordmap[2]][counter++]   =   K;
-
+        /// vertex 3
+        vertices[3 + coordmap[0]][counter] = i + 1;
+        vertices[3 + coordmap[1]][counter] = j + 1;
+        vertices[3 + coordmap[2]][counter++] = K;
       }
   else
-     for(j=J0;j<J1;j++)
-      for(i=I0;i<I1;i++){
-	//triangle 1
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+    for (j = J0; j < J1; j++)
+      for (i = I0; i < I1; i++) {
+        // triangle 1
+        // vertex 1
+        vertices[coordmap[0]][counter] = i;
+        vertices[coordmap[1]][counter] = j;
+        vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[6+coordmap[0]][counter]   =   i+1;
-	vertices[6+coordmap[1]][counter]   =   j;
-	vertices[6+coordmap[2]][counter]   =   K;
+        /// vertex 2
+        vertices[6 + coordmap[0]][counter] = i + 1;
+        vertices[6 + coordmap[1]][counter] = j;
+        vertices[6 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[3+coordmap[0]][counter]   =   i;
-	vertices[3+coordmap[1]][counter]   =   j+1;
-	vertices[3+coordmap[2]][counter++]   =   K;
+        /// vertex 3
+        vertices[3 + coordmap[0]][counter] = i;
+        vertices[3 + coordmap[1]][counter] = j + 1;
+        vertices[3 + coordmap[2]][counter++] = K;
 
-	//triangle 2
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i+1;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+        // triangle 2
+        // vertex 1
+        vertices[coordmap[0]][counter] = i + 1;
+        vertices[coordmap[1]][counter] = j;
+        vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[3+coordmap[0]][counter]   =   i;
-	vertices[3+coordmap[1]][counter]   =   j+1;
-	vertices[3+coordmap[2]][counter]   =   K;
+        /// vertex 2
+        vertices[3 + coordmap[0]][counter] = i;
+        vertices[3 + coordmap[1]][counter] = j + 1;
+        vertices[3 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[6+coordmap[0]][counter]   =   i+1;
-	vertices[6+coordmap[1]][counter]   =   j+1;
-	vertices[6+coordmap[2]][counter++]   =   K;
-
+        /// vertex 3
+        vertices[6 + coordmap[0]][counter] = i + 1;
+        vertices[6 + coordmap[1]][counter] = j + 1;
+        vertices[6 + coordmap[2]][counter++] = K;
       }
 
-  //now free memory
+  // now free memory
 
   free_cast_matlab_2D_array(vertices);
 }
 
-void triangulatePlaneSkip(int I0, int I1, int J0, int J1, int K,int coordmap[], int order, mxArray **vertexMatrix, int dI, int dJ){
+void triangulatePlaneSkip(int I0, int I1, int J0, int J1, int K, int coordmap[],
+                          int order, mxArray **vertexMatrix, int dI, int dJ) {
   int i, j, ndims, dims[2], counter = 0, countI = 0, countJ = 0;
-  int temp_res[] = {0,0,0};
+  int temp_res[] = {0, 0, 0};
   int **vertices;
   char buffer[100];
 
-  //first some basic error checks
+  // first some basic error checks
   /*  if( I1 <= I0 )
     mexErrMsgTxt("Error in triangulatePlane(), must have I1 > I0");
   if( J1 <= J0 )
     mexErrMsgTxt("Error in triangulatePlane(), must have J1 > J0");
   */
-  //now check that coordmap is correct, should be a permutation on {0,1,2}
-  for(i=0;i<=2;i++)
-    for(j=0;j<=2;j++)
-      temp_res[j] = temp_res[j] || coordmap[i]==j;
+  // now check that coordmap is correct, should be a permutation on {0,1,2}
+  for (i = 0; i <= 2; i++)
+    for (j = 0; j <= 2; j++) temp_res[j] = temp_res[j] || coordmap[i] == j;
 
-  //check all numbers are within range and none are equal
-  if( !(temp_res[0] && temp_res[1] && temp_res[2]) || (coordmap[0]==coordmap[1]) || (coordmap[1]==coordmap[2]) || (coordmap[0]==coordmap[2])){
-    snprintf(buffer, 100, "Error in triangulatePlane(), coordmap incorrect [%d %d %d], [%d %d %d]",coordmap[0],coordmap[1],coordmap[2],temp_res[0],temp_res[1],temp_res[2]);
+  // check all numbers are within range and none are equal
+  if (!(temp_res[0] && temp_res[1] && temp_res[2]) ||
+      (coordmap[0] == coordmap[1]) || (coordmap[1] == coordmap[2]) ||
+      (coordmap[0] == coordmap[2])) {
+    snprintf(buffer, 100,
+             "Error in triangulatePlane(), coordmap incorrect [%d %d %d], [%d "
+             "%d %d]",
+             coordmap[0], coordmap[1], coordmap[2], temp_res[0], temp_res[1],
+             temp_res[2]);
     mexErrMsgTxt(buffer);
-
   }
 
   ndims = 2;
 
-  dims[1] = 9;//each triangle has 3 vertices and each vertex has three indices
+  dims[1] = 9;// each triangle has 3 vertices and each vertex has three indices
 
-  for(i=I0;i<=I1;i=i+dI)
-    countI++;
-  for(j=J0;j<=J1;j=j+dJ)
-    countJ++;
+  for (i = I0; i <= I1; i = i + dI) countI++;
+  for (j = J0; j <= J1; j = j + dJ) countJ++;
 
 
-  dims[0] = 2*(countI-1)*(countJ-1);//number of triangles
+  dims[0] = 2 * (countI - 1) * (countJ - 1);// number of triangles
 
-  *vertexMatrix =  mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
-  vertices = cast_matlab_2D_array((int *) mxGetPr(*vertexMatrix), dims[0], dims[1]);
-  if(1){
-  if( !(order==1 || order==-1) )
-    mexErrMsgTxt("Error in triangulatePlane(), order can take the value of +1 or -1");
+  *vertexMatrix = mxCreateNumericArray(ndims, (const mwSize *) dims,
+                                       mxINT32_CLASS, mxREAL);
+  vertices = cast_matlab_2D_array((int *) mxGetPr(*vertexMatrix), dims[0],
+                                  dims[1]);
+  if (1) {
+    if (!(order == 1 || order == -1))
+      mexErrMsgTxt("Error in triangulatePlane(), order can take the value of "
+                   "+1 or -1");
 
-  if( order == 1)
-    for(j=J0;j<=(J1-dJ);j=j+dJ)
-      for(i=I0;i<=(I1-dI);i=i+dI){
-	//triangle 1
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+    if (order == 1)
+      for (j = J0; j <= (J1 - dJ); j = j + dJ)
+        for (i = I0; i <= (I1 - dI); i = i + dI) {
+          // triangle 1
+          // vertex 1
+          vertices[coordmap[0]][counter] = i;
+          vertices[coordmap[1]][counter] = j;
+          vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[3+coordmap[0]][counter]   =   i+dI;
-	vertices[3+coordmap[1]][counter]   =   j;
-	vertices[3+coordmap[2]][counter]   =   K;
+          /// vertex 2
+          vertices[3 + coordmap[0]][counter] = i + dI;
+          vertices[3 + coordmap[1]][counter] = j;
+          vertices[3 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[6+coordmap[0]][counter]   =   i;
-	vertices[6+coordmap[1]][counter]   =   j+dJ;
-	vertices[6+coordmap[2]][counter++]   =   K;
+          /// vertex 3
+          vertices[6 + coordmap[0]][counter] = i;
+          vertices[6 + coordmap[1]][counter] = j + dJ;
+          vertices[6 + coordmap[2]][counter++] = K;
 
-	//triangle 2
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i+dI;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+          // triangle 2
+          // vertex 1
+          vertices[coordmap[0]][counter] = i + dI;
+          vertices[coordmap[1]][counter] = j;
+          vertices[coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[6+coordmap[0]][counter]   =   i;
-	vertices[6+coordmap[1]][counter]   =   j+dJ;
-	vertices[6+coordmap[2]][counter]   =   K;
+          /// vertex 2
+          vertices[6 + coordmap[0]][counter] = i;
+          vertices[6 + coordmap[1]][counter] = j + dJ;
+          vertices[6 + coordmap[2]][counter] = K;
 
-	///vertex 3
-	vertices[3+coordmap[0]][counter]   =   i+dI;
-	vertices[3+coordmap[1]][counter]   =   j+dJ;
-	vertices[3+coordmap[2]][counter++]   =   K;
+          /// vertex 3
+          vertices[3 + coordmap[0]][counter] = i + dI;
+          vertices[3 + coordmap[1]][counter] = j + dJ;
+          vertices[3 + coordmap[2]][counter++] = K;
+        }
+    else
+      for (j = J0; j <= (J1 - dJ); j = j + dJ)
+        for (i = I0; i <= (I1 - dI); i = i + dI) {
 
-      }
-  else
-    for(j=J0;j<=(J1-dJ);j=j+dJ)
-      for(i=I0;i<=(I1-dI);i=i+dI){
+          // triangle 1
+          // vertex 1
+          vertices[coordmap[0]][counter] = i;
+          vertices[coordmap[1]][counter] = j;
+          vertices[coordmap[2]][counter] = K;
 
-	//triangle 1
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+          /// vertex 2
+          vertices[6 + coordmap[0]][counter] = i + dI;
+          vertices[6 + coordmap[1]][counter] = j;
+          vertices[6 + coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[6+coordmap[0]][counter]   =   i+dI;
-	vertices[6+coordmap[1]][counter]   =   j;
-	vertices[6+coordmap[2]][counter]   =   K;
+          /// vertex 3
+          vertices[3 + coordmap[0]][counter] = i;
+          vertices[3 + coordmap[1]][counter] = j + dJ;
+          vertices[3 + coordmap[2]][counter++] = K;
 
-	///vertex 3
-	vertices[3+coordmap[0]][counter]   =   i;
-	vertices[3+coordmap[1]][counter]   =   j+dJ;
-	vertices[3+coordmap[2]][counter++]   =   K;
+          // triangle 2
+          // vertex 1
+          vertices[coordmap[0]][counter] = i + dI;
+          vertices[coordmap[1]][counter] = j;
+          vertices[coordmap[2]][counter] = K;
 
-	//triangle 2
-	//vertex 1
-	vertices[coordmap[0]][counter]   =   i+dI;
-	vertices[coordmap[1]][counter]   =   j;
-	vertices[coordmap[2]][counter]   =   K;
+          /// vertex 2
+          vertices[3 + coordmap[0]][counter] = i;
+          vertices[3 + coordmap[1]][counter] = j + dJ;
+          vertices[3 + coordmap[2]][counter] = K;
 
-	///vertex 2
-	vertices[3+coordmap[0]][counter]   =   i;
-	vertices[3+coordmap[1]][counter]   =   j+dJ;
-	vertices[3+coordmap[2]][counter]   =   K;
+          /// vertex 3
+          vertices[6 + coordmap[0]][counter] = i + dI;
+          vertices[6 + coordmap[1]][counter] = j + dJ;
+          vertices[6 + coordmap[2]][counter++] = K;
+        }
 
-	///vertex 3
-	vertices[6+coordmap[0]][counter]   =   i+dI;
-	vertices[6+coordmap[1]][counter]   =   j+dJ;
-	vertices[6+coordmap[2]][counter++]   =   K;
+    // now free memory
 
-      }
-
-  //now free memory
-
-  free_cast_matlab_2D_array(vertices);
+    free_cast_matlab_2D_array(vertices);
   }
 }
 
-void triangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1, mxArray **vertexMatrix){
+void triangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1,
+                       mxArray **vertexMatrix) {
   /*
   if( I1 <= I0 )
     mexErrMsgTxt("Error in triangulateCuboid(), must have I1 > I0");
@@ -254,21 +265,28 @@ void triangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1, mxArray *
   if( K1 <= K0 )
     mexErrMsgTxt("Error in triangulateCuboid(), must have K1 > K0");
   */
-  int coordmap1[] = {0,1,2};
-  int coordmap2[] = {1,2,0};
-  int coordmap3[] = {0,2,1};
+  int coordmap1[] = {0, 1, 2};
+  int coordmap2[] = {1, 2, 0};
+  int coordmap3[] = {0, 2, 1};
 
-  triangulatePlane(I0, I1, J0, J1, K0, coordmap1, -1, &vertexMatrix[0]);//-ve z-axis s norm
-  triangulatePlane(I0, I1, J0, J1, K1, coordmap1,  1, &vertexMatrix[1]);//+ve z-axis s norm
+  triangulatePlane(I0, I1, J0, J1, K0, coordmap1, -1,
+                   &vertexMatrix[0]);//-ve z-axis s norm
+  triangulatePlane(I0, I1, J0, J1, K1, coordmap1, 1,
+                   &vertexMatrix[1]);//+ve z-axis s norm
 
-  triangulatePlane(J0, J1, K0, K1, I0, coordmap2, -1, &vertexMatrix[2]);//-ve x-axis s norm
-  triangulatePlane(J0, J1, K0, K1, I1, coordmap2,  1, &vertexMatrix[3]);//+ve x-axis s norm
+  triangulatePlane(J0, J1, K0, K1, I0, coordmap2, -1,
+                   &vertexMatrix[2]);//-ve x-axis s norm
+  triangulatePlane(J0, J1, K0, K1, I1, coordmap2, 1,
+                   &vertexMatrix[3]);//+ve x-axis s norm
 
-  triangulatePlane(I0, I1, K0, K1, J0, coordmap3,  1, &vertexMatrix[4]);//-ve y-axis s norm
-  triangulatePlane(I0, I1, K0, K1, J1, coordmap3, -1, &vertexMatrix[5]);//+ve y-axis s norm
+  triangulatePlane(I0, I1, K0, K1, J0, coordmap3, 1,
+                   &vertexMatrix[4]);//-ve y-axis s norm
+  triangulatePlane(I0, I1, K0, K1, J1, coordmap3, -1,
+                   &vertexMatrix[5]);//+ve y-axis s norm
 }
 
-void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1, mxArray **vertexMatrix, int dI, int dJ, int dK){
+void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1,
+                           mxArray **vertexMatrix, int dI, int dJ, int dK) {
   /*
   if( I1 <= I0 )
     mexErrMsgTxt("Error in triangulateCuboid(), must have I1 > I0");
@@ -277,28 +295,35 @@ void triangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1, mxArr
   if( K1 <= K0 )
     mexErrMsgTxt("Error in triangulateCuboid(), must have K1 > K0");
   */
-  int coordmap1[] = {0,1,2};
-  int coordmap2[] = {1,2,0};
-  int coordmap3[] = {0,2,1};
-  triangulatePlaneSkip(I0, I1, J0, J1, K0, coordmap1, -1, &vertexMatrix[0], dI, dJ);//-ve z-axis s norm
-  triangulatePlaneSkip(I0, I1, J0, J1, K1, coordmap1,  1, &vertexMatrix[1], dI, dJ);//+ve z-axis s norm
+  int coordmap1[] = {0, 1, 2};
+  int coordmap2[] = {1, 2, 0};
+  int coordmap3[] = {0, 2, 1};
+  triangulatePlaneSkip(I0, I1, J0, J1, K0, coordmap1, -1, &vertexMatrix[0], dI,
+                       dJ);//-ve z-axis s norm
+  triangulatePlaneSkip(I0, I1, J0, J1, K1, coordmap1, 1, &vertexMatrix[1], dI,
+                       dJ);//+ve z-axis s norm
 
-  triangulatePlaneSkip(J0, J1, K0, K1, I0, coordmap2, -1, &vertexMatrix[2], dJ, dK);//-ve x-axis s norm
-  triangulatePlaneSkip(J0, J1, K0, K1, I1, coordmap2,  1, &vertexMatrix[3], dJ, dK);//+ve x-axis s norm
+  triangulatePlaneSkip(J0, J1, K0, K1, I0, coordmap2, -1, &vertexMatrix[2], dJ,
+                       dK);//-ve x-axis s norm
+  triangulatePlaneSkip(J0, J1, K0, K1, I1, coordmap2, 1, &vertexMatrix[3], dJ,
+                       dK);//+ve x-axis s norm
 
-  triangulatePlaneSkip(I0, I1, K0, K1, J0, coordmap3,  1, &vertexMatrix[4], dI, dK);//-ve y-axis s norm
-  triangulatePlaneSkip(I0, I1, K0, K1, J1, coordmap3, -1, &vertexMatrix[5], dI, dK);//+ve y-axis s norm
+  triangulatePlaneSkip(I0, I1, K0, K1, J0, coordmap3, 1, &vertexMatrix[4], dI,
+                       dK);//-ve y-axis s norm
+  triangulatePlaneSkip(I0, I1, K0, K1, J1, coordmap3, -1, &vertexMatrix[5], dI,
+                       dK);//+ve y-axis s norm
 }
 
 void conciseTriangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1,
-			      mxArray **vertices, mxArray ** facets){
+                              mxArray **vertices, mxArray **facets) {
 
   mxArray *triangles[6];
   mxArray *index_map;
-  int ndims, dims[3], ***index_map_int, nindices, **vertices_int, i, **facets_int, j,k, **triangles_int,ii,jj,kk;
+  int ndims, dims[3], ***index_map_int, nindices, **vertices_int, i,
+          **facets_int, j, k, **triangles_int, ii, jj, kk;
   int ndims_v, dims_v[2];
   int ndims_f, dims_f[2];
-  //int *dims_t;
+  // int *dims_t;
   const mwSize *dims_t;
   int vertex_counter = 0, facets_counter = 0;
   int temp_vertex[3];
@@ -311,238 +336,258 @@ void conciseTriangulateCuboid(int I0, int I1, int J0, int J1, int K0, int K1,
   if( K1 <= K0 )
     mexErrMsgTxt("Error in conciseTriangulateCuboid(), must have K1 > K0");
   */
-  //this will keep count of the indices which have been allocated
+  // this will keep count of the indices which have been allocated
   ndims = 3;
-  dims[0] = I1-I0+1;
-  dims[1] = J1-J0+1;
-  dims[2] = K1-K0+1;
+  dims[0] = I1 - I0 + 1;
+  dims[1] = J1 - J0 + 1;
+  dims[2] = K1 - K0 + 1;
 
-  index_map = mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
-  index_map_int = cast_matlab_3D_array((int *) mxGetPr(index_map), dims[0], dims[1], dims[2]) ;
+  index_map = mxCreateNumericArray(ndims, (const mwSize *) dims, mxINT32_CLASS,
+                                   mxREAL);
+  index_map_int = cast_matlab_3D_array((int *) mxGetPr(index_map), dims[0],
+                                       dims[1], dims[2]);
 
-  //now initialise each entry to -1
-  for(i=0;i<dims[0];i++)
-    for(j=0;j<dims[1];j++)
-      for(k=0;k<dims[2];k++)
-	index_map_int[k][j][i] = -1;
+  // now initialise each entry to -1
+  for (i = 0; i < dims[0]; i++)
+    for (j = 0; j < dims[1]; j++)
+      for (k = 0; k < dims[2]; k++) index_map_int[k][j][i] = -1;
 
-  //the total number of indices that we will have
-  nindices = (I1 - I0 + 1)*( J1 - J0 + 1)*2 + (I1 - I0 + 1)*(K1 - K0 - 1)*2 + (J1 - J0 - 1)*(K1 - K0 - 1)*2;
-  //fprintf(stderr,"%d [%d %d %d %d %d %d]\n",nindices,I0,I1,J0,J1,K0,K1);
-  if( I1==I0 )
-    nindices = (J1 - J0 + 1)*(K1 - K0 + 1);
-  if( J1==J0 )
-    nindices = (I1 - I0 + 1)*(K1 - K0 + 1);
-  if( K1==K0 )
-    nindices = (I1 - I0 + 1)*(J1 - J0 + 1);
+  // the total number of indices that we will have
+  nindices = (I1 - I0 + 1) * (J1 - J0 + 1) * 2 +
+             (I1 - I0 + 1) * (K1 - K0 - 1) * 2 +
+             (J1 - J0 - 1) * (K1 - K0 - 1) * 2;
+  // fprintf(stderr,"%d [%d %d %d %d %d %d]\n",nindices,I0,I1,J0,J1,K0,K1);
+  if (I1 == I0) nindices = (J1 - J0 + 1) * (K1 - K0 + 1);
+  if (J1 == J0) nindices = (I1 - I0 + 1) * (K1 - K0 + 1);
+  if (K1 == K0) nindices = (I1 - I0 + 1) * (J1 - J0 + 1);
 
-  //construct vertice array
+  // construct vertice array
   ndims_v = 2;
   dims_v[0] = nindices;
   dims_v[1] = 3;
-  *vertices = mxCreateNumericArray( ndims_v, (const mwSize *)dims_v, mxINT32_CLASS, mxREAL);
-  vertices_int = cast_matlab_2D_array((int *) mxGetPr(*vertices), dims_v[0], dims_v[1]);
-  //now generate triangles
-  triangulateCuboid(I0,I1,J0,J1,K0,K1,triangles);
+  *vertices = mxCreateNumericArray(ndims_v, (const mwSize *) dims_v,
+                                   mxINT32_CLASS, mxREAL);
+  vertices_int = cast_matlab_2D_array((int *) mxGetPr(*vertices), dims_v[0],
+                                      dims_v[1]);
+  // now generate triangles
+  triangulateCuboid(I0, I1, J0, J1, K0, K1, triangles);
 
-  //now setup the facet array
+  // now setup the facet array
   ndims_f = 2;
-  dims_f[0] = 4*(I1-I0)*(J1-J0) + 4*(J1-J0)*(K1-K0) + 4*(I1-I0)*(K1-K0) ;//the total number of facets
-  if( I1==I0 || J1==J0 || K1==K0 )
-    dims_f[0] = dims_f[0]/2;
+  dims_f[0] = 4 * (I1 - I0) * (J1 - J0) + 4 * (J1 - J0) * (K1 - K0) +
+              4 * (I1 - I0) * (K1 - K0);// the total number of facets
+  if (I1 == I0 || J1 == J0 || K1 == K0) dims_f[0] = dims_f[0] / 2;
   dims_f[1] = 3;
-  *facets = mxCreateNumericArray( ndims_f, (const mwSize *)dims_f, mxINT32_CLASS, mxREAL);
-  facets_int = cast_matlab_2D_array((int *) mxGetPr(*facets), dims_f[0], dims_f[1]);
-  //now populate the matrices
-  for(i=0;i<6;i++){//loop over each plane
+  *facets = mxCreateNumericArray(ndims_f, (const mwSize *) dims_f,
+                                 mxINT32_CLASS, mxREAL);
+  facets_int =
+          cast_matlab_2D_array((int *) mxGetPr(*facets), dims_f[0], dims_f[1]);
+  // now populate the matrices
+  for (i = 0; i < 6; i++) {// loop over each plane
 
-    if( !(i==2 && I0==I1) && !(i==0 && K0==K1) && !(i==4 && J0==J1) ){
+    if (!(i == 2 && I0 == I1) && !(i == 0 && K0 == K1) &&
+        !(i == 4 && J0 == J1)) {
 
       dims_t = mxGetDimensions(triangles[i]);
-      triangles_int = cast_matlab_2D_array((int *) mxGetPr(triangles[i]), dims_t[0], dims_t[1]);
-      for(j=0;j<(int)dims_t[0];j++){//now iterate over triangle
+      triangles_int = cast_matlab_2D_array((int *) mxGetPr(triangles[i]),
+                                           dims_t[0], dims_t[1]);
+      for (j = 0; j < (int) dims_t[0]; j++) {// now iterate over triangle
 
-	for(k=0;k<3;k++){//now each vertex in the triangle
-	  //first check if this vertex has been allocated
-	  kk = triangles_int[3*k+2][j];
-	  jj = triangles_int[3*k+1][j];
-	  ii = triangles_int[3*k][j];
+        for (k = 0; k < 3; k++) {// now each vertex in the triangle
+          // first check if this vertex has been allocated
+          kk = triangles_int[3 * k + 2][j];
+          jj = triangles_int[3 * k + 1][j];
+          ii = triangles_int[3 * k][j];
 
-	  if( index_map_int[kk-K0][jj-J0][ii-I0] == -1){//not allocated yet
-	    index_map_int[kk-K0][jj-J0][ii-I0] = vertex_counter++;
-	    vertices_int[0][vertex_counter-1] = ii;
-	    vertices_int[1][vertex_counter-1] = jj;
-	    vertices_int[2][vertex_counter-1] = kk;
+          if (index_map_int[kk - K0][jj - J0][ii - I0] ==
+              -1) {// not allocated yet
+            index_map_int[kk - K0][jj - J0][ii - I0] = vertex_counter++;
+            vertices_int[0][vertex_counter - 1] = ii;
+            vertices_int[1][vertex_counter - 1] = jj;
+            vertices_int[2][vertex_counter - 1] = kk;
 
-	  }//of allocating new vertex
-	  temp_vertex[k] = index_map_int[kk-K0][jj-J0][ii-I0];
+          }// of allocating new vertex
+          temp_vertex[k] = index_map_int[kk - K0][jj - J0][ii - I0];
 
-	}//of loop on each vertex
-	facets_int[0][facets_counter] = temp_vertex[0];
-	facets_int[1][facets_counter] = temp_vertex[1];
-	facets_int[2][facets_counter++] = temp_vertex[2];
+        }// of loop on each vertex
+        facets_int[0][facets_counter] = temp_vertex[0];
+        facets_int[1][facets_counter] = temp_vertex[1];
+        facets_int[2][facets_counter++] = temp_vertex[2];
 
-      }//of loope on each triangle
+      }// of loope on each triangle
       free_cast_matlab_2D_array(triangles_int);
     }
-  }//of loop over each plane
+  }// of loop over each plane
 
 
-  //free memory etc
+  // free memory etc
   free_cast_matlab_3D_array(index_map_int, dims[2]);
   free_cast_matlab_2D_array(facets_int);
   free_cast_matlab_2D_array(vertices_int);
 
-  for(i=0;i<6;i++)
-    mxDestroyArray(triangles[i]);
+  for (i = 0; i < 6; i++) mxDestroyArray(triangles[i]);
 }
 
-void conciseCreateBoundary(int I0, int I1,int K0, int K1,
-			   mxArray **vertices, mxArray ** facets){
-  int Nverts = 2*(K1-K0) + 2*(I1-I0);
+void conciseCreateBoundary(int I0, int I1, int K0, int K1, mxArray **vertices,
+                           mxArray **facets) {
+  int Nverts = 2 * (K1 - K0) + 2 * (I1 - I0);
   int Nfacets = Nverts;
-  int Nv,tc;
-  int **verts_t,**facets_t;
-  int nextv=0;
-  int fcount=0;
-  int vcount=0;
+  int Nv, tc;
+  int **verts_t, **facets_t;
+  int nextv = 0;
+  int fcount = 0;
+  int vcount = 0;
 
-  verts_t=(int **)malloc((Nverts+4)*sizeof(int *));
-  for(int i=0;i<(Nverts+4);i++)
-    verts_t[i]=(int *)malloc(3*sizeof(int));
+  verts_t = (int **) malloc((Nverts + 4) * sizeof(int *));
+  for (int i = 0; i < (Nverts + 4); i++)
+    verts_t[i] = (int *) malloc(3 * sizeof(int));
 
-  facets_t=(int **)malloc((Nfacets)*sizeof(int *));
-  for(int i=0;i<(Nfacets);i++)
-    facets_t[i]=(int *)malloc(3*sizeof(int));
+  facets_t = (int **) malloc((Nfacets) * sizeof(int *));
+  for (int i = 0; i < (Nfacets); i++)
+    facets_t[i] = (int *) malloc(3 * sizeof(int));
 
-  Nv=I1-I0+1;tc=0;nextv=0;
-  for(int i=nextv;i<(nextv+Nv);i++){
-    verts_t[i][0]=I0+tc;
-    verts_t[i][1]=0;
-    verts_t[i][2]=K0;
+  Nv = I1 - I0 + 1;
+  tc = 0;
+  nextv = 0;
+  for (int i = nextv; i < (nextv + Nv); i++) {
+    verts_t[i][0] = I0 + tc;
+    verts_t[i][1] = 0;
+    verts_t[i][2] = K0;
     tc++;
   }
 
-  for(int i=0;i<(Nv-1);i++){
-    facets_t[fcount][0]=nextv+i;
-    facets_t[fcount][1]=facets_t[fcount][0]+1;
-    facets_t[fcount][2]=facets_t[fcount][1];
+  for (int i = 0; i < (Nv - 1); i++) {
+    facets_t[fcount][0] = nextv + i;
+    facets_t[fcount][1] = facets_t[fcount][0] + 1;
+    facets_t[fcount][2] = facets_t[fcount][1];
     fcount++;
   }
 
-  nextv=Nv+nextv;
-  Nv=I1-I0+1;tc=0;
-  for(int i=nextv;i<(nextv+Nv);i++){
-    verts_t[i][0]=I1-tc;
-    verts_t[i][1]=0;
-    verts_t[i][2]=K1;
+  nextv = Nv + nextv;
+  Nv = I1 - I0 + 1;
+  tc = 0;
+  for (int i = nextv; i < (nextv + Nv); i++) {
+    verts_t[i][0] = I1 - tc;
+    verts_t[i][1] = 0;
+    verts_t[i][2] = K1;
     tc++;
   }
 
-  for(int i=0;i<(Nv-1);i++){
-    facets_t[fcount][0]=nextv+i;
-    facets_t[fcount][1]=facets_t[fcount][0]+1;
-    facets_t[fcount][2]=facets_t[fcount][1];
+  for (int i = 0; i < (Nv - 1); i++) {
+    facets_t[fcount][0] = nextv + i;
+    facets_t[fcount][1] = facets_t[fcount][0] + 1;
+    facets_t[fcount][2] = facets_t[fcount][1];
     fcount++;
   }
 
-  nextv=Nv+nextv;
-  Nv=K1-K0+1;tc=0;
-  for(int i=nextv;i<(nextv+Nv);i++){
-    verts_t[i][0]=I0;
-    verts_t[i][1]=0;
-    verts_t[i][2]=K1-tc;
+  nextv = Nv + nextv;
+  Nv = K1 - K0 + 1;
+  tc = 0;
+  for (int i = nextv; i < (nextv + Nv); i++) {
+    verts_t[i][0] = I0;
+    verts_t[i][1] = 0;
+    verts_t[i][2] = K1 - tc;
     tc++;
   }
 
-  for(int i=0;i<(Nv-1);i++){
-    facets_t[fcount][0]=nextv+i;
-    facets_t[fcount][1]=facets_t[fcount][0]+1;
-    facets_t[fcount][2]=facets_t[fcount][1];
+  for (int i = 0; i < (Nv - 1); i++) {
+    facets_t[fcount][0] = nextv + i;
+    facets_t[fcount][1] = facets_t[fcount][0] + 1;
+    facets_t[fcount][2] = facets_t[fcount][1];
     fcount++;
   }
 
-  nextv=Nv+nextv;
-  Nv=K1-K0+1;tc=0;
-  for(int i=nextv;i<(nextv+Nv);i++){
-    verts_t[i][0]=I1;
-    verts_t[i][1]=0;
-    verts_t[i][2]=K0+tc;
+  nextv = Nv + nextv;
+  Nv = K1 - K0 + 1;
+  tc = 0;
+  for (int i = nextv; i < (nextv + Nv); i++) {
+    verts_t[i][0] = I1;
+    verts_t[i][1] = 0;
+    verts_t[i][2] = K0 + tc;
     tc++;
   }
 
-  for(int i=0;i<(Nv-1);i++){
-    facets_t[fcount][0]=nextv+i;
-    facets_t[fcount][1]=facets_t[fcount][0]+1;
-    facets_t[fcount][2]=facets_t[fcount][1];
+  for (int i = 0; i < (Nv - 1); i++) {
+    facets_t[fcount][0] = nextv + i;
+    facets_t[fcount][1] = facets_t[fcount][0] + 1;
+    facets_t[fcount][2] = facets_t[fcount][1];
     fcount++;
   }
 
   /*for(int i=0;i<(Nverts+4);i++)
-    fprintf(stdout,"[v] %02d %02d %02d\n",verts_t[i][0],verts_t[i][1],verts_t[i][2]);
+    fprintf(stdout,"[v] %02d %02d
+    %02d\n",verts_t[i][0],verts_t[i][1],verts_t[i][2]);
 
     for(int i=0;i<(Nfacets);i++)
-    fprintf(stdout,"[f] %02d %02d %02d\n",facets_t[i][0],facets_t[i][1],facets_t[i][2]);
+    fprintf(stdout,"[f] %02d %02d
+    %02d\n",facets_t[i][0],facets_t[i][1],facets_t[i][2]);
   */
   int **ind_map;
-  ind_map=(int **)malloc((I1-I0+1)*sizeof(int *));
-  for(int i=0;i<(I1-I0+1);i++)
-    ind_map[i]=(int *)malloc((K1-K0+1)*sizeof(int));
-  for(int i=0;i<(I1-I0+1);i++)
-    for(int j=0;j<(K1-K0+1);j++)
-      ind_map[i][j]=-1;
+  ind_map = (int **) malloc((I1 - I0 + 1) * sizeof(int *));
+  for (int i = 0; i < (I1 - I0 + 1); i++)
+    ind_map[i] = (int *) malloc((K1 - K0 + 1) * sizeof(int));
+  for (int i = 0; i < (I1 - I0 + 1); i++)
+    for (int j = 0; j < (K1 - K0 + 1); j++) ind_map[i][j] = -1;
 
-  mwSize *dims = (mwSize *)malloc(2*sizeof(mwSize));
+  mwSize *dims = (mwSize *) malloc(2 * sizeof(mwSize));
   int ndims = 2;
   dims[0] = Nverts;
   dims[1] = 3;
-  *vertices = mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
-  int **vertices_int = cast_matlab_2D_array((int *) mxGetPr(*vertices), dims[0], dims[1]);
+  *vertices = mxCreateNumericArray(ndims, (const mwSize *) dims, mxINT32_CLASS,
+                                   mxREAL);
+  int **vertices_int =
+          cast_matlab_2D_array((int *) mxGetPr(*vertices), dims[0], dims[1]);
 
   dims[0] = Nfacets;
   dims[1] = 3;
-  *facets = mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
-  int **facets_int = cast_matlab_2D_array((int *) mxGetPr(*facets), dims[0], dims[1]);
+  *facets = mxCreateNumericArray(ndims, (const mwSize *) dims, mxINT32_CLASS,
+                                 mxREAL);
+  int **facets_int =
+          cast_matlab_2D_array((int *) mxGetPr(*facets), dims[0], dims[1]);
 
-  int vertc=0;int vind_i;int vind_k;int verti;
-  for(fcount=0;fcount<Nfacets;fcount++){
-    for(vcount=0;vcount<2;vcount++){
-      vind_i=verts_t[facets_t[fcount][vcount]][0];
-      vind_k=verts_t[facets_t[fcount][vcount]][2];
-      if( ind_map[vind_i-I0][vind_k-K0]==-1 ){
-	vertices_int[0][vertc]=vind_i;
-	vertices_int[1][vertc]=0;
-	vertices_int[2][vertc]=vind_k;
-	ind_map[vind_i-I0][vind_k-K0]=vertc;vertc++;
+  int vertc = 0;
+  int vind_i;
+  int vind_k;
+  int verti;
+  for (fcount = 0; fcount < Nfacets; fcount++) {
+    for (vcount = 0; vcount < 2; vcount++) {
+      vind_i = verts_t[facets_t[fcount][vcount]][0];
+      vind_k = verts_t[facets_t[fcount][vcount]][2];
+      if (ind_map[vind_i - I0][vind_k - K0] == -1) {
+        vertices_int[0][vertc] = vind_i;
+        vertices_int[1][vertc] = 0;
+        vertices_int[2][vertc] = vind_k;
+        ind_map[vind_i - I0][vind_k - K0] = vertc;
+        vertc++;
       }
-      verti=ind_map[vind_i-I0][vind_k-K0];
-      facets_int[vcount][fcount]=verti;
+      verti = ind_map[vind_i - I0][vind_k - K0];
+      facets_int[vcount][fcount] = verti;
     }
-    facets_int[2][fcount]=verti;
+    facets_int[2][fcount] = verti;
   }
 
   free_cast_matlab_2D_array(facets_int);
   free_cast_matlab_2D_array(vertices_int);
 
-  for(int i=0;i<(Nverts+4);i++)
-    free(verts_t[i]);
+  for (int i = 0; i < (Nverts + 4); i++) free(verts_t[i]);
   free(verts_t);
-  for(int i=0;i<(Nfacets);i++)
-    free(facets_t[i]);
+  for (int i = 0; i < (Nfacets); i++) free(facets_t[i]);
   free(facets_t);
-  for(int i=0;i<(I1-I0+1);i++)
-    free(ind_map[i]);
+  for (int i = 0; i < (I1 - I0 + 1); i++) free(ind_map[i]);
   free(ind_map);
   free(dims);
 }
 
-void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1,
-                                  const SurfaceSpacingStride &spacing_stride, mxArray **vertices, mxArray ** facets){
+void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0,
+                                  int K1,
+                                  const SurfaceSpacingStride &spacing_stride,
+                                  mxArray **vertices, mxArray **facets) {
 
   int dI = spacing_stride.x, dJ = spacing_stride.y, dK = spacing_stride.z;
   mxArray *triangles[6];
   mxArray *index_map;
-  int ndims, ***index_map_int, nindices, **vertices_int, i, **facets_int, j,k, **triangles_int,ii,jj,kk;
+  int ndims, ***index_map_int, nindices, **vertices_int, i, **facets_int, j, k,
+          **triangles_int, ii, jj, kk;
   int ndims_v;//, dims_v[2];
   int ndims_f;//, dims_f[2];
   //  int *dims_t;
@@ -551,8 +596,8 @@ void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1
   int vertex_counter = 0, facets_counter = 0;
   int temp_vertex[3];
 
-  dims_v = (mwSize *)malloc(2*sizeof(mwSize));
-  dims_f = (mwSize *)malloc(2*sizeof(mwSize));
+  dims_v = (mwSize *) malloc(2 * sizeof(mwSize));
+  dims_f = (mwSize *) malloc(2 * sizeof(mwSize));
 
   /*
   if( I1 <= I0 )
@@ -562,93 +607,100 @@ void conciseTriangulateCuboidSkip(int I0, int I1, int J0, int J1, int K0, int K1
   if( K1 <= K0 )
     mexErrMsgTxt("Error in conciseTriangulateCuboid(), must have K1 > K0");
   */
-  //this will keep count of the indices which have been allocated
-  dims = (mwSize *)malloc(3*sizeof(mwSize));
+  // this will keep count of the indices which have been allocated
+  dims = (mwSize *) malloc(3 * sizeof(mwSize));
   ndims = 3;
-  dims[0] = (I1-I0)/dI+1;
-  dims[1] = (J1-J0)/dJ+1;
-  dims[2] = (K1-K0)/dK+1;
+  dims[0] = (I1 - I0) / dI + 1;
+  dims[1] = (J1 - J0) / dJ + 1;
+  dims[2] = (K1 - K0) / dK + 1;
 
-  index_map = mxCreateNumericArray( ndims, (const mwSize *)dims, mxINT32_CLASS, mxREAL);
-  index_map_int = cast_matlab_3D_array((int *) mxGetPr(index_map), dims[0], dims[1], dims[2]) ;
+  index_map = mxCreateNumericArray(ndims, (const mwSize *) dims, mxINT32_CLASS,
+                                   mxREAL);
+  index_map_int = cast_matlab_3D_array((int *) mxGetPr(index_map), dims[0],
+                                       dims[1], dims[2]);
 
-  //now initialise each entry to -1
-  for(i=0;i<(int)dims[0];i++)
-    for(j=0;j<(int)dims[1];j++)
-      for(k=0;k<(int)dims[2];k++)
-	index_map_int[k][j][i] = -1;
-    //the total number of indices that we will have
+  // now initialise each entry to -1
+  for (i = 0; i < (int) dims[0]; i++)
+    for (j = 0; j < (int) dims[1]; j++)
+      for (k = 0; k < (int) dims[2]; k++) index_map_int[k][j][i] = -1;
+  // the total number of indices that we will have
   int Iw, Jw, Kw;
-  Iw = (I1-I0)/dI+1;
-  Jw = (J1-J0)/dJ+1;
-  Kw = (K1-K0)/dK+1;
+  Iw = (I1 - I0) / dI + 1;
+  Jw = (J1 - J0) / dJ + 1;
+  Kw = (K1 - K0) / dK + 1;
 
-  nindices = Iw*Jw*2 + Iw*(Kw-2)*2 + (Jw-2)*(Kw-2)*2;
+  nindices = Iw * Jw * 2 + Iw * (Kw - 2) * 2 + (Jw - 2) * (Kw - 2) * 2;
   //  fprintf(stderr,"%d [%d %d %d]\n",nindices,Iw,Jw,Kw);
-  if( (I1-I0)<dI )
-    nindices = Jw*Kw;
-  if( (J1-J0)<dJ )
-    nindices = Iw*Kw;
-  if( (K1-K0)<dK )
-    nindices = Iw*Jw;
+  if ((I1 - I0) < dI) nindices = Jw * Kw;
+  if ((J1 - J0) < dJ) nindices = Iw * Kw;
+  if ((K1 - K0) < dK) nindices = Iw * Jw;
 
-  //construct vertice array
+  // construct vertice array
   ndims_v = 2;
   dims_v[0] = nindices;
   dims_v[1] = 3;
-  *vertices = mxCreateNumericArray( ndims_v, (const mwSize *)dims_v, mxINT32_CLASS, mxREAL);
+  *vertices = mxCreateNumericArray(ndims_v, (const mwSize *) dims_v,
+                                   mxINT32_CLASS, mxREAL);
 
-  vertices_int = cast_matlab_2D_array((int *) mxGetPr(*vertices), dims_v[0], dims_v[1]);
-  //now generate triangles
-  triangulateCuboidSkip(I0,I1,J0,J1,K0,K1,triangles,dI,dJ,dK);
+  vertices_int = cast_matlab_2D_array((int *) mxGetPr(*vertices), dims_v[0],
+                                      dims_v[1]);
+  // now generate triangles
+  triangulateCuboidSkip(I0, I1, J0, J1, K0, K1, triangles, dI, dJ, dK);
 
-  //now setup the facet array
+  // now setup the facet array
   ndims_f = 2;
-  dims_f[0] = 4*(Iw-1)*(Jw-1) + 4*(Jw-1)*(Kw-1) + 4*(Iw-1)*(Kw-1) ;//the total number of facets
-  if( (I1-I0)<dI || (J1-J0)<dJ || (K1-K0)<dK )
-    dims_f[0] = dims_f[0]/2;
+  dims_f[0] = 4 * (Iw - 1) * (Jw - 1) + 4 * (Jw - 1) * (Kw - 1) +
+              4 * (Iw - 1) * (Kw - 1);// the total number of facets
+  if ((I1 - I0) < dI || (J1 - J0) < dJ || (K1 - K0) < dK)
+    dims_f[0] = dims_f[0] / 2;
   dims_f[1] = 3;
-  *facets = mxCreateNumericArray( ndims_f, (const mwSize *)dims_f, mxINT32_CLASS, mxREAL);
-  facets_int = cast_matlab_2D_array((int *) mxGetPr(*facets), dims_f[0], dims_f[1]);
+  *facets = mxCreateNumericArray(ndims_f, (const mwSize *) dims_f,
+                                 mxINT32_CLASS, mxREAL);
+  facets_int =
+          cast_matlab_2D_array((int *) mxGetPr(*facets), dims_f[0], dims_f[1]);
 
-  //now populate the matrices
-  for(i=0;i<6;i++){//loop over each plane
+  // now populate the matrices
+  for (i = 0; i < 6; i++) {// loop over each plane
     //    fprintf(stderr,"Here %d\n",i);
-    if( !(i==2 && (I1-I0)<dI) && !(i==0 && (K1-K0)<dK) && !(i==4 && (J1-J0)<dJ) ){
+    if (!(i == 2 && (I1 - I0) < dI) && !(i == 0 && (K1 - K0) < dK) &&
+        !(i == 4 && (J1 - J0) < dJ)) {
       dims_t = mxGetDimensions(triangles[i]);
-      triangles_int = cast_matlab_2D_array((int *) mxGetPr(triangles[i]), dims_t[0], dims_t[1]);
+      triangles_int = cast_matlab_2D_array((int *) mxGetPr(triangles[i]),
+                                           dims_t[0], dims_t[1]);
 
-      for(j=0;j<(int)dims_t[0];j++){//now iterate over triangle
+      for (j = 0; j < (int) dims_t[0]; j++) {// now iterate over triangle
 
-	for(k=0;k<3;k++){//now each vertex in the triangle
-	  //first check if this vertex has been allocated
-	  kk = triangles_int[3*k+2][j];
-	  jj = triangles_int[3*k+1][j];
-	  ii = triangles_int[3*k][j];
-	  if( index_map_int[(kk-K0)/dK][(jj-J0)/dJ][(ii-I0)/dI] == -1){//not allocated yet
-	    index_map_int[(kk-K0)/dK][(jj-J0)/dJ][(ii-I0)/dI] = vertex_counter++;
-	    vertices_int[0][vertex_counter-1] = ii;
-	    vertices_int[1][vertex_counter-1] = jj;
-	    vertices_int[2][vertex_counter-1] = kk;
+        for (k = 0; k < 3; k++) {// now each vertex in the triangle
+          // first check if this vertex has been allocated
+          kk = triangles_int[3 * k + 2][j];
+          jj = triangles_int[3 * k + 1][j];
+          ii = triangles_int[3 * k][j];
+          if (index_map_int[(kk - K0) / dK][(jj - J0) / dJ][(ii - I0) / dI] ==
+              -1) {// not allocated yet
+            index_map_int[(kk - K0) / dK][(jj - J0) / dJ][(ii - I0) / dI] =
+                    vertex_counter++;
+            vertices_int[0][vertex_counter - 1] = ii;
+            vertices_int[1][vertex_counter - 1] = jj;
+            vertices_int[2][vertex_counter - 1] = kk;
 
-	  }//of allocating new vertex
-	  temp_vertex[k] = index_map_int[(kk-K0)/dK][(jj-J0)/dJ][(ii-I0)/dI];
-	}//of loop on each vertex
-	facets_int[0][facets_counter] = temp_vertex[0];
-	facets_int[1][facets_counter] = temp_vertex[1];
-	facets_int[2][facets_counter++] = temp_vertex[2];
-      }//of loope on each triangle
+          }// of allocating new vertex
+          temp_vertex[k] =
+                  index_map_int[(kk - K0) / dK][(jj - J0) / dJ][(ii - I0) / dI];
+        }// of loop on each vertex
+        facets_int[0][facets_counter] = temp_vertex[0];
+        facets_int[1][facets_counter] = temp_vertex[1];
+        facets_int[2][facets_counter++] = temp_vertex[2];
+      }// of loope on each triangle
       free_cast_matlab_2D_array(triangles_int);
     }
-  }//of loop over each plane
+  }// of loop over each plane
 
-  //free memory etc
+  // free memory etc
   free_cast_matlab_3D_array(index_map_int, dims[2]);
   free_cast_matlab_2D_array(facets_int);
   free_cast_matlab_2D_array(vertices_int);
 
-  for(i=0;i<6;i++)
-    mxDestroyArray(triangles[i]);
+  for (i = 0; i < 6; i++) mxDestroyArray(triangles[i]);
   free(dims);
   free(dims_v);
   free(dims_f);

--- a/tdms/src/numerical_derivative.cpp
+++ b/tdms/src/numerical_derivative.cpp
@@ -13,70 +13,71 @@ using namespace std;
 using namespace tdms_math_constants;
 
 // fftw_complex is typdef to a double[2] - first element is Re, second Im.
-const int REAL=0, IMAG=1;
+const int REAL = 0, IMAG = 1;
 
-void complex_mult_vec(fftw_complex *a, fftw_complex *b, fftw_complex *c, int len){
+void complex_mult_vec(fftw_complex *a, fftw_complex *b, fftw_complex *c,
+                      int len) {
 
-  for(int i=0; i<=(len-1); i++){
+  for (int i = 0; i <= (len - 1); i++) {
     // WARNING: these intermediate variables *must* be defined
-    double c0 = a[i][REAL]*b[i][REAL] - a[i][IMAG]*b[i][IMAG];
-    double c1 = a[i][REAL]*b[i][IMAG] + a[i][IMAG]*b[i][REAL];
+    double c0 = a[i][REAL] * b[i][REAL] - a[i][IMAG] * b[i][IMAG];
+    double c1 = a[i][REAL] * b[i][IMAG] + a[i][IMAG] * b[i][REAL];
     c[i][REAL] = c0;
     c[i][IMAG] = c1;
   }
 }
 
-void init_diff_shift_op(double delta, fftw_complex *Dk, int N){
+void init_diff_shift_op(double delta, fftw_complex *Dk, int N) {
 
   spdlog::debug("init_diff_shift_op, delta={}", delta);
 
-  //define an
-  auto *an = (double *)malloc(sizeof(double) * N);
-  if( (N % 2) == 0){//even case
-    for(int i=0;i<=(N/2);i++)
-      an[i] = (double) i;
+  // define an
+  auto *an = (double *) malloc(sizeof(double) * N);
+  if ((N % 2) == 0) {// even case
+    for (int i = 0; i <= (N / 2); i++) an[i] = (double) i;
     //    an[N/2] = 0.;
-    for(int i=N/2+1;i<=(N-1);i++)
-      an[i] = (double) (i-N);
-  }
-  else{//odd case
-    for(int i=0;i<=(N-1)/2;i++)
-      an[i] = (double) i;
-    for(int i=(N+1)/2;i<=(N-1);i++)
-      an[i] = (double) (i-N);
+    for (int i = N / 2 + 1; i <= (N - 1); i++) an[i] = (double) (i - N);
+  } else {// odd case
+    for (int i = 0; i <= (N - 1) / 2; i++) an[i] = (double) i;
+    for (int i = (N + 1) / 2; i <= (N - 1); i++) an[i] = (double) (i - N);
   }
 
-  for(int i=0;i<=(N-1);i++){
-    Dk[i][REAL] = -1.*sin(an[i]*2.*DCPI*delta/( (double)N ))*an[i]*2.*DCPI;
-    Dk[i][IMAG] =  cos(an[i]*2.*DCPI*delta/( (double)N ))*an[i]*2.*DCPI;
+  for (int i = 0; i <= (N - 1); i++) {
+    Dk[i][REAL] = -1. * sin(an[i] * 2. * DCPI * delta / ((double) N)) * an[i] *
+                  2. * DCPI;
+    Dk[i][IMAG] =
+            cos(an[i] * 2. * DCPI * delta / ((double) N)) * an[i] * 2. * DCPI;
   }
-  if( (N % 2) == 0){
-    Dk[N/2][REAL] = -1.*sin(an[N/2]*2.*DCPI*delta/( (double)N ))*an[N/2]*2.*DCPI;
-    Dk[N/2][IMAG] = 0.;
+  if ((N % 2) == 0) {
+    Dk[N / 2][REAL] = -1. * sin(an[N / 2] * 2. * DCPI * delta / ((double) N)) *
+                      an[N / 2] * 2. * DCPI;
+    Dk[N / 2][IMAG] = 0.;
   }
   spdlog::trace("delta: {}\n", delta);
-  for(int i=0;i<=(N-1);i++){
-    spdlog::trace("{} {} {}",an[i],Dk[i][0],Dk[i][1]);
+  for (int i = 0; i <= (N - 1); i++) {
+    spdlog::trace("{} {} {}", an[i], Dk[i][0], Dk[i][1]);
   }
   free(an);
 }
 
-void first_derivative( fftw_complex *in_pb_pf, fftw_complex *out_pb_pf,
-		       fftw_complex *Dk, int N, fftw_plan pf, fftw_plan pb){
+void first_derivative(fftw_complex *in_pb_pf, fftw_complex *out_pb_pf,
+                      fftw_complex *Dk, int N, fftw_plan pf, fftw_plan pb) {
   /*
-   *  1. Fourier transform the data in in_pb_pf, placing the result into out_pb_pf
-   *  2. Multiply the result of the FT (out_pb_pf) by the Dk coefficients, placing
-   *     the result into in_pb_pf.
+   *  1. Fourier transform the data in in_pb_pf, placing the result into
+   * out_pb_pf
+   *  2. Multiply the result of the FT (out_pb_pf) by the Dk coefficients,
+   * placing the result into in_pb_pf.
    *  3. Fourier transform back.
    *
-   *  Due to how we've organised things, we can use the same fftw_scheme as in the
-   *  first step, providing the data in_pb_pf and getting the output in out_pb_pf
+   *  Due to how we've organised things, we can use the same fftw_scheme as in
+   * the first step, providing the data in_pb_pf and getting the output in
+   * out_pb_pf
    */
   fftw_execute(pf);
   complex_mult_vec(out_pb_pf, Dk, in_pb_pf, N);
   fftw_execute(pb);
-  for(int i=0;i<=(N-1);i++){
-    out_pb_pf[i][REAL] = out_pb_pf[i][REAL]/((double) N);
-    out_pb_pf[i][IMAG] = out_pb_pf[i][IMAG]/((double) N);
+  for (int i = 0; i <= (N - 1); i++) {
+    out_pb_pf[i][REAL] = out_pb_pf[i][REAL] / ((double) N);
+    out_pb_pf[i][IMAG] = out_pb_pf[i][IMAG] / ((double) N);
   }
 }

--- a/tdms/src/output_matrices/id_variables.cpp
+++ b/tdms/src/output_matrices/id_variables.cpp
@@ -4,22 +4,26 @@
 
 using namespace std;
 
-void IDVariables::link_to_pointer(mxArray *&id_pointer, int _n_frequencies, int _n_det_modes) {
+void IDVariables::link_to_pointer(mxArray *&id_pointer, int _n_frequencies,
+                                  int _n_det_modes) {
   // save array sizes for deallocation
   n_frequencies = _n_frequencies;
   n_det_modes = _n_det_modes;
   // flag memory assignment
   memory_assigned = true;
 
-  // now construct the fields for the structure array, and assign pointers to the data
+  // now construct the fields for the structure array, and assign pointers to
+  // the data
   int ndims = 2;
   int dims[2] = {n_det_modes, n_frequencies};
 
-  x_ptr = mxCreateNumericArray(ndims, (const mwSize *) dims, mxDOUBLE_CLASS, mxCOMPLEX);
+  x_ptr = mxCreateNumericArray(ndims, (const mwSize *) dims, mxDOUBLE_CLASS,
+                               mxCOMPLEX);
   x_real = cast_matlab_2D_array(mxGetPr(x_ptr), dims[0], dims[1]);
   x_imag = cast_matlab_2D_array(mxGetPi(x_ptr), dims[0], dims[1]);
 
-  y_ptr = mxCreateNumericArray(ndims, (const mwSize *) dims, mxDOUBLE_CLASS, mxCOMPLEX);
+  y_ptr = mxCreateNumericArray(ndims, (const mwSize *) dims, mxDOUBLE_CLASS,
+                               mxCOMPLEX);
   y_real = cast_matlab_2D_array(mxGetPr(y_ptr), dims[0], dims[1]);
   y_imag = cast_matlab_2D_array(mxGetPi(y_ptr), dims[0], dims[1]);
 

--- a/tdms/src/output_matrices/output_matrices.cpp
+++ b/tdms/src/output_matrices/output_matrices.cpp
@@ -13,7 +13,8 @@ void OutputMatrices::compute_interpolated_fields(Dimension dimension) {
   interp_output_grid_labels.y = mxGetPr(output_arrays["y_i"]);
   interp_output_grid_labels.z = mxGetPr(output_arrays["z_i"]);
 
-  // depending on whether we are in 3D or not, the Yee cell range we interpolate over changes, which we address here
+  // depending on whether we are in 3D or not, the Yee cell range we interpolate
+  // over changes, which we address here
   int i_upper = E.tot.i - 2, i_lower = 2;
   int j_upper = E.tot.j - 2, j_lower = 2;
   int k_upper = E.tot.k - 2, k_lower = 2;
@@ -22,16 +23,21 @@ void OutputMatrices::compute_interpolated_fields(Dimension dimension) {
     k_upper = k_lower = 0;
   }
 
-  // now interpolate over the extracted phasors, and set the interpolated gridlabels
-  E.interpolate_over_range(output_arrays["Ex_i"], output_arrays["Ey_i"], output_arrays["Ez_i"],
-                           i_lower, i_upper, j_lower, j_upper, k_lower, k_upper, dimension);
-  H.interpolate_over_range(output_arrays["Hx_i"], output_arrays["Hy_i"], output_arrays["Hz_i"],
-                           i_lower, i_upper, j_lower, j_upper, k_lower, k_upper, dimension);
-  interp_output_grid_labels.initialise_from(output_grid_labels, i_lower, i_upper, j_lower, j_upper,
-                                            k_lower, k_upper);
+  // now interpolate over the extracted phasors, and set the interpolated
+  // gridlabels
+  E.interpolate_over_range(output_arrays["Ex_i"], output_arrays["Ey_i"],
+                           output_arrays["Ez_i"], i_lower, i_upper, j_lower,
+                           j_upper, k_lower, k_upper, dimension);
+  H.interpolate_over_range(output_arrays["Hx_i"], output_arrays["Hy_i"],
+                           output_arrays["Hz_i"], i_lower, i_upper, j_lower,
+                           j_upper, k_lower, k_upper, dimension);
+  interp_output_grid_labels.initialise_from(output_grid_labels, i_lower,
+                                            i_upper, j_lower, j_upper, k_lower,
+                                            k_upper);
 }
 
-void OutputMatrices::setup_vertex_phasors(const mxArray *vp_ptr, int n_frequencies) {
+void OutputMatrices::setup_vertex_phasors(const mxArray *vp_ptr,
+                                          int n_frequencies) {
   // setup from the input provided
   vertex_phasors.set_from(vp_ptr);
 
@@ -43,7 +49,8 @@ void OutputMatrices::setup_vertex_phasors(const mxArray *vp_ptr, int n_frequenci
     vertex_phasors.setup_complex_amplitude_arrays(n_frequencies);
     output_arrays["campssample"] = vertex_phasors.get_mx_camplitudes();
   } else {
-    output_arrays.assign_empty_matrix({"campssample"}, mxDOUBLE_CLASS, mxCOMPLEX, 3);
+    output_arrays.assign_empty_matrix({"campssample"}, mxDOUBLE_CLASS,
+                                      mxCOMPLEX, 3);
   }
 }
 
@@ -55,7 +62,8 @@ void OutputMatrices::setup_fieldsample(const mxArray *fieldsample_input_data) {
 void OutputMatrices::set_maxresfield(double maxfield, bool overwrite_existing) {
   if (overwrite_existing) {
     if (!output_arrays.memory_already_assigned({"maxresfield"})) {
-      throw runtime_error("Error: maxresfield has no allocated memory, but a write was attempted");
+      throw runtime_error("Error: maxresfield has no allocated memory, but a "
+                          "write was attempted");
     }
     // overwrite the value currently at maxresfield
   } else {
@@ -70,28 +78,37 @@ void OutputMatrices::set_maxresfield(double maxfield, bool overwrite_existing) {
   *mxGetPr(output_arrays["maxresfield"]) = maxfield;
 }
 
-void OutputMatrices::setup_EH_and_gridlabels(const SimulationParameters &params, const GridLabels &input_grid_labels, PreferredInterpolationMethods pim) {
+void OutputMatrices::setup_EH_and_gridlabels(
+        const SimulationParameters &params, const GridLabels &input_grid_labels,
+        PreferredInterpolationMethods pim) {
   // set the interpolation methods
   set_interpolation_methods(pim);
 
   /* Set the dimensions of the field
-  If a PML is present, we allow for 2 "buffer" cells surrounding the PML, which will form the range of cells over which we interpolate.
-  This also provides a translation between the global Yee cell indexing system and the local indexing system, cell (il, jl, kl) is local cell (0,0,0). */
+  If a PML is present, we allow for 2 "buffer" cells surrounding the PML, which
+  will form the range of cells over which we interpolate. This also provides a
+  translation between the global Yee cell indexing system and the local indexing
+  system, cell (il, jl, kl) is local cell (0,0,0). */
   E.il = H.il = (params.pml.Dxl) ? params.pml.Dxl + 2 : 0;
-  E.iu = H.iu = (params.pml.Dxu) ? n_Yee_cells.i - params.pml.Dxu - 1 : n_Yee_cells.i;
+  E.iu = H.iu =
+          (params.pml.Dxu) ? n_Yee_cells.i - params.pml.Dxu - 1 : n_Yee_cells.i;
   E.jl = H.jl = (params.pml.Dyl) ? params.pml.Dyl + 2 : 0;
-  E.ju = H.ju = (params.pml.Dyu) ? n_Yee_cells.j - params.pml.Dyu - 1 : n_Yee_cells.j;
+  E.ju = H.ju =
+          (params.pml.Dyu) ? n_Yee_cells.j - params.pml.Dyu - 1 : n_Yee_cells.j;
   E.kl = H.kl = (params.pml.Dzl) ? params.pml.Dzl + 2 : 0;
-  E.ku = H.ku = (params.pml.Dzu) ? n_Yee_cells.k - params.pml.Dzu - 1 : n_Yee_cells.k;
+  E.ku = H.ku =
+          (params.pml.Dzu) ? n_Yee_cells.k - params.pml.Dzu - 1 : n_Yee_cells.k;
   // upper/lower limits of cell extraction
   E.tot.i = H.tot.i = E.iu - E.il + 1;
   E.tot.j = H.tot.j = E.ju - E.jl + 1;
   E.tot.k = H.tot.k = E.ku - E.kl + 1;
 
   // depending on the simulation, we might not need to assign this memory
-  bool need_EH_memory = (params.run_mode == RunMode::complete && params.exphasorsvolume);
+  bool need_EH_memory =
+          (params.run_mode == RunMode::complete && params.exphasorsvolume);
   // field matrices we will be assigning
-  vector<string> field_matrices = {"Ex_out", "Ey_out", "Ez_out", "Hx_out", "Hy_out", "Hz_out"};
+  vector<string> field_matrices = {"Ex_out", "Ey_out", "Ez_out",
+                                   "Hx_out", "Hy_out", "Hz_out"};
   // gridlabels matrices we will be assigning
   vector<string> grid_matrices = {"x_out", "y_out", "z_out"};
   if (!need_EH_memory) {
@@ -108,51 +125,70 @@ void OutputMatrices::setup_EH_and_gridlabels(const SimulationParameters &params,
     spdlog::info("dims: ({0:d},{1:d},{2:d})", dims[0], dims[1], dims[2]);
 
     // create MATLAB data storage for the field-component outputs
-    for(string matrix : field_matrices) {
-      output_arrays[matrix] = mxCreateNumericArray(3, (const mwSize *) dims, mxDOUBLE_CLASS, mxCOMPLEX);
+    for (string matrix : field_matrices) {
+      output_arrays[matrix] = mxCreateNumericArray(3, (const mwSize *) dims,
+                                                   mxDOUBLE_CLASS, mxCOMPLEX);
     }
     // create MATLAB data storage for the gridlabel outputs
     int label_dims_x[2] = {1, E.tot.i};
     int label_dims_y[2] = {1, E.tot.j};
     int label_dims_z[2] = {1, E.tot.k};
-    output_arrays["x_out"] = mxCreateNumericArray(2, (const mwSize *) label_dims_x, mxDOUBLE_CLASS, mxREAL);
-    output_arrays["y_out"] = mxCreateNumericArray(2, (const mwSize *) label_dims_y, mxDOUBLE_CLASS, mxREAL);
-    output_arrays["z_out"] = mxCreateNumericArray(2, (const mwSize *) label_dims_z, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["x_out"] = mxCreateNumericArray(
+            2, (const mwSize *) label_dims_x, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["y_out"] = mxCreateNumericArray(
+            2, (const mwSize *) label_dims_y, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["z_out"] = mxCreateNumericArray(
+            2, (const mwSize *) label_dims_z, mxDOUBLE_CLASS, mxREAL);
 
     // cast E, H, and gridlabel members to the MATLAB structures
-    E.real.x = cast_matlab_3D_array(mxGetPr(output_arrays["Ex_out"]), E.tot.i, E.tot.j, E.tot.k);
-    E.imag.x = cast_matlab_3D_array(mxGetPi(output_arrays["Ex_out"]), E.tot.i, E.tot.j, E.tot.k);
+    E.real.x = cast_matlab_3D_array(mxGetPr(output_arrays["Ex_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
+    E.imag.x = cast_matlab_3D_array(mxGetPi(output_arrays["Ex_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
 
-    E.real.y = cast_matlab_3D_array(mxGetPr(output_arrays["Ey_out"]), E.tot.i, E.tot.j, E.tot.k);
-    E.imag.y = cast_matlab_3D_array(mxGetPi(output_arrays["Ey_out"]), E.tot.i, E.tot.j, E.tot.k);
+    E.real.y = cast_matlab_3D_array(mxGetPr(output_arrays["Ey_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
+    E.imag.y = cast_matlab_3D_array(mxGetPi(output_arrays["Ey_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
 
-    E.real.z = cast_matlab_3D_array(mxGetPr(output_arrays["Ez_out"]), E.tot.i, E.tot.j, E.tot.k);
-    E.imag.z = cast_matlab_3D_array(mxGetPi(output_arrays["Ez_out"]), E.tot.i, E.tot.j, E.tot.k);
+    E.real.z = cast_matlab_3D_array(mxGetPr(output_arrays["Ez_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
+    E.imag.z = cast_matlab_3D_array(mxGetPi(output_arrays["Ez_out"]), E.tot.i,
+                                    E.tot.j, E.tot.k);
 
-    H.real.x = cast_matlab_3D_array(mxGetPr(output_arrays["Hx_out"]), H.tot.i, H.tot.j, H.tot.k);
-    H.imag.x = cast_matlab_3D_array(mxGetPi(output_arrays["Hx_out"]), H.tot.i, H.tot.j, H.tot.k);
+    H.real.x = cast_matlab_3D_array(mxGetPr(output_arrays["Hx_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
+    H.imag.x = cast_matlab_3D_array(mxGetPi(output_arrays["Hx_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
 
-    H.real.y = cast_matlab_3D_array(mxGetPr(output_arrays["Hy_out"]), H.tot.i, H.tot.j, H.tot.k);
-    H.imag.y = cast_matlab_3D_array(mxGetPi(output_arrays["Hy_out"]), H.tot.i, H.tot.j, H.tot.k);
+    H.real.y = cast_matlab_3D_array(mxGetPr(output_arrays["Hy_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
+    H.imag.y = cast_matlab_3D_array(mxGetPi(output_arrays["Hy_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
 
-    H.real.z = cast_matlab_3D_array(mxGetPr(output_arrays["Hz_out"]), H.tot.i, H.tot.j, H.tot.k);
-    H.imag.z = cast_matlab_3D_array(mxGetPi(output_arrays["Hz_out"]), H.tot.i, H.tot.j, H.tot.k);
+    H.real.z = cast_matlab_3D_array(mxGetPr(output_arrays["Hz_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
+    H.imag.z = cast_matlab_3D_array(mxGetPi(output_arrays["Hz_out"]), H.tot.i,
+                                    H.tot.j, H.tot.k);
 
-    //now construct the grid labels
+    // now construct the grid labels
     output_grid_labels.x = mxGetPr(output_arrays["x_out"]);
     output_grid_labels.y = mxGetPr(output_arrays["y_out"]);
     output_grid_labels.z = mxGetPr(output_arrays["z_out"]);
 
-    //initialise field arrays
+    // initialise field arrays
     E.zero();
     H.zero();
 
-    // initialise the gridlabels from the input grid labels (essentially shave off the PML labels)
-    output_grid_labels.initialise_from(input_grid_labels, E.il, E.iu, E.jl, E.ju, E.kl, E.ku);
+    // initialise the gridlabels from the input grid labels (essentially shave
+    // off the PML labels)
+    output_grid_labels.initialise_from(input_grid_labels, E.il, E.iu, E.jl,
+                                       E.ju, E.kl, E.ku);
   }
 }
 
-void OutputMatrices::setup_Id(bool empty_allocation, int n_frequencies, int n_det_modes) {
+void OutputMatrices::setup_Id(bool empty_allocation, int n_frequencies,
+                              int n_det_modes) {
   // create output by reserving memory
   if (empty_allocation) {
     output_arrays.assign_empty_matrix({"Id"});
@@ -163,7 +199,8 @@ void OutputMatrices::setup_Id(bool empty_allocation, int n_frequencies, int n_de
     // create a structure array with two fields
     int dims[2] = {1, 1};
     const char *fieldnames[] = {"Idx", "Idy"};
-    output_arrays["Id"] = mxCreateStructArray(2, (const mwSize *) dims, 2, fieldnames);
+    output_arrays["Id"] =
+            mxCreateStructArray(2, (const mwSize *) dims, 2, fieldnames);
 
     // setup the IDVariables member so we can later write data to it
     ID.link_to_pointer(output_arrays["Id"], n_frequencies, n_det_modes);
@@ -171,8 +208,10 @@ void OutputMatrices::setup_Id(bool empty_allocation, int n_frequencies, int n_de
 }
 
 void OutputMatrices::setup_interpolation_outputs(SimulationParameters params) {
-  // if we do not need to interpolate, we do not need to allocate memory to the interpolation-related outputs
-  bool need_to_interpolate = (params.run_mode == RunMode::complete && params.exphasorsvolume);
+  // if we do not need to interpolate, we do not need to allocate memory to the
+  // interpolation-related outputs
+  bool need_to_interpolate =
+          (params.run_mode == RunMode::complete && params.exphasorsvolume);
 
   // output names that we will be allocating here
   vector<string> interpolated_gridlabels_names = {"x_i", "y_i", "z_i"};
@@ -190,13 +229,13 @@ void OutputMatrices::setup_interpolation_outputs(SimulationParameters params) {
     output_arrays.error_on_memory_assigned(interpolated_H_field_names);
     output_arrays.error_on_memory_assigned(interpolated_gridlabels_names);
 
-    // interpolated field memory needs to be assigned. Since E, H field have the same {IJK}_tot, we can set the dimensions once, and do it here rather than separately for each field
+    // interpolated field memory needs to be assigned. Since E, H field have the
+    // same {IJK}_tot, we can set the dimensions once, and do it here rather
+    // than separately for each field
     int i_upper = E.tot.i - 2, i_lower = 2;
     int j_upper = E.tot.j - 2, j_lower = 2;
     int k_upper = E.tot.k - 2, k_lower = 2;
-    if (params.dimension != THREE) {
-      k_upper = k_lower = 0;
-    }
+    if (params.dimension != THREE) { k_upper = k_lower = 0; }
     // dimensions of the interpolated fields
     int outdims[3] = {i_upper - i_lower + 1, j_upper - j_lower + 1, 0};
     if (params.dimension == THREE) {
@@ -206,51 +245,52 @@ void OutputMatrices::setup_interpolation_outputs(SimulationParameters params) {
 
     // Create interpolated E-field memory
     for (string matrix : interpolated_E_field_names) {
-      output_arrays[matrix] =
-              mxCreateNumericArray(3, (mwSize *) outdims, mxDOUBLE_CLASS, mxCOMPLEX);
+      output_arrays[matrix] = mxCreateNumericArray(3, (mwSize *) outdims,
+                                                   mxDOUBLE_CLASS, mxCOMPLEX);
     }
     // Create interpolated H-field memory
     for (string matrix : interpolated_H_field_names) {
-      output_arrays[matrix] =
-              mxCreateNumericArray(3, (mwSize *) outdims, mxDOUBLE_CLASS, mxCOMPLEX);
+      output_arrays[matrix] = mxCreateNumericArray(3, (mwSize *) outdims,
+                                                   mxDOUBLE_CLASS, mxCOMPLEX);
     }
 
     // interpolated gridlabels memory needs to be assigned
     // x-labels are always a fixed size
     int label_dims[2] = {1, E.tot.i - 3};
-    output_arrays["x_i"] =
-            mxCreateNumericArray(2, (const mwSize *) label_dims, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["x_i"] = mxCreateNumericArray(2, (const mwSize *) label_dims,
+                                                mxDOUBLE_CLASS, mxREAL);
     // y-labels might receive nJ < 0, in which case a manual adjustment is made
     label_dims[1] = max(E.tot.j - 3, 1);
-    output_arrays["y_i"] =
-            mxCreateNumericArray(2, (const mwSize *) label_dims, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["y_i"] = mxCreateNumericArray(2, (const mwSize *) label_dims,
+                                                mxDOUBLE_CLASS, mxREAL);
     // z-labels depend on the dimensionality of the simulation
     if (params.dimension == THREE) {
       label_dims[1] = E.tot.k - 3;
     } else {
       label_dims[1] = 1;
     }
-    output_arrays["z_i"] =
-            mxCreateNumericArray(2, (const mwSize *) label_dims, mxDOUBLE_CLASS, mxREAL);
+    output_arrays["z_i"] = mxCreateNumericArray(2, (const mwSize *) label_dims,
+                                                mxDOUBLE_CLASS, mxREAL);
 
     // now run the post-processing interpolation
     compute_interpolated_fields(params.dimension);
   }
 }
 
-void OutputMatrices::setup_surface_mesh(const Cuboid &cuboid, const SimulationParameters &params, int n_frequencies) {
+void OutputMatrices::setup_surface_mesh(const Cuboid &cuboid,
+                                        const SimulationParameters &params,
+                                        int n_frequencies) {
   if (params.exphasorssurface && params.run_mode == RunMode::complete) {
     mxArray *mx_surface_facets = nullptr;
     if (n_Yee_cells.j == 0) {
       conciseCreateBoundary(cuboid[0], cuboid[1], cuboid[4], cuboid[5],
                             &mx_surface_vertices, &mx_surface_facets);
     } else {
-      conciseTriangulateCuboidSkip(cuboid[0], cuboid[1], cuboid[2],
-                                   cuboid[3], cuboid[4], cuboid[5],
-                                   params.spacing_stride, &mx_surface_vertices,
-                                   &mx_surface_facets);
+      conciseTriangulateCuboidSkip(cuboid[0], cuboid[1], cuboid[2], cuboid[3],
+                                   cuboid[4], cuboid[5], params.spacing_stride,
+                                   &mx_surface_vertices, &mx_surface_facets);
     }
-    //we don't need the facets so destroy the matrix now to save memory
+    // we don't need the facets so destroy the matrix now to save memory
     mxDestroyArray(mx_surface_facets);
     // now cast the MATLAB array that we created to the surface phasors object
     surface_phasors.set_from_matlab_array(mx_surface_vertices, n_frequencies);
@@ -270,18 +310,19 @@ void OutputMatrices::assign_surface_phasor_outputs(bool empty_allocation,
 
     // pull the memory blocks from the phasors
     output_arrays["vertices"] = surface_phasors.get_vertex_list();
-    output_arrays["camplitudes"] =
-            surface_phasors.get_mx_surface_amplitudes();
+    output_arrays["camplitudes"] = surface_phasors.get_mx_surface_amplitudes();
     output_arrays["facets"] = mx_surface_facets;
   }
 }
 
-void OutputMatrices::save_outputs(const string &output_file_name, bool compressed_output) {
+void OutputMatrices::save_outputs(const string &output_file_name,
+                                  bool compressed_output) {
   MATFile *output_file = matOpen(output_file_name.c_str(), "w7.3");
 
   // check output file was opened successfully
   if (output_file == nullptr) {
-    throw runtime_error("Unable to open output file" + string(output_file_name));
+    throw runtime_error("Unable to open output file" +
+                        string(output_file_name));
   }
 
   // if we don't want a compressed output we save additional matrices
@@ -291,15 +332,18 @@ void OutputMatrices::save_outputs(const string &output_file_name, bool compresse
   } else {
     output_matrices_requested = outputmatrices_all;
   }
-  // iterate through the matrices we want to save, setting names and placing them into the matfile
-  for(string matrix_to_write : output_matrices_requested) {
+  // iterate through the matrices we want to save, setting names and placing
+  // them into the matfile
+  for (string matrix_to_write : output_matrices_requested) {
     // returns 0 if successful and non-zero if an error occurred
-    int mpv_out = matPutVariable(output_file, matrix_to_write.c_str(), output_arrays[matrix_to_write]);
+    int mpv_out = matPutVariable(output_file, matrix_to_write.c_str(),
+                                 output_arrays[matrix_to_write]);
     if (mpv_out != 0) {
-        // print error information
-        FILE *fp = matGetFp(output_file);
-        spdlog::info("Could not write array {0:s} to {1:s} ({2:d},{3:d},{4:d})",
-                     matrix_to_write.c_str(), output_file_name, mpv_out, feof(fp), ferror(fp));
+      // print error information
+      FILE *fp = matGetFp(output_file);
+      spdlog::info("Could not write array {0:s} to {1:s} ({2:d},{3:d},{4:d})",
+                   matrix_to_write.c_str(), output_file_name, mpv_out, feof(fp),
+                   ferror(fp));
     }
   }
 
@@ -309,7 +353,5 @@ void OutputMatrices::save_outputs(const string &output_file_name, bool compresse
 
 OutputMatrices::~OutputMatrices() {
   // free underlying surface phasor MATLAB array, if we need to
-  if (mx_surface_vertices != nullptr) {
-    mxDestroyArray(mx_surface_vertices);
-  }
+  if (mx_surface_vertices != nullptr) { mxDestroyArray(mx_surface_vertices); }
 }

--- a/tdms/src/output_matrices/output_matrix_pointers.cpp
+++ b/tdms/src/output_matrices/output_matrix_pointers.cpp
@@ -6,7 +6,8 @@ using namespace tdms_matrix_names;
 using namespace std;
 
 int OutputMatrixPointers::index_from_matrix_name(const string &matrix_name) {
-  auto position = find(outputmatrices_all.begin(), outputmatrices_all.end(), matrix_name);
+  auto position = find(outputmatrices_all.begin(), outputmatrices_all.end(),
+                       matrix_name);
   if (position == outputmatrices_all.end()) {
     // could not find the matrix name in the list of expected input matrices
     throw runtime_error(matrix_name + " not found in outputmatrices_all");
@@ -14,22 +15,26 @@ int OutputMatrixPointers::index_from_matrix_name(const string &matrix_name) {
   return distance(outputmatrices_all.begin(), position);
 }
 
-bool OutputMatrixPointers::memory_already_assigned(const vector<string> &matrix_names) {
+bool OutputMatrixPointers::memory_already_assigned(
+        const vector<string> &matrix_names) {
   for (const string &matrix_name : matrix_names) {
-    if (matrix_pointers[index_from_matrix_name(matrix_name)] != nullptr) { return true; }
+    if (matrix_pointers[index_from_matrix_name(matrix_name)] != nullptr) {
+      return true;
+    }
   }
   return false;
 }
 
-void OutputMatrixPointers::assign_empty_matrix(const vector<string> &matrix_names, mxClassID data_type,
-                                               mxComplexity complexity, int ndims) {
+void OutputMatrixPointers::assign_empty_matrix(
+        const vector<string> &matrix_names, mxClassID data_type,
+        mxComplexity complexity, int ndims) {
   // avoid memory leaks
   error_on_memory_assigned(matrix_names);
   // assign the empty array to all the matrix_names
   vector<int> dims(ndims, 0);
   for (string matrix : matrix_names) {
-    matrix_pointers[index_from_matrix_name(matrix)] =
-            mxCreateNumericArray(ndims, (const mwSize *) dims.data(), data_type, complexity);
+    matrix_pointers[index_from_matrix_name(matrix)] = mxCreateNumericArray(
+            ndims, (const mwSize *) dims.data(), data_type, complexity);
   }
 }
 

--- a/tdms/src/shapes.cpp
+++ b/tdms/src/shapes.cpp
@@ -18,10 +18,12 @@ void Cuboid::initialise(const mxArray *ptr, int J_tot) {
   }
 
   for (int i = 0; i < 6; i++) {
-    array[i] = max((int) *(mxGetPr(ptr) + i) - 1, // Change from MATLAB -> C indexing
+    array[i] = max((int) *(mxGetPr(ptr) + i) -
+                           1,// Change from MATLAB -> C indexing
                    0);
   }
   if (J_tot == 0 && array[2] != array[3]) {
-      throw runtime_error("When doing a 2D simulation, J0 should equal J1 in phasorsurface.");
+    throw runtime_error(
+            "When doing a 2D simulation, J0 should equal J1 in phasorsurface.");
   }
 }

--- a/tdms/src/simulation_manager/fdtd_bootstrapper.cpp
+++ b/tdms/src/simulation_manager/fdtd_bootstrapper.cpp
@@ -17,35 +17,37 @@ void FDTDBootstrapper::allocate_memory(const IJKDimensions &IJK_tot) {
   Hy.allocate(I_tot, J_tot + 1);
 }
 
-void FDTDBootstrapper::extract_phasors_in_plane(const ElectricSplitField &E_s, const MagneticSplitField &H_s,
-                                                const IJKDimensions &IJK_tot, int K1, int tind,
-                                                const SimulationParameters &params) {
+void FDTDBootstrapper::extract_phasors_in_plane(
+        const ElectricSplitField &E_s, const MagneticSplitField &H_s,
+        const IJKDimensions &IJK_tot, int K1, int tind,
+        const SimulationParameters &params) {
   int Nt = params.Nt, I_tot = IJK_tot.i, J_tot = IJK_tot.j;
 
-  complex<double> phaseTerm = fmod(params.omega_an * ((double) tind) * params.dt, 2 * DCPI);
+  complex<double> phaseTerm =
+          fmod(params.omega_an * ((double) tind) * params.dt, 2 * DCPI);
   complex<double> subResult = 0.;
 
   for (int j = 0; j < J_tot; j++) {
     for (int i = 0; i < (I_tot + 1); i++) {
-      //Eyz
-      subResult = (E_s.yz[K1][j][i] + E_s.yx[K1][j][i]) * exp(phaseTerm * IMAGINARY_UNIT) * 1. /
-                  ((double) Nt);
+      // Eyz
+      subResult = (E_s.yz[K1][j][i] + E_s.yx[K1][j][i]) *
+                  exp(phaseTerm * IMAGINARY_UNIT) * 1. / ((double) Nt);
       Ey[i][j] += subResult;
-      //Hxz
-      subResult = (H_s.xz[K1 - 1][j][i] + H_s.xy[K1][j][i]) * exp(phaseTerm * IMAGINARY_UNIT) * 1. /
-                  ((double) Nt);
+      // Hxz
+      subResult = (H_s.xz[K1 - 1][j][i] + H_s.xy[K1][j][i]) *
+                  exp(phaseTerm * IMAGINARY_UNIT) * 1. / ((double) Nt);
       Hx[i][j] += subResult;
     }
   }
   for (int j = 0; j < (J_tot + 1); j++)
     for (int i = 0; i < I_tot; i++) {
-      //Exz
-      subResult = (E_s.xz[K1][j][i] + E_s.xy[K1][j][i]) * exp(phaseTerm * IMAGINARY_UNIT) * 1. /
-                  ((double) Nt);
+      // Exz
+      subResult = (E_s.xz[K1][j][i] + E_s.xy[K1][j][i]) *
+                  exp(phaseTerm * IMAGINARY_UNIT) * 1. / ((double) Nt);
       Ex[i][j] += subResult;
-      //Hyz
-      subResult = (H_s.yz[K1 - 1][j][i] + H_s.yx[K1][j][i]) * exp(phaseTerm * IMAGINARY_UNIT) * 1. /
-                  ((double) Nt);
+      // Hyz
+      subResult = (H_s.yz[K1 - 1][j][i] + H_s.yx[K1][j][i]) *
+                  exp(phaseTerm * IMAGINARY_UNIT) * 1. / ((double) Nt);
       Hy[i][j] += subResult;
     }
 }

--- a/tdms/src/simulation_manager/loop_variables.cpp
+++ b/tdms/src/simulation_manager/loop_variables.cpp
@@ -7,12 +7,16 @@
 using namespace tdms_phys_constants;
 using namespace std;
 
-LoopVariables::LoopVariables(const ObjectsFromInfile &data, IJKDimensions E_field_dims) {
+LoopVariables::LoopVariables(const ObjectsFromInfile &data,
+                             IJKDimensions E_field_dims) {
   // deduce the number of non-pml cells in the z-direction, for efficiency
-  n_non_pml_cells_in_K = data.IJK_tot.k - data.params.pml.Dxl - data.params.pml.Dxu;
+  n_non_pml_cells_in_K =
+          data.IJK_tot.k - data.params.pml.Dxl - data.params.pml.Dxu;
 
   // deduce refractive index, and print to log
-  refind = sqrt(1. / (data.freespace_Cbx[0] / data.params.dt * data.params.delta.dx) / EPSILON0);
+  refind = sqrt(
+          1. / (data.freespace_Cbx[0] / data.params.dt * data.params.delta.dx) /
+          EPSILON0);
   spdlog::info("refind (Refractive index) = {0:e}", refind);
 
   // setup temporary storgage for detector sensitivity evaluation
@@ -23,32 +27,42 @@ LoopVariables::LoopVariables(const ObjectsFromInfile &data, IJKDimensions E_fiel
     Ey_t.initialise(n1, n0);
   }
 
-  // We need to test for convergence under the following conditions. As such, we need to initialise the array (E_at_previous_iteration) that will ultimately be copies of the phasors at the previous iteration, to test convergence against
-  if (data.params.run_mode == RunMode::complete && data.params.exphasorsvolume &&
+  // We need to test for convergence under the following conditions. As such, we
+  // need to initialise the array (E_at_previous_iteration) that will ultimately
+  // be copies of the phasors at the previous iteration, to test convergence
+  // against
+  if (data.params.run_mode == RunMode::complete &&
+      data.params.exphasorsvolume &&
       data.params.source_mode == SourceMode::steadystate) {
     int dummy_dims[3] = {E_field_dims.i, E_field_dims.j, E_field_dims.k};
     // allocate memory space for this array
-    E_copy_MATLAB_data[0] =
-            mxCreateNumericArray(3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);//Ex
-    E_copy_MATLAB_data[1] =
-            mxCreateNumericArray(3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);//Ey
-    E_copy_MATLAB_data[2] =
-            mxCreateNumericArray(3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);//Ez
+    E_copy_MATLAB_data[0] = mxCreateNumericArray(
+            3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);// Ex
+    E_copy_MATLAB_data[1] = mxCreateNumericArray(
+            3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);// Ey
+    E_copy_MATLAB_data[2] = mxCreateNumericArray(
+            3, (const mwSize *) dummy_dims, mxDOUBLE_CLASS, mxCOMPLEX);// Ez
 
-    E_at_previous_iteration.real.x = cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[0]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
-    E_at_previous_iteration.imag.x = cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[0]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.real.x =
+            cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[0]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.imag.x =
+            cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[0]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
 
-    E_at_previous_iteration.real.y = cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[1]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
-    E_at_previous_iteration.imag.y = cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[1]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.real.y =
+            cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[1]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.imag.y =
+            cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[1]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
 
-    E_at_previous_iteration.real.z = cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[2]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
-    E_at_previous_iteration.imag.z = cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[2]), dummy_dims[0],
-                                         dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.real.z =
+            cast_matlab_3D_array(mxGetPr(E_copy_MATLAB_data[2]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
+    E_at_previous_iteration.imag.z =
+            cast_matlab_3D_array(mxGetPi(E_copy_MATLAB_data[2]), dummy_dims[0],
+                                 dummy_dims[1], dummy_dims[2]);
 
     E_at_previous_iteration.tot = E_field_dims;
 
@@ -67,27 +81,33 @@ LoopVariables::LoopVariables(const ObjectsFromInfile &data, IJKDimensions E_fiel
 void LoopVariables::setup_dispersive_properties(const ObjectsFromInfile &data) {
   IJKDimensions IJK = data.IJK_tot;
   // determine whether or not we have a dispersive medium
-  is_dispersive = is_dispersive_medium(data.materials, IJK, data.gamma, data.params.dt);
-  // work out if we have conductive background: background is conductive if at least one entry exceeds 1e-15
-  is_conductive = !(data.rho_cond.all_elements_less_than(1e-15, IJK.i + 1, IJK.j + 1, IJK.k + 1));
+  is_dispersive =
+          is_dispersive_medium(data.materials, IJK, data.gamma, data.params.dt);
+  // work out if we have conductive background: background is conductive if at
+  // least one entry exceeds 1e-15
+  is_conductive = !(data.rho_cond.all_elements_less_than(1e-15, IJK.i + 1,
+                                                         IJK.j + 1, IJK.k + 1));
 
   // prepare additional field variables for dispersive media
   E_nm1 = ElectricSplitField(IJK.i, IJK.j, IJK.k);
   J_nm1 = CurrentDensitySplitField(IJK.i, IJK.j, IJK.k);
   J_c = CurrentDensitySplitField(IJK.i, IJK.j, IJK.k);
-  // if we have a dispersive material we will need to write to the additional fields, so assign the memory to them and zero the entries
+  // if we have a dispersive material we will need to write to the additional
+  // fields, so assign the memory to them and zero the entries
   if (is_dispersive || data.params.is_disp_ml) {
     E_nm1.allocate_and_zero();
     J_nm1.allocate_and_zero();
     J_s.allocate_and_zero();
   }
-  // if we have a conductive material we will also need the conductivity/current-density of each cell
+  // if we have a conductive material we will also need the
+  // conductivity/current-density of each cell
   if (is_conductive) { J_c.allocate_and_zero(); }
 }
 
-bool LoopVariables::is_dispersive_medium(uint8_t ***materials, const IJKDimensions &IJK_tot,
-                                         double *attenuation_constants, double dt,
-                                         double non_zero_tol) {
+bool LoopVariables::is_dispersive_medium(uint8_t ***materials,
+                                         const IJKDimensions &IJK_tot,
+                                         double *attenuation_constants,
+                                         double dt, double non_zero_tol) {
   int max_mat = 0;
   // determine the number of entries in gamma, by examining the materials array
   for (int k = 0; k < (IJK_tot.k + 1); k++)
@@ -103,30 +123,36 @@ bool LoopVariables::is_dispersive_medium(uint8_t ***materials, const IJKDimensio
 }
 
 LoopVariables::~LoopVariables() {
-  for(int i = 0; i < 3; i++) {
-    if (E_copy_MATLAB_data[i] != nullptr) { mxDestroyArray(E_copy_MATLAB_data[i]); }
+  for (int i = 0; i < 3; i++) {
+    if (E_copy_MATLAB_data[i] != nullptr) {
+      mxDestroyArray(E_copy_MATLAB_data[i]);
+    }
   }
 }
 
-void LoopVariables::optimise_loop_J_range(const ObjectsFromInfile &data, double non_zero_tol) {
+void LoopVariables::optimise_loop_J_range(const ObjectsFromInfile &data,
+                                          double non_zero_tol) {
   bool ksource_nz[4];//< "k source non-zero"
   for (int icomp = 0; icomp < 4; icomp++) { ksource_nz[icomp] = false; }
 
   if (data.IJK_tot.j == 0) {
     for (int icomp = 0; icomp < 4; icomp++)
       for (int ki = 0; ki < (data.IJK_tot.i + 1); ki++) {
-        ksource_nz[icomp] = ksource_nz[icomp] ||
-                            (fabs(data.Ksource.imag[0][ki - (data.I0.index)][icomp]) > non_zero_tol) ||
-                            (fabs(data.Ksource.real[0][ki - (data.I0.index)][icomp]) > non_zero_tol);
+        ksource_nz[icomp] =
+                ksource_nz[icomp] ||
+                (fabs(data.Ksource.imag[0][ki - (data.I0.index)][icomp]) >
+                 non_zero_tol) ||
+                (fabs(data.Ksource.real[0][ki - (data.I0.index)][icomp]) >
+                 non_zero_tol);
       }
   }
   /* We now know the following information:
-    Ey and Hx receive an input from the source condition only if ksource_nz[2] or ksource_nz[1]
-    are non-zero.
-    Ex and Hy receive an input from the source condition only if ksource_nz[3] or ksource_nz[0]
-    are non-zero.
+    Ey and Hx receive an input from the source condition only if ksource_nz[2]
+    or ksource_nz[1] are non-zero. Ex and Hy receive an input from the source
+    condition only if ksource_nz[3] or ksource_nz[0] are non-zero.
 
-    Thus we can set the variables J_loop_upper_bound_plus_1, J_loop_upper_bound accordingly for the 3D, 2D-TE, and 2D-TM simulations.
+    Thus we can set the variables J_loop_upper_bound_plus_1, J_loop_upper_bound
+    accordingly for the 3D, 2D-TE, and 2D-TM simulations.
   */
   J_loop_upper_bound = data.IJK_tot.j;
   J_loop_upper_bound_plus_1 = data.IJK_tot.j + 1;

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -10,9 +10,9 @@
 
 using tdms_math_constants::DCPI;
 
-IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrices_from_input_file,
-                                                           SolverMethod _solver_method,
-                                                           PreferredInterpolationMethods _pim)
+IndependentObjectsFromInfile::IndependentObjectsFromInfile(
+        InputMatrices matrices_from_input_file, SolverMethod _solver_method,
+        PreferredInterpolationMethods _pim)
     :// initialisation list - members whose classes have no default constructors
       Cmaterial(matrices_from_input_file["Cmaterial"]),// get Cmaterial
       Dmaterial(matrices_from_input_file["Dmaterial"]),// get Dmaterial
@@ -24,8 +24,9 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
       J1(matrices_from_input_file["interface"], "J1"),
       K0(matrices_from_input_file["interface"], "K0"),
       K1(matrices_from_input_file["interface"], "K1"),
-      matched_layer(matrices_from_input_file["dispersive_aux"]),// get dispersive_aux
-      Ei(matrices_from_input_file["tdfield"])                   // get tdfield
+      matched_layer(
+              matrices_from_input_file["dispersive_aux"]),// get dispersive_aux
+      Ei(matrices_from_input_file["tdfield"])             // get tdfield
 {
   // set solver method
   set_solver_method(_solver_method);
@@ -37,20 +38,21 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
 
   // get the fdtd grid
   init_grid_arrays(matrices_from_input_file["fdtdgrid"], E_s, H_s, materials);
-  // set the {IJK}_tot variables using the split-field information we just unpacked
+  // set the {IJK}_tot variables using the split-field information we just
+  // unpacked
   IJK_tot = E_s.tot;
 
   // Get freespace - Cby Cbz Dbx Dby Dbz are unused
-  freespace_Cbx =
-          mxGetPr(ptr_to_vector_in(matrices_from_input_file["freespace"], "Cbx", "freespace"));
+  freespace_Cbx = mxGetPr(ptr_to_vector_in(
+          matrices_from_input_file["freespace"], "Cbx", "freespace"));
 
   // Get disp_params
-  alpha = mxGetPr(ptr_to_vector_or_empty_in(matrices_from_input_file["disp_params"], "alpha",
-                                            "disp_params"));
-  beta = mxGetPr(ptr_to_vector_or_empty_in(matrices_from_input_file["disp_params"], "beta",
-                                           "disp_params"));
-  gamma = mxGetPr(ptr_to_vector_or_empty_in(matrices_from_input_file["disp_params"], "gamma",
-                                            "disp_params"));
+  alpha = mxGetPr(ptr_to_vector_or_empty_in(
+          matrices_from_input_file["disp_params"], "alpha", "disp_params"));
+  beta = mxGetPr(ptr_to_vector_or_empty_in(
+          matrices_from_input_file["disp_params"], "beta", "disp_params"));
+  gamma = mxGetPr(ptr_to_vector_or_empty_in(
+          matrices_from_input_file["disp_params"], "gamma", "disp_params"));
 
   // Get grid_labels (not needed in main loop)
   input_grid_labels = GridLabels(matrices_from_input_file["grid_labels"]);
@@ -64,12 +66,15 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
   // Get conductive_aux, and setup with pointers
   // mxGetPr pointers will be cleaned up by XYZVectors destructor
   rho_cond = XYZVectors();
-  rho_cond.x = mxGetPr(
-          ptr_to_vector_in(matrices_from_input_file["conductive_aux"], "rho_x", "conductive_aux"));
-  rho_cond.y = mxGetPr(
-          ptr_to_vector_in(matrices_from_input_file["conductive_aux"], "rho_y", "conductive_aux"));
-  rho_cond.z = mxGetPr(
-          ptr_to_vector_in(matrices_from_input_file["conductive_aux"], "rho_z", "conductive_aux"));
+  rho_cond.x =
+          mxGetPr(ptr_to_vector_in(matrices_from_input_file["conductive_aux"],
+                                   "rho_x", "conductive_aux"));
+  rho_cond.y =
+          mxGetPr(ptr_to_vector_in(matrices_from_input_file["conductive_aux"],
+                                   "rho_y", "conductive_aux"));
+  rho_cond.z =
+          mxGetPr(ptr_to_vector_in(matrices_from_input_file["conductive_aux"],
+                                   "rho_z", "conductive_aux"));
 
   // prepare variables dependent on frequency extraction vector
   f_vec = FrequencyVectors();
@@ -78,13 +83,16 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
   // if exdetintegral is flagged, setup pupil, D_tilde, and f_vec accordingly
   if (params.exdetintegral) {
     f_vec.initialise(matrices_from_input_file["f_vec"]);
-    pupil.initialise(matrices_from_input_file["Pupil"], f_vec.x.size(), f_vec.y.size());
-    D_tilde.initialise(matrices_from_input_file["D_tilde"], f_vec.x.size(), f_vec.y.size());
+    pupil.initialise(matrices_from_input_file["Pupil"], f_vec.x.size(),
+                     f_vec.y.size());
+    D_tilde.initialise(matrices_from_input_file["D_tilde"], f_vec.x.size(),
+                       f_vec.y.size());
 
     if (!mxIsEmpty(matrices_from_input_file["k_det_obs_global"])) {
-      params.k_det_obs =
-              int_cast_from_double_in(matrices_from_input_file["k_det_obs_global"], "k_det_obs") -
-              1;
+      params.k_det_obs = int_cast_from_double_in(
+                                 matrices_from_input_file["k_det_obs_global"],
+                                 "k_det_obs") -
+                         1;
     }
     params.z_obs = input_grid_labels.z[params.k_det_obs];
   }
@@ -110,9 +118,12 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
   }
 
   // work out if we have a dispersive background
-  if (params.is_disp_ml) { params.is_disp_ml = matched_layer.is_dispersive(IJK_tot.k); }
+  if (params.is_disp_ml) {
+    params.is_disp_ml = matched_layer.is_dispersive(IJK_tot.k);
+  }
 
-  // Set dt so that an integer number of time periods fits within a sinusoidal period
+  // Set dt so that an integer number of time periods fits within a sinusoidal
+  // period
   double Nsteps_tmp = 0.0;
   double dt_old;
   if (params.source_mode == SourceMode::steadystate) {
@@ -124,12 +135,16 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(InputMatrices matrice
     }
   }
   Nsteps = (int) lround(Nsteps_tmp);
-  // Nt should be an integer number of Nsteps in the case of steady-state operation
-  if (params.source_mode == SourceMode::steadystate && params.run_mode == RunMode::complete) {
+  // Nt should be an integer number of Nsteps in the case of steady-state
+  // operation
+  if (params.source_mode == SourceMode::steadystate &&
+      params.run_mode == RunMode::complete) {
     if (params.Nt / Nsteps * Nsteps != params.Nt) {
-      int old_Nt = params.Nt;//< For logging purposes, holds the Nt value that had to be changed
+      int old_Nt = params.Nt;//< For logging purposes, holds the Nt value that
+                             // had to be changed
       params.Nt = params.Nt / Nsteps * Nsteps;
-      spdlog::info("Changing the value of Nt to {0:d} (was {1:d})", params.Nt, old_Nt);
+      spdlog::info("Changing the value of Nt to {0:d} (was {1:d})", params.Nt,
+                   old_Nt);
     }
     spdlog::info("Nsteps: {0:d}", Nsteps);
   }
@@ -147,14 +162,16 @@ ObjectsFromInfile::ObjectsFromInfile(InputMatrices matrices_from_input_file,
                                      SolverMethod _solver_method,
                                      PreferredInterpolationMethods _pim)
     :// build the independent objects first
-      IndependentObjectsFromInfile(matrices_from_input_file, _solver_method, _pim),
-      // Source has no default constructor, and we need information from the Iterator_IndependentObjectsFromInfile first
-      Isource(matrices_from_input_file["Isource"], J1.index - J0.index + 1, K1.index - K0.index + 1,
-              "Isource"),
-      Jsource(matrices_from_input_file["Jsource"], I1.index - I0.index + 1, K1.index - K0.index + 1,
-              "Jsource"),
-      Ksource(matrices_from_input_file["Ksource"], I1.index - I0.index + 1, J1.index - J0.index + 1,
-              "Ksource"),
+      IndependentObjectsFromInfile(matrices_from_input_file, _solver_method,
+                                   _pim),
+      // Source has no default constructor, and we need information from the
+      // Iterator_IndependentObjectsFromInfile first
+      Isource(matrices_from_input_file["Isource"], J1.index - J0.index + 1,
+              K1.index - K0.index + 1, "Isource"),
+      Jsource(matrices_from_input_file["Jsource"], I1.index - I0.index + 1,
+              K1.index - K0.index + 1, "Jsource"),
+      Ksource(matrices_from_input_file["Ksource"], I1.index - I0.index + 1,
+              J1.index - J0.index + 1, "Ksource"),
       // Get structure, we need I_tot from Iterator_IndependentObjectsFromInfile
       structure(matrices_from_input_file["structure"], IJK_tot.i),
       // Get f_ex_vec, the vector of frequencies to extract the field at.

--- a/tdms/src/simulation_manager/simulation_manager.cpp
+++ b/tdms/src/simulation_manager/simulation_manager.cpp
@@ -7,10 +7,10 @@
 using namespace std;
 using namespace tdms_math_constants;
 
-SimulationManager::SimulationManager(InputMatrices in_matrices, SolverMethod _solver_method,
+SimulationManager::SimulationManager(InputMatrices in_matrices,
+                                     SolverMethod _solver_method,
                                      PreferredInterpolationMethods _pim)
-    : inputs(in_matrices, _solver_method, _pim),
-    FDTD(n_Yee_cells()) {
+    : inputs(in_matrices, _solver_method, _pim), FDTD(n_Yee_cells()) {
   solver_method = _solver_method;
   pim = _pim;
 
@@ -36,34 +36,41 @@ SimulationManager::SimulationManager(InputMatrices in_matrices, SolverMethod _so
   prepare_output(in_matrices["fieldsample"], in_matrices["campssample"]);
 }
 
-void SimulationManager::extract_phasor_norms(int frequency_index, int tind, int Nt) {
+void SimulationManager::extract_phasor_norms(int frequency_index, int tind,
+                                             int Nt) {
   double omega = inputs.f_ex_vec[frequency_index] * 2 * DCPI;
   E_norm[frequency_index] +=
           outputs.E.ft *
-          exp(fmod(omega * ((double) (tind + 1)) * inputs.params.dt, 2 * DCPI) * IMAGINARY_UNIT) *
+          exp(fmod(omega * ((double) (tind + 1)) * inputs.params.dt, 2 * DCPI) *
+              IMAGINARY_UNIT) *
           1. / ((double) Nt);
   H_norm[frequency_index] +=
           outputs.H.ft *
-          exp(fmod(omega * ((double) tind + 0.5) * inputs.params.dt, 2 * DCPI) * IMAGINARY_UNIT) *
+          exp(fmod(omega * ((double) tind + 0.5) * inputs.params.dt, 2 * DCPI) *
+              IMAGINARY_UNIT) *
           1. / ((double) Nt);
 }
 
-void SimulationManager::prepare_output(const mxArray *fieldsample, const mxArray *campssample) {
+void SimulationManager::prepare_output(const mxArray *fieldsample,
+                                       const mxArray *campssample) {
   IJKDimensions IJK_tot = n_Yee_cells();
 
   outputs.set_n_Yee_cells(IJK_tot);
   /*set up surface mesh if required*/
-  outputs.setup_surface_mesh(inputs.cuboid, inputs.params, inputs.f_ex_vec.size());
-  /*Now set up the phasor array, we will have 3 complex output arrays for Ex, Ey and Ez.
-    Phasors are extracted over the range Dxl + 3 - 1 to I_tot - Dxu - 1 to avoid pml cells
-    see page III.80 for explanation of the following. This has been extended so that interpolation
-    is done at the end of the FDTD run and also to handle the case of when there is no PML in place
-    more appropriatley*/
+  outputs.setup_surface_mesh(inputs.cuboid, inputs.params,
+                             inputs.f_ex_vec.size());
+  /*Now set up the phasor array, we will have 3 complex output arrays for Ex, Ey
+    and Ez. Phasors are extracted over the range Dxl + 3 - 1 to I_tot - Dxu - 1
+    to avoid pml cells see page III.80 for explanation of the following. This
+    has been extended so that interpolation is done at the end of the FDTD run
+    and also to handle the case of when there is no PML in place more
+    appropriatley*/
   outputs.setup_EH_and_gridlabels(inputs.params, inputs.input_grid_labels, pim);
   // Setup the ID output
-  bool need_Id_memory =
-          (inputs.params.exdetintegral && inputs.params.run_mode == RunMode::complete);
-  outputs.setup_Id(!need_Id_memory, inputs.f_ex_vec.size(), inputs.D_tilde.num_det_modes());
+  bool need_Id_memory = (inputs.params.exdetintegral &&
+                         inputs.params.run_mode == RunMode::complete);
+  outputs.setup_Id(!need_Id_memory, inputs.f_ex_vec.size(),
+                   inputs.D_tilde.num_det_modes());
   // Link to the fieldsample and vertex_phasor inputs
   outputs.setup_fieldsample(fieldsample);
   outputs.setup_vertex_phasors(campssample, inputs.f_ex_vec.size());
@@ -71,17 +78,20 @@ void SimulationManager::prepare_output(const mxArray *fieldsample, const mxArray
 
 void SimulationManager::post_loop_processing() {
   // normalise the phasors in the volume, if we extracted there
-  if (inputs.params.run_mode == RunMode::complete && inputs.params.exphasorsvolume) {
+  if (inputs.params.run_mode == RunMode::complete &&
+      inputs.params.exphasorsvolume) {
     outputs.E.normalise_volume();
     outputs.H.normalise_volume();
   }
 
   // normalise the phasors on the surface, if we extracted there
-  if (inputs.params.run_mode == RunMode::complete && inputs.params.exphasorssurface) {
+  if (inputs.params.run_mode == RunMode::complete &&
+      inputs.params.exphasorssurface) {
     spdlog::info("Surface phasors");
     for (int ifx = 0; ifx < inputs.f_ex_vec.size(); ifx++) {
       outputs.surface_phasors.normalise_surface(ifx, E_norm[ifx], H_norm[ifx]);
-      spdlog::info("\tE_norm[{0:d}]: {1:.5e} {2:.5e}", ifx, real(E_norm[ifx]), imag(E_norm[ifx]));
+      spdlog::info("\tE_norm[{0:d}]: {1:.5e} {2:.5e}", ifx, real(E_norm[ifx]),
+                   imag(E_norm[ifx]));
     }
   }
   // normalise the phasors on the vertices, if we extracted at any
@@ -90,13 +100,16 @@ void SimulationManager::post_loop_processing() {
     spdlog::info("Vertex phasors");
     for (int ifx = 0; ifx < inputs.f_ex_vec.size(); ifx++) {
       outputs.vertex_phasors.normalise_vertices(ifx, E_norm[ifx], H_norm[ifx]);
-      spdlog::info("\tE_norm[{0:d}]: {1:.5e} {2:.5e}", ifx, real(E_norm[ifx]), imag(E_norm[ifx]));
+      spdlog::info("\tE_norm[{0:d}]: {1:.5e} {2:.5e}", ifx, real(E_norm[ifx]),
+                   imag(E_norm[ifx]));
     }
   }
 
-  // write the ID output using the phasor norms at each frequency, obtained from the main loop
+  // write the ID output using the phasor norms at each frequency, obtained from
+  // the main loop
   if (inputs.params.source_mode == SourceMode::pulsed &&
-      inputs.params.run_mode == RunMode::complete && inputs.params.exdetintegral) {
+      inputs.params.run_mode == RunMode::complete &&
+      inputs.params.exdetintegral) {
     for (int im = 0; im < inputs.D_tilde.num_det_modes(); im++)
       for (int ifx = 0; ifx < inputs.f_ex_vec.size(); ifx++) {
         outputs.ID.x[ifx][im] = outputs.ID.x[ifx][im] / E_norm[ifx];
@@ -111,7 +124,8 @@ void SimulationManager::post_loop_processing() {
   }
 
   // Write the maximum absolute value of residual field in the grid
-  double maxfield = max(inputs.E_s.largest_field_value(), inputs.H_s.largest_field_value());
+  double maxfield = max(inputs.E_s.largest_field_value(),
+                        inputs.H_s.largest_field_value());
   outputs.set_maxresfield(maxfield, false);
 
   // setup interpolated field outputs and labels (if necessary)
@@ -120,28 +134,33 @@ void SimulationManager::post_loop_processing() {
   /*Now export 3 matrices, a vertex list, a matrix of complex amplitudes at
     these vertices and a list of facets*/
 
-  // if we need to extract the phasors, we will need to allocate memory in the output
-  bool extracting_phasors =
-          (inputs.params.exphasorssurface && inputs.params.run_mode == RunMode::complete);
+  // if we need to extract the phasors, we will need to allocate memory in the
+  // output
+  bool extracting_phasors = (inputs.params.exphasorssurface &&
+                             inputs.params.run_mode == RunMode::complete);
   mxArray *mx_surface_facets = nullptr;
   if (extracting_phasors) {
-    //first regenerate the mesh since we threw away the facet list before iterating
+    // first regenerate the mesh since we threw away the facet list before
+    // iterating
     mxArray *dummy_vertex_list;
     if (n_Yee_cells().j == 0)
-      conciseCreateBoundary(inputs.cuboid[0], inputs.cuboid[1], inputs.cuboid[4], inputs.cuboid[5],
+      conciseCreateBoundary(inputs.cuboid[0], inputs.cuboid[1],
+                            inputs.cuboid[4], inputs.cuboid[5],
                             &dummy_vertex_list, &mx_surface_facets);
     else
-      conciseTriangulateCuboidSkip(inputs.cuboid[0], inputs.cuboid[1], inputs.cuboid[2],
-                                   inputs.cuboid[3], inputs.cuboid[4], inputs.cuboid[5],
-                                   inputs.params.spacing_stride, &dummy_vertex_list,
-                                   &mx_surface_facets);
+      conciseTriangulateCuboidSkip(inputs.cuboid[0], inputs.cuboid[1],
+                                   inputs.cuboid[2], inputs.cuboid[3],
+                                   inputs.cuboid[4], inputs.cuboid[5],
+                                   inputs.params.spacing_stride,
+                                   &dummy_vertex_list, &mx_surface_facets);
     mxDestroyArray(dummy_vertex_list);
 
-    //now create and populate the vertex list
+    // now create and populate the vertex list
     outputs.surface_phasors.create_vertex_list(inputs.input_grid_labels);
   }
   // assign to the output
   outputs.assign_surface_phasor_outputs(!extracting_phasors, mx_surface_facets);
-  // it is safe to reassign the mx_surface_facets pointer here, since outputs.surface_phasors now tracks the memory
+  // it is safe to reassign the mx_surface_facets pointer here, since
+  // outputs.surface_phasors now tracks the memory
   mx_surface_facets = nullptr;
 }

--- a/tdms/src/simulation_parameters.cpp
+++ b/tdms/src/simulation_parameters.cpp
@@ -45,7 +45,7 @@ void SimulationParameters::set_dimension(string mode_string) {
   }
 }
 
-void SimulationParameters::set_spacing_stride(const double* vector) {
+void SimulationParameters::set_spacing_stride(const double *vector) {
   spacing_stride.x = (int) vector[0];
   spacing_stride.y = (int) vector[1];
   spacing_stride.z = (int) vector[2];
@@ -56,15 +56,17 @@ void SimulationParameters::set_Np(FrequencyExtractVector &f_ex_vec) {
   double f_max = f_ex_vec.max();
   Np = (int) floor(1. / (2.5 * dt * f_max));
 
-  //calculate Npe, the temporal DFT will be evaluated whenever tind increments by Npe
-  for (unsigned int tind = start_tind; tind < Nt; tind++){
+  // calculate Npe, the temporal DFT will be evaluated whenever tind increments
+  // by Npe
+  for (unsigned int tind = start_tind; tind < Nt; tind++) {
     if ((tind - start_tind) % Np == 0) Npe++;
   }
-  spdlog::info("Np = {}, Nt = {}, Npe = {}, f_max = {}, Npraw = {}", Np, Nt, Npe, f_max,
-               2.5 * dt * f_max);
+  spdlog::info("Np = {}, Nt = {}, Npe = {}, f_max = {}, Npraw = {}", Np, Nt,
+               Npe, f_max, 2.5 * dt * f_max);
 }
 
-void SimulationParameters::unpack_from_input_matrices(InputMatrices in_matrices) {
+void SimulationParameters::unpack_from_input_matrices(
+        InputMatrices in_matrices) {
   // determine if we have a dispersive medium or multilayer
   CCollection C(in_matrices["C"]);
   is_disp_ml = C.is_disp_ml;
@@ -94,11 +96,14 @@ void SimulationParameters::unpack_from_input_matrices(InputMatrices in_matrices)
   set_run_mode(string_in(in_matrices["runmode"], "runmode"));
 
   // determine additional behaviour of this call to tdms
-  exphasorsvolume = bool_cast_from_double_in(in_matrices["exphasorsvolume"], "exphasorsvolume");
-  exphasorssurface = bool_cast_from_double_in(in_matrices["exphasorssurface"], "exphasorssurface");
-  intphasorssurface =
-          bool_cast_from_double_in(in_matrices["intphasorssurface"], "intphasorssurface");
-  interp_mat_props = bool_cast_from_double_in(in_matrices["intmatprops"], "intmatprops");
+  exphasorsvolume = bool_cast_from_double_in(in_matrices["exphasorsvolume"],
+                                             "exphasorsvolume");
+  exphasorssurface = bool_cast_from_double_in(in_matrices["exphasorssurface"],
+                                              "exphasorssurface");
+  intphasorssurface = bool_cast_from_double_in(in_matrices["intphasorssurface"],
+                                               "intphasorssurface");
+  interp_mat_props =
+          bool_cast_from_double_in(in_matrices["intmatprops"], "intmatprops");
 
   // set the stride and dimension of the simulation
   set_spacing_stride(mxGetPr(in_matrices["phasorinc"]));
@@ -106,7 +111,8 @@ void SimulationParameters::unpack_from_input_matrices(InputMatrices in_matrices)
 
   // get exdetintegral if it is present
   if (!mxIsEmpty(in_matrices["exdetintegral"])) {
-    exdetintegral = bool_cast_from_double_in(in_matrices["exdetintegral"], "exdetintegral");
+    exdetintegral = bool_cast_from_double_in(in_matrices["exdetintegral"],
+                                             "exdetintegral");
   }
 
   // get air interface
@@ -117,7 +123,8 @@ void SimulationParameters::unpack_from_input_matrices(InputMatrices in_matrices)
 
   // get intmethod
   if (!mxIsEmpty(in_matrices["intmethod"])) {
-    interp_method = InterpolationMethod(int_cast_from_double_in(in_matrices["intmethod"], "intmethod"));
+    interp_method = InterpolationMethod(
+            int_cast_from_double_in(in_matrices["intmethod"], "intmethod"));
   }
   spdlog::info("intmethod = " + to_string(interp_method));
 

--- a/tdms/src/source.cpp
+++ b/tdms/src/source.cpp
@@ -1,34 +1,35 @@
 #include "source.h"
 
-#include <stdexcept>
 #include <iostream>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 
-#include "matlabio.h"
 #include "dimensions.h"
+#include "matlabio.h"
 
 
 using namespace std;
 
-Source::Source(const mxArray *ptr, int dim1, int dim2, const std::string &name){
+Source::Source(const mxArray *ptr, int dim1, int dim2,
+               const std::string &name) {
 
   if (mxIsEmpty(ptr)) {
     spdlog::info("{} is empty", name);
   } else {
     auto dims = Dimensions(ptr);
 
-    if (dims.are_1d()){
-      throw runtime_error(name+" should be 3- or 2-dimensional");
+    if (dims.are_1d()) {
+      throw runtime_error(name + " should be 3- or 2-dimensional");
     }
-    if (dims.are_2d()){
-      dim2 = 0;
-    }
-    if (!(dims[0] == 8 && dims[1] == dim1 && dims[2] == dim2)){
+    if (dims.are_2d()) { dim2 = 0; }
+    if (!(dims[0] == 8 && dims[1] == dim1 && dims[2] == dim2)) {
       cerr << name << " has incorrect size" << endl;
     }
-    if (!mxIsComplex(ptr)){
-      throw runtime_error(name+" should be complex, use a call of "
-                          "complex(real(Isource),imag(Isource)) in matlab if necessary");
+    if (!mxIsComplex(ptr)) {
+      throw runtime_error(
+              name +
+              " should be complex, use a call of "
+              "complex(real(Isource),imag(Isource)) in matlab if necessary");
     }
     real = cast_matlab_3D_array(mxGetPr(ptr), dims[0], dims[1], dims[2]);
     imag = cast_matlab_3D_array(mxGetPi(ptr), dims[0], dims[1], dims[2]);

--- a/tdms/src/timer.cpp
+++ b/tdms/src/timer.cpp
@@ -5,19 +5,13 @@
 #include <omp.h>
 #include <spdlog/spdlog.h>
 
-void Timer::start() {
-  start_time = omp_get_wtime();
-}
+void Timer::start() { start_time = omp_get_wtime(); }
 
-void Timer::end() {
-  end_time = omp_get_wtime();
-}
+void Timer::end() { end_time = omp_get_wtime(); }
 
-double Timer::delta_seconds() const {
-  return end_time - start_time ;
-}
+double Timer::delta_seconds() const { return end_time - start_time; }
 
-void Timer::click(){
+void Timer::click() {
   end();
   spdlog::info("Time ellapsed (s): %.03e", delta_seconds());
   start();

--- a/tdms/src/utils.cpp
+++ b/tdms/src/utils.cpp
@@ -1,31 +1,25 @@
 #include "utils.h"
 
 #include <cstdio>
-#include <string>
 #include <cstring>
 #include <stdexcept>
+#include <string>
 
 using namespace std;
 
-void assert_can_open_file(const char* filename, const char* mode){
+void assert_can_open_file(const char *filename, const char *mode) {
 
   auto file = fopen(filename, mode);
 
-  if(file == nullptr){
+  if (file == nullptr) {
     throw runtime_error("Unable to open file " + string(filename));
   }
 
   fclose(file);
 }
 
-bool are_equal(const char* a, const char* b){
-  return strcmp(a, b) == 0;
-}
+bool are_equal(const char *a, const char *b) { return strcmp(a, b) == 0; }
 
-string to_string(char c){
-  return {1, c};
-}
+string to_string(char c) { return {1, c}; }
 
-int max(int a, int b, int c) {
-  return std::max(std::max(a, b), c);
-}
+int max(int a, int b, int c) { return std::max(std::max(a, b), c); }

--- a/tdms/src/vertex_phasors.cpp
+++ b/tdms/src/vertex_phasors.cpp
@@ -13,27 +13,34 @@ void VertexPhasors::set_from(const mxArray *ptr) {
     spdlog::info("VertexPhasors: struct provided is empty");
     return;
   }
-  assert_is_struct_with_n_fields(ptr, 2, "VertexPhasors (using campssample array)");
+  assert_is_struct_with_n_fields(ptr, 2,
+                                 "VertexPhasors (using campssample array)");
   vertices.initialise(ptr);
   components.initialise(ptr);
 }
 
-void VertexPhasors::normalise_vertices(int frequency_index, complex<double> Enorm,
+void VertexPhasors::normalise_vertices(int frequency_index,
+                                       complex<double> Enorm,
                                        complex<double> Hnorm) {
-  for(int i = FieldComponents::Ex; i <= FieldComponents::Hz; i++) {
-    // determine whether we are extracting this field component at the vertices or not
+  for (int i = FieldComponents::Ex; i <= FieldComponents::Hz; i++) {
+    // determine whether we are extracting this field component at the vertices
+    // or not
     int index_in_camplitudes = components.index(i);
     if (index_in_camplitudes >= 0) {
       // we are extracting this component, determine the normalisation factor
       complex<double> norm = i <= FieldComponents::Ez ? Enorm : Hnorm;
       // loop over all entries and normalise
-      for(int vindex = 0; vindex < n_vertices(); vindex++) {
+      for (int vindex = 0; vindex < n_vertices(); vindex++) {
         complex<double> normalised_amplitude =
-                complex<double>(camplitudesR[frequency_index][index_in_camplitudes][vindex],
-                                camplitudesI[frequency_index][index_in_camplitudes][vindex]) /
+                complex<double>(camplitudesR[frequency_index]
+                                            [index_in_camplitudes][vindex],
+                                camplitudesI[frequency_index]
+                                            [index_in_camplitudes][vindex]) /
                 norm;
-        camplitudesR[frequency_index][index_in_camplitudes][vindex] = normalised_amplitude.real();
-        camplitudesI[frequency_index][index_in_camplitudes][vindex] = normalised_amplitude.imag();
+        camplitudesR[frequency_index][index_in_camplitudes][vindex] =
+                normalised_amplitude.real();
+        camplitudesI[frequency_index][index_in_camplitudes][vindex] =
+                normalised_amplitude.imag();
       }
     }
   }
@@ -49,14 +56,19 @@ void VertexPhasors::setup_complex_amplitude_arrays(int n_frequencies) {
     dims[0] = n_vertices();
     dims[1] = components.size();
     dims[2] = f_ex_vector_size;
-    mx_camplitudes = mxCreateNumericArray(3, (const mwSize *) dims, mxDOUBLE_CLASS, mxCOMPLEX);
-    camplitudesR = cast_matlab_3D_array(mxGetPr(mx_camplitudes), dims[0], dims[1], dims[2]);
-    camplitudesI = cast_matlab_3D_array(mxGetPi(mx_camplitudes), dims[0], dims[1], dims[2]);
+    mx_camplitudes = mxCreateNumericArray(3, (const mwSize *) dims,
+                                          mxDOUBLE_CLASS, mxCOMPLEX);
+    camplitudesR = cast_matlab_3D_array(mxGetPr(mx_camplitudes), dims[0],
+                                        dims[1], dims[2]);
+    camplitudesI = cast_matlab_3D_array(mxGetPi(mx_camplitudes), dims[0],
+                                        dims[1], dims[2]);
   }
 }
 
-void VertexPhasors::extractPhasorsVertices(int frequency_index, ElectricSplitField &E,
-                                           MagneticSplitField &H, int n, double omega,
+void VertexPhasors::extractPhasorsVertices(int frequency_index,
+                                           ElectricSplitField &E,
+                                           MagneticSplitField &H, int n,
+                                           double omega,
                                            SimulationParameters &params) {
   int vindex;
   FullFieldSnapshot F;
@@ -70,16 +82,17 @@ void VertexPhasors::extractPhasorsVertices(int frequency_index, ElectricSplitFie
 
   /* Loop over every vertex requested by the user.
 
-  Since the value of the phasors at each vertex is entirely determined from the previously calculated fields,
-  these computations can be done in parallel as the computation of the phasors is independent of one another.
-  Ergo, we use a parallel loop.
+  Since the value of the phasors at each vertex is entirely determined from the
+  previously calculated fields, these computations can be done in parallel as
+  the computation of the phasors is independent of one another. Ergo, we use a
+  parallel loop.
   */
-#pragma omp parallel default(shared) \
-        private(F, vindex)
+#pragma omp parallel default(shared) private(F, vindex)
   {
 #pragma omp for
     for (vindex = 0; vindex < n_vertices(); vindex++) {// loop over every vertex
-      CellCoordinate current_cell {vertices[0][vindex], vertices[1][vindex], vertices[2][vindex]};
+      CellCoordinate current_cell{vertices[0][vindex], vertices[1][vindex],
+                                  vertices[2][vindex]};
 
       switch (params.dimension) {
         case Dimension::THREE:
@@ -111,27 +124,33 @@ void VertexPhasors::extractPhasorsVertices(int frequency_index, ElectricSplitFie
       // update the master arrays
       update_vertex_camplitudes(frequency_index, vindex, F);
     }
-  }//end parallel region
+  }// end parallel region
 }
 
-void VertexPhasors::update_vertex_camplitudes(int frequency_index, int vertex_index, FullFieldSnapshot F) {
-  for(int component_id = FieldComponents::Ex; component_id <= FieldComponents::Hz; component_id++) {
-      int idx = components.index(component_id);
-      // MATLAB indexes Ex->Hz with 1->6 (FieldComponents enum) whilst C++ indexes Ex->Hz with 0->5 (FullFieldSnapshot)
-      // this is not an ideal fix, but it is the simplist so long as we remember the correspondence above
-      int cpp_component_index = component_id - 1;
-      if (idx >= 0) {
-          // this component has been requested for extraction
-          camplitudesR[frequency_index][idx][vertex_index] += real(F[cpp_component_index]);
-          camplitudesI[frequency_index][idx][vertex_index] += imag(F[cpp_component_index]);
-      }
+void VertexPhasors::update_vertex_camplitudes(int frequency_index,
+                                              int vertex_index,
+                                              FullFieldSnapshot F) {
+  for (int component_id = FieldComponents::Ex;
+       component_id <= FieldComponents::Hz; component_id++) {
+    int idx = components.index(component_id);
+    // MATLAB indexes Ex->Hz with 1->6 (FieldComponents enum) whilst C++ indexes
+    // Ex->Hz with 0->5 (FullFieldSnapshot) this is not an ideal fix, but it is
+    // the simplist so long as we remember the correspondence above
+    int cpp_component_index = component_id - 1;
+    if (idx >= 0) {
+      // this component has been requested for extraction
+      camplitudesR[frequency_index][idx][vertex_index] +=
+              real(F[cpp_component_index]);
+      camplitudesI[frequency_index][idx][vertex_index] +=
+              imag(F[cpp_component_index]);
+    }
   }
 }
 
 VertexPhasors::~VertexPhasors() {
-    // cleanup storage arrays if they were created
-    if (there_are_vertices_to_extract_at()) {
-        free_cast_matlab_3D_array(camplitudesR, f_ex_vector_size);
-        free_cast_matlab_3D_array(camplitudesI, f_ex_vector_size);
-    }
+  // cleanup storage arrays if they were created
+  if (there_are_vertices_to_extract_at()) {
+    free_cast_matlab_3D_array(camplitudesR, f_ex_vector_size);
+    free_cast_matlab_3D_array(camplitudesI, f_ex_vector_size);
+  }
 }

--- a/tdms/tests/include/abstract_array_test_class.h
+++ b/tdms/tests/include/abstract_array_test_class.h
@@ -11,23 +11,29 @@
 #include "arrays.h"
 
 /**
- * @brief Abstract container for the tests that classes in arrays.h will have to pass.
+ * @brief Abstract container for the tests that classes in arrays.h will have to
+ * pass.
  *
- * Private methods are empty, and designed to be overridden in the derived class. However this also means that definitions for these tests can be left out of those subclasses, whilst not changing the run_all_tests() function.
+ * Private methods are empty, and designed to be overridden in the derived
+ * class. However this also means that definitions for these tests can be left
+ * out of those subclasses, whilst not changing the run_all_tests() function.
  *
  */
 class AbstractArrayTest {
 protected:
-  int empty_dimensions[2] = {0, 1};   //< For initialising empty arrays
-  int I_tot = 4, J_tot = 8, K_tot = 4;//< For mimicing simulation grid dimensions
-  int n_numeric_elements =
-          8;//< For standardising the number of elements we initialise MATLAB vectors with
-  int dimensions_2d[2] = {1, 1};               //< For defining 2D MATLAB arrays
+  int empty_dimensions[2] = {0, 1};//< For initialising empty arrays
+  int I_tot = 4, J_tot = 8,
+      K_tot = 4;                //< For mimicing simulation grid dimensions
+  int n_numeric_elements = 8;   //< For standardising the number of elements we
+                                // initialise MATLAB vectors with
+  int dimensions_2d[2] = {1, 1};//< For defining 2D MATLAB arrays
   int dimensions_3d[3] = {I_tot, J_tot, K_tot};//< For defining 3D MATLAB arrays
 
-  // To point to the (top-level) matlab inputs the classes require. Top-level structure ensures mxDestroyArray clears all sub-arrays too
+  // To point to the (top-level) matlab inputs the classes require. Top-level
+  // structure ensures mxDestroyArray clears all sub-arrays too
   mxArray *matlab_input = nullptr;
-  // Flags if we have created an mxArray manually, so we are forced to destroy to free memory when done
+  // Flags if we have created an mxArray manually, so we are forced to destroy
+  // to free memory when done
   bool matlab_input_assigned = false;
 
   /**
@@ -48,11 +54,13 @@ protected:
   /**
    * @brief Creates a MATLAB structure array
    *
-   * @param n_rows,n_cols Dimensions of the array. This is the number of identical structs in the array, not the size of a particular field
+   * @param n_rows,n_cols Dimensions of the array. This is the number of
+   * identical structs in the array, not the size of a particular field
    * @param n_fields Number of fields
    * @param fields Names of the fields
    */
-  void create_struct_array(int n_rows, int n_cols, int n_fields, const char *fields[]) {
+  void create_struct_array(int n_rows, int n_cols, int n_fields,
+                           const char *fields[]) {
     matlab_input = mxCreateStructMatrix(n_rows, n_cols, n_fields, fields);
     matlab_input_assigned = true;
   }
@@ -60,12 +68,15 @@ protected:
    * @brief Creates a MATLAB structure array
    *
    * @param n_dimensions Number of dimensions of the array.
-   * @param dimensions Array or vector, containing the number of elements in each axis of the array
+   * @param dimensions Array or vector, containing the number of elements in
+   * each axis of the array
    * @param n_fields Number of fields
    * @param fields Names of the fields
    */
-  void create_struct_array(int n_dimensions, int *dimensions, int n_fields, const char *fields[]) {
-    matlab_input = mxCreateStructArray(n_dimensions, (const mwSize *) dimensions, n_fields, fields);
+  void create_struct_array(int n_dimensions, int *dimensions, int n_fields,
+                           const char *fields[]) {
+    matlab_input = mxCreateStructArray(
+            n_dimensions, (const mwSize *) dimensions, n_fields, fields);
     matlab_input_assigned = true;
   }
   /**
@@ -80,54 +91,64 @@ protected:
   /**
    * @brief Creates the MATLAB empty struct (no fields, 0 size)
    */
-  void create_empty_struct() {
-    create_struct_array(0, 1, 0, {});
-  }
+  void create_empty_struct() { create_struct_array(0, 1, 0, {}); }
   /**
    * @brief Creates a MATLAB numeric array
    *
    * @param n_dims Number of dimensions in the array
-   * @param dimensions Array/vector containing the number of elements in each dimension, sequentially
+   * @param dimensions Array/vector containing the number of elements in each
+   * dimension, sequentially
    * @param data_type The MATLAB data type to populate the array with
    * @param complex_flag Whether the data is real or complex
    */
-  void create_numeric_array(int n_dims, int *dimensions, mxClassID data_type = mxDOUBLE_CLASS,
+  void create_numeric_array(int n_dims, int *dimensions,
+                            mxClassID data_type = mxDOUBLE_CLASS,
                             mxComplexity complex_flag = mxREAL) {
-    matlab_input =
-            mxCreateNumericArray(n_dims, (const mwSize *) dimensions, data_type, complex_flag);
+    matlab_input = mxCreateNumericArray(n_dims, (const mwSize *) dimensions,
+                                        data_type, complex_flag);
     matlab_input_assigned = true;
   }
 
   /* Test functions to be overriden by each class.
-  These methods are designed to be overriden by the subclasses specific to each arrays.h class.
+  These methods are designed to be overriden by the subclasses specific to each
+  arrays.h class.
 
-  The default behaviour of each test_ method is to set ran_a_test to false - this means that subclasses that skip over certain functionality (EG do not need to test the result of providing an empty MATLAB input) are skipped in when run_all_class_tests() is run, and do not bloat the log.
-  If overriden, a test_ method should not alter ran_a_test
+  The default behaviour of each test_ method is to set ran_a_test to false -
+  this means that subclasses that skip over certain functionality (EG do not
+  need to test the result of providing an empty MATLAB input) are skipped in
+  when run_all_class_tests() is run, and do not bloat the log. If overriden, a
+  test_ method should not alter ran_a_test
   */
 
   bool ran_a_test = true;
   /**
-  * @brief Tests the behaviour of construction when passed an empty MATLAB array
-  */
+   * @brief Tests the behaviour of construction when passed an empty MATLAB
+   * array
+   */
   virtual void test_empty_construction() { ran_a_test = false; }
   /**
-   * @brief Tests the behaviour of construction when passed an array of the incorrect dimensions
+   * @brief Tests the behaviour of construction when passed an array of the
+   * incorrect dimensions
    */
   virtual void test_wrong_input_dimensions() { ran_a_test = false; }
   /**
-   * @brief Tests the behaviour of construction when passed an array of the incorrect type
+   * @brief Tests the behaviour of construction when passed an array of the
+   * incorrect type
    */
   virtual void test_wrong_input_type() { ran_a_test = false; }
   /**
-   * @brief Tests the behaviour of construction when passed a struct with the wrong number of fields
+   * @brief Tests the behaviour of construction when passed a struct with the
+   * wrong number of fields
    */
   virtual void test_incorrect_number_of_fields() { ran_a_test = false; }
   /**
-   * @brief Tests the behaviour of construction methods when passed a struct with an incorrect fieldname
+   * @brief Tests the behaviour of construction methods when passed a struct
+   * with an incorrect fieldname
    */
   virtual void test_incorrect_fieldname() { ran_a_test = false; }
   /**
-   * @brief Tests the behaviour of construction methods when passing the expected inputs
+   * @brief Tests the behaviour of construction methods when passing the
+   * expected inputs
    */
   virtual void test_correct_construction() { ran_a_test = false; }
   /**

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -18,31 +18,32 @@
  * public:
  *   std::string get_class_name() override { return "SETME"; }
  * };
-*/
+ */
 #pragma once
 
 #include "abstract_array_test_class.h"
 
 class CCollectionTest : public AbstractArrayTest {
-  private:
-    const char *fieldnames[9] = { "Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz" };
+private:
+  const char *fieldnames[9] = {"Cax", "Cay", "Caz", "Cbx", "Cby",
+                               "Cbz", "Ccx", "Ccy", "Ccz"};
 
-    void test_incorrect_number_of_fields() override;
-    void test_correct_construction() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
 
-  public:
-    std::string get_class_name() override {return "CCollection";}
+public:
+  std::string get_class_name() override { return "CCollection"; }
 };
 
 class DCollectionTest : public AbstractArrayTest {
-  private:
-    const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
+private:
+  const char *fieldnames[6] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz"};
 
-    void test_incorrect_number_of_fields() override;
-    void test_correct_construction() override;
+  void test_incorrect_number_of_fields() override;
+  void test_correct_construction() override;
 
-  public:
-    std::string get_class_name() override { return "DCollection"; }
+public:
+  std::string get_class_name() override { return "DCollection"; }
 };
 
 class DetectorSensitivityArraysTest : public AbstractArrayTest {
@@ -53,14 +54,15 @@ private:
   void test_initialise_method() override;
 
 public:
-  std::string get_class_name() override { return "DetectorSensitivityArray";}
+  std::string get_class_name() override { return "DetectorSensitivityArray"; }
 };
 
 class DispersiveMultilayerTest : public AbstractArrayTest {
 private:
   const int n_fields = 9;
-  const char *fieldnames[9] = {"alpha",   "beta",    "gamma",   "kappa_x", "kappa_y",
-                               "kappa_z", "sigma_x", "sigma_y", "sigma_z"};
+  const char *fieldnames[9] = {"alpha",   "beta",    "gamma",
+                               "kappa_x", "kappa_y", "kappa_z",
+                               "sigma_x", "sigma_y", "sigma_z"};
 
   void test_empty_construction() override;
   void test_wrong_input_type() override;
@@ -72,11 +74,12 @@ public:
   std::string get_class_name() override { return "DispersiveMultilayer"; }
 };
 
-// Test methods check the performance of initialise, as this is the de-facto constructor
+// Test methods check the performance of initialise, as this is the de-facto
+// constructor
 class DTildeTest : public AbstractArrayTest {
 private:
   const int n_fields = 2;
-  const char *fieldnames[2] = { "Dx_tilde", "Dy_tilde" };
+  const char *fieldnames[2] = {"Dx_tilde", "Dy_tilde"};
 
   void test_empty_construction() override;
   void test_wrong_input_type() override;
@@ -102,7 +105,8 @@ public:
   std::string get_class_name() override { return "FieldSample"; }
 };
 
-// Test methods check the performance of initialise, as this is the de-facto constructor
+// Test methods check the performance of initialise, as this is the de-facto
+// constructor
 class FrequencyVectorsTest : public AbstractArrayTest {
 private:
   const int n_fields = 2;
@@ -123,7 +127,8 @@ private:
   // multiply_{E,H}_by()
   void test_other_methods() override;
 
-  public : std::string get_class_name() override { return "FullFieldSnapshot"; }
+public:
+  std::string get_class_name() override { return "FullFieldSnapshot"; }
 };
 
 class IncidentFieldTest : public AbstractArrayTest {
@@ -144,8 +149,10 @@ public:
 class CMaterialTest : public AbstractArrayTest {
 private:
   const int n_fields = 9;
-  const char *fieldnames[9] = {"Cax", "Cay", "Caz", "Cbx", "Cby", "Cbz", "Ccx", "Ccy", "Ccz"};
-  const char *wrong_fieldnames[9] = {"Dax", "Cay", "Daz", "Cbx", "Dby", "Cbz", "Ccx", "Ccy", "Ccz"};
+  const char *fieldnames[9] = {"Cax", "Cay", "Caz", "Cbx", "Cby",
+                               "Cbz", "Ccx", "Ccy", "Ccz"};
+  const char *wrong_fieldnames[9] = {"Dax", "Cay", "Daz", "Cbx", "Dby",
+                                     "Cbz", "Ccx", "Ccy", "Ccz"};
 
   void test_incorrect_number_of_fields() override;
   void test_incorrect_fieldname() override;

--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -15,17 +15,19 @@ using tdms_math_constants::DCPI;
 
 namespace tdms_tests {
 
-  inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
+inline double TOLERANCE = 1e-16;//< Floating-point comparison tolerance
 
-  /**
-  * @brief Determines whether a value is close to zero
-  *
-  * @param x Value to test
-  * @param tol Tolerance for being "close" to zero
-  */
-  inline bool near_zero(const double &x, double tol=TOLERANCE) { return std::abs(x) < tol; }
+/**
+ * @brief Determines whether a value is close to zero
+ *
+ * @param x Value to test
+ * @param tol Tolerance for being "close" to zero
+ */
+inline bool near_zero(const double &x, double tol = TOLERANCE) {
+  return std::abs(x) < tol;
+}
 
-  /**
+/**
  * @brief Determines if two numerical values are close by relative comparison.
  *
  * Checks the truth value of the condition
@@ -36,23 +38,26 @@ namespace tdms_tests {
  * @param tol Relative comparison tolerance
  * @param close_to_zero_tol Cutoff value for the "close to zero" criterion
  */
-  template<typename T>
-  inline bool is_close(T a, T b, double tol = 1E-10, double close_to_zero_tol = 1E-30) {
+template<typename T>
+inline bool is_close(T a, T b, double tol = 1E-10,
+                     double close_to_zero_tol = 1E-30) {
 
-    auto max_norm = std::max(std::abs(a), std::abs(b));
+  auto max_norm = std::max(std::abs(a), std::abs(b));
 
-    if (near_zero(max_norm, close_to_zero_tol)) {// Prevent dividing by zero
-      return true;
-    }
-
-    return std::abs(a - b) / max_norm < tol;
+  if (near_zero(max_norm, close_to_zero_tol)) {// Prevent dividing by zero
+    return true;
   }
 
-  /**
- * @brief Determines whether an error value is better than a benchmark, or sufficiently close to be insignificant.
+  return std::abs(a - b) / max_norm < tol;
+}
+
+/**
+ * @brief Determines whether an error value is better than a benchmark, or
+ * sufficiently close to be insignificant.
  *
- * If the error to check is superior (IE, closer to zero in absolute value) than the benchmark, return true.
- * Otherwise, use relative comparison to determine if the errors are sufficiently similar.
+ * If the error to check is superior (IE, closer to zero in absolute value) than
+ * the benchmark, return true. Otherwise, use relative comparison to determine
+ * if the errors are sufficiently similar.
  *
  * @param to_check Numerical error to evaluate suitability of
  * @param to_beat Benchmark error
@@ -61,67 +66,69 @@ namespace tdms_tests {
  * @return true to_check is a superior or equivalent error to to_beat
  * @return false to_check is an inferior error
  */
-  template<typename T>
-  inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
-                                 double close_to_zero_tol = 1E-30) {
-    if (std::abs(to_check) < std::abs(to_beat)) {
-      // return true if the value to_check is better (closer to 0) than to_beat
-      return true;
-    } else {
-      // determine if the numerical values are close by relative comparison
-      return is_close(to_check, to_beat, tol, close_to_zero_tol);
-    }
+template<typename T>
+inline bool is_close_or_better(T to_check, T to_beat, double tol = 1E-10,
+                               double close_to_zero_tol = 1E-30) {
+  if (std::abs(to_check) < std::abs(to_beat)) {
+    // return true if the value to_check is better (closer to 0) than to_beat
+    return true;
+  } else {
+    // determine if the numerical values are close by relative comparison
+    return is_close(to_check, to_beat, tol, close_to_zero_tol);
   }
+}
 
-  /**
+/**
  * @brief Compute the relative mean square difference of two arrays
  *
  * @param x,y Arrays to read from
  * @param n_elements Number of elements in the arrays
- * @param x_start,y_start Index to start reading the buffer from the x, y array respectively (default 0)
+ * @param x_start,y_start Index to start reading the buffer from the x, y array
+ * respectively (default 0)
  * @param close_to_zero_tol Tolerance for MSDs being zero (to avoid /0 errors)
  * @return double The relative mean square difference of x and y
  */
-  inline double relative_mean_square_difference(double *x, double *y, int n_elements,
-                                                int x_start = 0, int y_start = 0,
-                                                double close_to_zero_tol = TOLERANCE) {
-    double mean_sq_x = 0., mean_sq_y = 0., mean_sq_diff = 0.;
-    for (int i = 0; i < n_elements; i++) {
-      mean_sq_x += x[i + x_start] * x[i + x_start];
-      mean_sq_y += y[i + y_start] * y[i + y_start];
-      mean_sq_diff += (x[i + x_start] - y[i + y_start]) * (x[i + x_start] - y[i + y_start]);
-    }
-    mean_sq_x = mean_sq_x / (double) n_elements;
-    mean_sq_y = mean_sq_y / (double) n_elements;
-    if (mean_sq_x < close_to_zero_tol && mean_sq_y < close_to_zero_tol) {
-      return 0.;
-    } else {
-      mean_sq_diff = mean_sq_diff / (((double) n_elements) * std::max(mean_sq_x, mean_sq_y));
-      return mean_sq_diff;
-    }
+inline double
+relative_mean_square_difference(double *x, double *y, int n_elements,
+                                int x_start = 0, int y_start = 0,
+                                double close_to_zero_tol = TOLERANCE) {
+  double mean_sq_x = 0., mean_sq_y = 0., mean_sq_diff = 0.;
+  for (int i = 0; i < n_elements; i++) {
+    mean_sq_x += x[i + x_start] * x[i + x_start];
+    mean_sq_y += y[i + y_start] * y[i + y_start];
+    mean_sq_diff += (x[i + x_start] - y[i + y_start]) *
+                    (x[i + x_start] - y[i + y_start]);
   }
-
-  /**
-* @brief Computes the Euclidean norm of the vector provided
-*
-* @param v Vector or array
-* @param end (Inclusive) end of buffer to read vector from
-* @param start (Inclusive) start of buffer to read vector from
-* @return double Euclidean norm
-*/
-  template<typename T>
-  inline double euclidean(T *v, int end, int start = 0) {
-    double norm_val = 0.;
-    for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
-    return std::sqrt(norm_val);
+  mean_sq_x = mean_sq_x / (double) n_elements;
+  mean_sq_y = mean_sq_y / (double) n_elements;
+  if (mean_sq_x < close_to_zero_tol && mean_sq_y < close_to_zero_tol) {
+    return 0.;
+  } else {
+    mean_sq_diff = mean_sq_diff /
+                   (((double) n_elements) * std::max(mean_sq_x, mean_sq_y));
+    return mean_sq_diff;
   }
+}
 
-  // returns the order of magnitude of the value x
-  inline int order_of_magnitude(double x) {
-    return floor(log10(x));
-  }
+/**
+ * @brief Computes the Euclidean norm of the vector provided
+ *
+ * @param v Vector or array
+ * @param end (Inclusive) end of buffer to read vector from
+ * @param start (Inclusive) start of buffer to read vector from
+ * @return double Euclidean norm
+ */
+template<typename T>
+inline double euclidean(T *v, int end, int start = 0) {
+  double norm_val = 0.;
+  for (int i = start; i < end; i++) { norm_val += std::norm(v[i]); }
+  return std::sqrt(norm_val);
+}
 
-  /**
+// returns the order of magnitude of the value x
+inline int order_of_magnitude(double x) { return floor(log10(x)); }
+
+/**
  * @brief Create a temporary directory for writing files.
  *
  * Creates a subdirectory (with randomised name) in the system tmp.  This can be
@@ -132,19 +139,20 @@ namespace tdms_tests {
  *
  * @return std::filesystem::path Path to the temporary directory.
  */
-  inline std::filesystem::path create_tmp_dir() {
-    // random number setup
-    std::random_device device_seed;
-    std::mt19937 random_number_generator(device_seed());
+inline std::filesystem::path create_tmp_dir() {
+  // random number setup
+  std::random_device device_seed;
+  std::mt19937 random_number_generator(device_seed());
 
-    // get system tmp directory (OS-dependent), add a uniquely named subdirectory
-    auto tmp = std::filesystem::temp_directory_path();
-    std::string subdir = "tdms_unit_tests_" + std::to_string(random_number_generator());
-    auto path = tmp / subdir;
+  // get system tmp directory (OS-dependent), add a uniquely named subdirectory
+  auto tmp = std::filesystem::temp_directory_path();
+  std::string subdir =
+          "tdms_unit_tests_" + std::to_string(random_number_generator());
+  auto path = tmp / subdir;
 
-    // mkdir and return the path to the directory we've just created
-    std::filesystem::create_directory(path);
-    return path;
-  }
+  // mkdir and return the path to the directory we've just created
+  std::filesystem::create_directory(path);
+  return path;
+}
 
 }// namespace tdms_tests

--- a/tdms/tests/matlab/.clang-format
+++ b/tdms/tests/matlab/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/tdms/tests/unit/array_tests/test_CollectionBase.cpp
+++ b/tdms/tests/unit/array_tests/test_CollectionBase.cpp
@@ -1,7 +1,8 @@
 /**
  * @file test_CollectionBase.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Unit tests for CollectionBase class and its subclasses (CCollection, DCollection)
+ * @brief Unit tests for CollectionBase class and its subclasses (CCollection,
+ * DCollection)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
@@ -19,7 +20,8 @@ void CCollectionTest::test_correct_construction() {
     create_1by1_struct(6, fieldnames);
     mxArray *field_arrays[6];
     for (int i = 0; i < 6; i++) {
-      field_arrays[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+      field_arrays[i] = mxCreateNumericMatrix(1, n_numeric_elements,
+                                              mxDOUBLE_CLASS, mxREAL);
       mxSetField(matlab_input, 0, fieldnames[i], field_arrays[i]);
     }
     CCollection cc6(matlab_input);
@@ -30,7 +32,8 @@ void CCollectionTest::test_correct_construction() {
     create_1by1_struct(9, fieldnames);
     mxArray *field_arrays[9];
     for (int i = 0; i < 9; i++) {
-      field_arrays[i] = mxCreateNumericMatrix(2, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+      field_arrays[i] = mxCreateNumericMatrix(2, n_numeric_elements,
+                                              mxDOUBLE_CLASS, mxREAL);
       mxSetField(matlab_input, 0, fieldnames[i], field_arrays[i]);
     }
     CCollection cc9(matlab_input);
@@ -48,7 +51,8 @@ void DCollectionTest::test_correct_construction() {
   create_1by1_struct(6, fieldnames);
   mxArray *elements6[6];
   for (int i = 0; i < 6; i++) {
-    elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    elements6[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS,
+                                         mxREAL);
     mxSetField(matlab_input, 0, fieldnames[i], elements6[i]);
   }
   REQUIRE_NOTHROW(DCollection(matlab_input));

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -6,16 +6,17 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 
 using namespace std;
 
 void DTildeTest::test_correct_construction() {
-  // check no information is contained in the DTilde object when declared with default constructor
+  // check no information is contained in the DTilde object when declared with
+  // default constructor
   DTilde dt;
-  bool no_information_stored =
-          (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
+  bool no_information_stored = (dt.num_det_modes() == 0) &&
+                               (!dt.x.has_elements()) && (!dt.y.has_elements());
   REQUIRE(no_information_stored);
 }
 
@@ -27,14 +28,15 @@ void DTildeTest::test_empty_construction() {
   // attempt assignment (2nd and 3rd args don't matter)
   dt.initialise(matlab_input, 0, 0);
   // should still be unassigned vectors
-  no_information_stored =
-          (dt.num_det_modes() == 0) && (!dt.x.has_elements()) && (!dt.y.has_elements());
+  no_information_stored = (dt.num_det_modes() == 0) && (!dt.x.has_elements()) &&
+                          (!dt.y.has_elements());
   REQUIRE(no_information_stored);
 }
 
 void DTildeTest::test_wrong_input_type() {
   DTilde dt;
-  // initialise() will throw error if we attempt to provide a non-empty, non-struct array
+  // initialise() will throw error if we attempt to provide a non-empty,
+  // non-struct array
   dimensions_2d[0] = 2;
   dimensions_2d[1] = 3;
   create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
@@ -43,7 +45,8 @@ void DTildeTest::test_wrong_input_type() {
 
 void DTildeTest::test_incorrect_number_of_fields() {
   DTilde dt;
-  // assignment will throw error if we attempt to provide a struct array that doesn't have two fields
+  // assignment will throw error if we attempt to provide a struct array that
+  // doesn't have two fields
   SECTION("Struct with too many fields") {
     const char *too_mny_names[3] = {"field1", "field2", "field3"};
     create_struct_array(2, dimensions_2d, 3, too_mny_names);
@@ -58,8 +61,9 @@ void DTildeTest::test_incorrect_number_of_fields() {
 
 void DTildeTest::test_initialise_method() {
   DTilde dt;
-  // otherwise, we need to provide a struct with two fields, Dx_tilde and Dy_tilde
-  // these fields must contain (n_det_modes, n_rows, n_cols) arrays of doubles/complex
+  // otherwise, we need to provide a struct with two fields, Dx_tilde and
+  // Dy_tilde these fields must contain (n_det_modes, n_rows, n_cols) arrays of
+  // doubles/complex
   const int target_n_det_modes = 5, n_rows = 6, n_cols = 4;
   const int field_array_dimensions[3] = {target_n_det_modes, n_rows, n_cols};
   // create the struct
@@ -67,18 +71,17 @@ void DTildeTest::test_initialise_method() {
   // create the data for the fields of our struct
   mxArray *field_array_ptrs[n_fields];
   for (int i = 0; i < n_fields; i++) {
-    field_array_ptrs[i] = mxCreateNumericArray(3, (const mwSize *) field_array_dimensions,
-                                               mxDOUBLE_CLASS, mxCOMPLEX);
+    field_array_ptrs[i] =
+            mxCreateNumericArray(3, (const mwSize *) field_array_dimensions,
+                                 mxDOUBLE_CLASS, mxCOMPLEX);
     mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
   // attempt to create a vector from this struct
   REQUIRE_NOTHROW(dt.initialise(matlab_input, n_rows, n_cols));
   // check that we actually assigned values to the Vectors under the hood
-  bool information_stored = (dt.num_det_modes() == target_n_det_modes) && (dt.x.has_elements()) &&
-                            (dt.y.has_elements());
+  bool information_stored = (dt.num_det_modes() == target_n_det_modes) &&
+                            (dt.x.has_elements()) && (dt.y.has_elements());
   CHECK(information_stored);
 }
 
-TEST_CASE("DTilde") {
-  DTildeTest().run_all_class_tests();
-}
+TEST_CASE("DTilde") { DTildeTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
+++ b/tdms/tests/unit/array_tests/test_DetectorSensitivityArrays.cpp
@@ -20,7 +20,8 @@ void DetectorSensitivityArraysTest::test_correct_construction() {
   DetectorSensitivityArrays dsa;
   // default constructor should set everything to nullptrs
   // destructor uses fftw destroy, which handles nullptrs itself
-  bool all_are_nullptrs = (dsa.cm == nullptr) && (dsa.plan == nullptr) && (dsa.v == nullptr);
+  bool all_are_nullptrs =
+          (dsa.cm == nullptr) && (dsa.plan == nullptr) && (dsa.v == nullptr);
   REQUIRE(all_are_nullptrs);
 }
 
@@ -37,9 +38,12 @@ void DetectorSensitivityArraysTest::test_initialise_method() {
       dsa.v[j * n_rows + i][1] = dsa.cm[i][j].imag();
     }
   }
-  // we can call the fftw_plan execution, which should place the 2D FFT into dsa.v
-  // simply checking executation is sufficient, as fftw should cover whether the FFT is actually meaningful in what it puts out
+  // we can call the fftw_plan execution, which should place the 2D FFT into
+  // dsa.v simply checking executation is sufficient, as fftw should cover
+  // whether the FFT is actually meaningful in what it puts out
   REQUIRE_NOTHROW(fftw_execute(dsa.plan));
 }
 
-TEST_CASE("DetectorSensitivityArrays") { DetectorSensitivityArraysTest().run_all_class_tests(); }
+TEST_CASE("DetectorSensitivityArrays") {
+  DetectorSensitivityArraysTest().run_all_class_tests();
+}

--- a/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/array_tests/test_DispersiveMultiLayer.cpp
@@ -3,12 +3,12 @@
  * @author William Graham (ccaegra@ucl.ac.uk)
  * @brief Tests for the DispersiveMultiLayer class and its subclasses
  */
-#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "unit_test_utils.h"
 
 using namespace std;
@@ -23,21 +23,25 @@ void DispersiveMultilayerTest::test_empty_construction() {
 
 void DispersiveMultilayerTest::test_wrong_input_type() {
   // Constructor should throw runtime_error at not recieving struct
-  dimensions_2d[0] = 2; dimensions_2d[1] = 3;
+  dimensions_2d[0] = 2;
+  dimensions_2d[1] = 3;
   create_numeric_array(2, dimensions_2d, mxUINT16_CLASS);
   REQUIRE_THROWS_AS(DispersiveMultiLayer(matlab_input), runtime_error);
 }
 
 void DispersiveMultilayerTest::test_correct_construction() {
   create_1by1_struct(n_fields, fieldnames);
-  // build "data" for each of the fields, which is going to be the same array filled with consecutive integers
+  // build "data" for each of the fields, which is going to be the same array
+  // filled with consecutive integers
   const int array_size[2] = {1, n_numeric_elements};
   mxArray *field_array_ptrs[n_fields];
   for (int i = 0; i < n_fields; i++) {
-    field_array_ptrs[i] =
-            mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
+    field_array_ptrs[i] = mxCreateNumericArray(2, (const mwSize *) array_size,
+                                               mxDOUBLE_CLASS, mxREAL);
     mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
-    for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) i; }
+    for (int i = 0; i < n_numeric_elements; i++) {
+      where_to_place_data[i] = (double) i;
+    }
     mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
   }
   // we should now be able to create a DispersiveMultiLayer object
@@ -64,16 +68,19 @@ void DispersiveMultilayerTest::test_other_methods() {
     const int array_size[2] = {1, n_numeric_elements};
     mxArray *field_array_ptrs[n_fields];
     for (int i = 0; i < n_fields; i++) {
-      field_array_ptrs[i] =
-              mxCreateNumericArray(2, (const mwSize *) array_size, mxDOUBLE_CLASS, mxREAL);
+      field_array_ptrs[i] = mxCreateNumericArray(2, (const mwSize *) array_size,
+                                                 mxDOUBLE_CLASS, mxREAL);
       mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
-      for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = 1.; }
+      for (int i = 0; i < n_numeric_elements; i++) {
+        where_to_place_data[i] = 1.;
+      }
       mxSetField(matlab_input, 0, fieldnames[i], field_array_ptrs[i]);
     }
     // create DispersiveMultiLayer object
     DispersiveMultiLayer dml(matlab_input);
 
-    // all entries in gamma are 1. -> so a tolerance of 1.5 should flag the dml as not dispersive
+    // all entries in gamma are 1. -> so a tolerance of 1.5 should flag the dml
+    // as not dispersive
     REQUIRE(!dml.is_dispersive(n_numeric_elements, 1.5));
     // yet a tolerance of 0.5 should flag it as dispersive
     REQUIRE(dml.is_dispersive(n_numeric_elements, 0.5));

--- a/tdms/tests/unit/array_tests/test_FrequencyVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_FrequencyVectors.cpp
@@ -6,15 +6,16 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "unit_test_utils.h"
 
 using namespace std;
 using tdms_tests::TOLERANCE;
 
 void FrequencyVectorsTest::test_empty_construction() {
-  // initialise() method should exit without assignment if we pass in a pointer to an empty array (regardless of whether this is a struct or not)
+  // initialise() method should exit without assignment if we pass in a pointer
+  // to an empty array (regardless of whether this is a struct or not)
   FrequencyVectors fv;
   dimensions_2d[0] = 0;
   create_numeric_array(2, dimensions_2d, mxUINT8_CLASS);
@@ -35,7 +36,8 @@ void FrequencyVectorsTest::test_wrong_input_type() {
 }
 
 void FrequencyVectorsTest::test_incorrect_number_of_fields() {
-  // assignment will throw error if we attempt to provide a struct array that doesn't have two fields
+  // assignment will throw error if we attempt to provide a struct array that
+  // doesn't have two fields
   FrequencyVectors fv;
   SECTION("Struct with too many inputs") {
     const char *too_many_names[3] = {"field1", "field2", "field3"};
@@ -63,8 +65,8 @@ void FrequencyVectorsTest::test_initialise_method() {
   // create the data for the fields of our struct
   mxArray *field_array_ptrs[2];
   for (int i = 0; i < 2; i++) {
-    field_array_ptrs[i] = mxCreateNumericArray(2, (const mwSize *) field_array_dimensions,
-                                               mxDOUBLE_CLASS, mxREAL);
+    field_array_ptrs[i] = mxCreateNumericArray(
+            2, (const mwSize *) field_array_dimensions, mxDOUBLE_CLASS, mxREAL);
     mxDouble *where_to_place_data = mxGetPr(field_array_ptrs[i]);
     // 0th field, fx_vec[i], will be 1/(i+1)
     // 1st field, fy_vec[i], will be -1/(i+1)
@@ -77,8 +79,8 @@ void FrequencyVectorsTest::test_initialise_method() {
   REQUIRE_NOTHROW(fv.initialise(matlab_input));
   // check that we actually assigned values to the Vectors under the hood
   bool not_assigned = (!fv.x.has_elements() && !fv.y.has_elements());
-  bool expected_size =
-          (fv.x.size() == n_numeric_elements && fv.y.size() == n_numeric_elements);
+  bool expected_size = (fv.x.size() == n_numeric_elements &&
+                        fv.y.size() == n_numeric_elements);
   bool assigned_and_correct_size = ((!not_assigned) && expected_size);
   REQUIRE(assigned_and_correct_size);
   // and the values themselves are what we expect
@@ -91,6 +93,4 @@ void FrequencyVectorsTest::test_initialise_method() {
   REQUIRE(values_are_correct);
 }
 
-TEST_CASE("FrequencyVectors") {
-  FrequencyVectorsTest().run_all_class_tests();
-}
+TEST_CASE("FrequencyVectors") { FrequencyVectorsTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_FullFieldSnapshot.cpp
+++ b/tdms/tests/unit/array_tests/test_FullFieldSnapshot.cpp
@@ -16,30 +16,38 @@ using tdms_math_constants::IMAGINARY_UNIT;
 using tdms_tests::is_close;
 
 void FullFieldSnapshotTest::test_other_methods() {
-    FullFieldSnapshot F;
-    F.Ex = IMAGINARY_UNIT;
-    F.Ey = 1.;
-    F.Ez = 0.;
-    F.Hx = 1. + IMAGINARY_UNIT;
-    F.Hy = 1.;
-    F.Hz = 0.;
-    SECTION("multiply_{E,H}_by") {
-      bool multiply_E_by_correct = true;
-      // multiply E-field by imaginary unit
-      F.multiply_E_by(IMAGINARY_UNIT);
-      multiply_E_by_correct = multiply_E_by_correct && is_close(F.Ex, complex<double>(-1., 0.));
-      multiply_E_by_correct = multiply_E_by_correct && is_close(F.Ey, IMAGINARY_UNIT);
-      multiply_E_by_correct = multiply_E_by_correct && is_close(F.Ez, complex<double>(0., 0.));
-      REQUIRE(multiply_E_by_correct);
+  FullFieldSnapshot F;
+  F.Ex = IMAGINARY_UNIT;
+  F.Ey = 1.;
+  F.Ez = 0.;
+  F.Hx = 1. + IMAGINARY_UNIT;
+  F.Hy = 1.;
+  F.Hz = 0.;
+  SECTION("multiply_{E,H}_by") {
+    bool multiply_E_by_correct = true;
+    // multiply E-field by imaginary unit
+    F.multiply_E_by(IMAGINARY_UNIT);
+    multiply_E_by_correct =
+            multiply_E_by_correct && is_close(F.Ex, complex<double>(-1., 0.));
+    multiply_E_by_correct =
+            multiply_E_by_correct && is_close(F.Ey, IMAGINARY_UNIT);
+    multiply_E_by_correct =
+            multiply_E_by_correct && is_close(F.Ez, complex<double>(0., 0.));
+    REQUIRE(multiply_E_by_correct);
 
-      bool multiply_H_by_correct = true;
-      // multiply H-field by the value of the Hx field
-      F.multiply_H_by(F.Hx);
-      multiply_H_by_correct = multiply_H_by_correct && is_close(F.Hx, 2. * IMAGINARY_UNIT);
-      multiply_H_by_correct = multiply_H_by_correct && is_close(F.Hy, 1. + IMAGINARY_UNIT);
-      multiply_H_by_correct = multiply_H_by_correct && is_close(F.Hz, complex<double>(0., 0.));
-      REQUIRE(multiply_H_by_correct);
-    }
+    bool multiply_H_by_correct = true;
+    // multiply H-field by the value of the Hx field
+    F.multiply_H_by(F.Hx);
+    multiply_H_by_correct =
+            multiply_H_by_correct && is_close(F.Hx, 2. * IMAGINARY_UNIT);
+    multiply_H_by_correct =
+            multiply_H_by_correct && is_close(F.Hy, 1. + IMAGINARY_UNIT);
+    multiply_H_by_correct =
+            multiply_H_by_correct && is_close(F.Hz, complex<double>(0., 0.));
+    REQUIRE(multiply_H_by_correct);
+  }
 }
 
-TEST_CASE("FullFieldSnapshot") { FullFieldSnapshotTest().run_all_class_tests(); }
+TEST_CASE("FullFieldSnapshot") {
+  FullFieldSnapshotTest().run_all_class_tests();
+}

--- a/tdms/tests/unit/array_tests/test_IncidentField.cpp
+++ b/tdms/tests/unit/array_tests/test_IncidentField.cpp
@@ -6,8 +6,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "unit_test_utils.h"
 
 using namespace std;
@@ -48,8 +48,8 @@ void IncidentFieldTest::test_correct_construction() {
   // create the data for the fields of our struct
   mxArray *field_array_ptrs[2];
   for (int i = 0; i < 2; i++) {
-    field_array_ptrs[i] = mxCreateNumericArray(3, (const mwSize *) dimensions_3d,
-                                               mxDOUBLE_CLASS, mxREAL);
+    field_array_ptrs[i] = mxCreateNumericArray(
+            3, (const mwSize *) dimensions_3d, mxDOUBLE_CLASS, mxREAL);
     mxDouble *place_data = mxGetPr(field_array_ptrs[i]);
     for (int ii = 0; ii < n_rows; ii++) {
       for (int jj = 0; jj < n_cols; jj++) {
@@ -64,7 +64,8 @@ void IncidentFieldTest::test_correct_construction() {
   // attempt to create a vector from this struct
   IncidentField i_field(matlab_input);
   // check that we actually assigned values to the Vectors under the hood
-  bool information_stored = (i_field.x.has_elements()) && (i_field.y.has_elements());
+  bool information_stored =
+          (i_field.x.has_elements()) && (i_field.y.has_elements());
   REQUIRE(information_stored);
   bool elements_set_correctly = true;
   for (int ii = 0; ii < n_rows; ii++) {
@@ -72,14 +73,14 @@ void IncidentFieldTest::test_correct_construction() {
       for (int kk = 0; kk < n_layers; kk++) {
         elements_set_correctly =
                 elements_set_correctly &&
-                (abs(i_field.x[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE) &&
-                (abs(i_field.y[kk][jj][ii] - 1. / ((double) (kk + jj + ii + 1))) < TOLERANCE);
+                (abs(i_field.x[kk][jj][ii] -
+                     1. / ((double) (kk + jj + ii + 1))) < TOLERANCE) &&
+                (abs(i_field.y[kk][jj][ii] -
+                     1. / ((double) (kk + jj + ii + 1))) < TOLERANCE);
       }
     }
   }
   REQUIRE(elements_set_correctly);
 }
 
-TEST_CASE("IncidentField") {
-  IncidentFieldTest().run_all_class_tests();
-}
+TEST_CASE("IncidentField") { IncidentFieldTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_Material.cpp
+++ b/tdms/tests/unit/array_tests/test_Material.cpp
@@ -1,13 +1,14 @@
 /**
  * @file test_Material.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Unit tests for the Material class and it's subclasses (CMaterial, DMaterial)
+ * @brief Unit tests for the Material class and it's subclasses (CMaterial,
+ * DMaterial)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 
 void CMaterialTest::test_incorrect_number_of_fields() {
   SECTION("Too few fields") {
@@ -31,7 +32,8 @@ void CMaterialTest::test_correct_construction() {
   create_1by1_struct(n_fields, fieldnames);
   mxArray *elements[n_fields];
   for (int i = 0; i < n_fields; i++) {
-    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS,
+                                        mxREAL);
     mxSetField(matlab_input, 0, fieldnames[i], elements[i]);
   }
   // construction should succeed
@@ -44,7 +46,8 @@ void DMaterialTest::test_incorrect_number_of_fields() {
     REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
   }
   SECTION("Too many fields") {
-    const char *too_many_fields[] = {"Dax", "Day", "Daz", "Dbx", "Dby", "Dbz", "extra"};
+    const char *too_many_fields[] = {"Dax", "Day", "Daz",  "Dbx",
+                                     "Dby", "Dbz", "extra"};
     create_1by1_struct(n_fields + 1, too_many_fields);
     REQUIRE_THROWS_AS(DMaterial(matlab_input), std::runtime_error);
   }
@@ -59,17 +62,14 @@ void DMaterialTest::test_correct_construction() {
   create_1by1_struct(n_fields, fieldnames);
   mxArray *elements[n_fields];
   for (int i = 0; i < n_fields; i++) {
-    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS, mxREAL);
+    elements[i] = mxCreateNumericMatrix(1, n_numeric_elements, mxDOUBLE_CLASS,
+                                        mxREAL);
     mxSetField(matlab_input, 0, fieldnames[i], elements[i]);
   }
   // construction should succeed
   DMaterial dm(matlab_input);
 }
 
-TEST_CASE("CMaterial") {
-  CMaterialTest().run_all_class_tests();
-}
+TEST_CASE("CMaterial") { CMaterialTest().run_all_class_tests(); }
 
-TEST_CASE("DMaterial") {
-  DMaterialTest().run_all_class_tests();
-}
+TEST_CASE("DMaterial") { DMaterialTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -1,13 +1,14 @@
 /**
  * @file test_Matrix.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests for the Matrix class and its subclasses (Vertices, GratingStructure, Pupil, EHVec)
+ * @brief Tests for the Matrix class and its subclasses (Vertices,
+ * GratingStructure, Pupil, EHVec)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "unit_test_utils.h"
 
 using tdms_tests::is_close;
@@ -16,13 +17,15 @@ void MatrixTest::test_correct_construction() {
   // create a Matrix via the default constructor
   SECTION("Default constructor") {
     Matrix<int> M_int;
-    // although created, the matrix should not have any elements, and should be flagged as such
+    // although created, the matrix should not have any elements, and should be
+    // flagged as such
     REQUIRE(!M_int.has_elements());
   }
   // create a Matrix using the overloaded constructor, and fill it with 1s
   SECTION("Overloaded constructor") {
     Matrix<double> M_double(n_rows, n_cols);
-    // because we used the overloaded constructor, the matrix should have elements
+    // because we used the overloaded constructor, the matrix should have
+    // elements
     REQUIRE(M_double.has_elements());
 
     // should be able to assign to these values without seg faults now
@@ -49,7 +52,8 @@ void MatrixTest::test_other_methods() {
 void VerticesTest::test_correct_construction() {
   // initialise the struct, it needs the fieldname "vertices"
   create_1by1_struct(n_fields, fieldnames);
-  mxArray *vertices_array = mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
+  mxArray *vertices_array =
+          mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
   mxSetField(matlab_input, 0, fieldnames[0], vertices_array);
   // create object
   Vertices v;
@@ -67,8 +71,8 @@ void GratingStructureTest::test_empty_construction() {
   dimensions_2d[0] = 0;
   dimensions_2d[1] = I_tot;
   create_numeric_array(2, dimensions_2d, mxINT32_CLASS);
-  // note: "new" used here since we need to delete gs to then safely delete matlab_input AFTERWARDS
-  // we cannot delete matlab_array before gs
+  // note: "new" used here since we need to delete gs to then safely delete
+  // matlab_input AFTERWARDS we cannot delete matlab_array before gs
   GratingStructure *gs;
   REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, I_tot));
   REQUIRE(!gs->has_elements());
@@ -82,7 +86,8 @@ void GratingStructureTest::test_wrong_input_dimensions() {
     dimensions_3d[1] = I_tot;
     dimensions_3d[2] = 3;
     create_numeric_array(3, dimensions_3d, mxINT32_CLASS);
-    REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot), std::runtime_error);
+    REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot),
+                      std::runtime_error);
   }
   SECTION("Wrong dimension size") {
     SECTION("(axis 0)") {
@@ -94,7 +99,8 @@ void GratingStructureTest::test_wrong_input_dimensions() {
       dimensions_2d[1] = I_tot;
     }
     create_numeric_array(2, dimensions_2d, mxINT32_CLASS);
-    REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot), std::runtime_error);
+    REQUIRE_THROWS_AS(GratingStructure(matlab_input, I_tot),
+                      std::runtime_error);
   }
 }
 
@@ -102,8 +108,8 @@ void GratingStructureTest::test_correct_construction() {
   dimensions_2d[0] = 2;
   dimensions_2d[1] = I_tot + 1;
   create_numeric_array(2, dimensions_2d, mxINT32_CLASS, mxREAL);
-  // note: "new" used here since we need to delete gs to then safely delete matlab_input AFTERWARDS
-  // we cannot delete matlab_array before gs
+  // note: "new" used here since we need to delete gs to then safely delete
+  // matlab_input AFTERWARDS we cannot delete matlab_array before gs
   GratingStructure *gs;
   REQUIRE_NOTHROW(gs = new GratingStructure(matlab_input, I_tot));
   REQUIRE(gs->has_elements());
@@ -116,8 +122,9 @@ void PupilTest::test_empty_construction() {
   dimensions_2d[0] = 0;
   dimensions_2d[1] = n_cols;
   create_numeric_array(2, dimensions_2d);
-  // passing in an empty array to initialise() doesn't error, but also doesn't assign
-  // additionally, the rows and columns arguments aren't even used, so can be garbage
+  // passing in an empty array to initialise() doesn't error, but also doesn't
+  // assign additionally, the rows and columns arguments aren't even used, so
+  // can be garbage
   p.initialise(matlab_input, 1, 1);
   REQUIRE(!p.has_elements());// shouldn't have assigned any memory or pointers
 }
@@ -129,23 +136,23 @@ void PupilTest::test_wrong_input_dimensions() {
     dimensions_3d[1] = n_cols;
     dimensions_3d[2] = 2;
     create_numeric_array(3, dimensions_3d);
-    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols), std::runtime_error);
+    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols),
+                      std::runtime_error);
     REQUIRE(!p.has_elements());
   }
   SECTION("Wrong dimension size") {
     dimensions_2d[0] = 2 * n_rows;
     dimensions_2d[1] = n_cols + 1;
     create_numeric_array(2, dimensions_2d);
-    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols), std::runtime_error);
+    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols),
+                      std::runtime_error);
     REQUIRE(!p.has_elements());
   }
 }
 
 void PupilTest::test_correct_construction() {
   Pupil p;
-  SECTION("Default constructor") {
-    REQUIRE(!p.has_elements());
-  }
+  SECTION("Default constructor") { REQUIRE(!p.has_elements()); }
   SECTION("Overloaded constructor") {
     dimensions_2d[0] = n_rows;
     dimensions_2d[1] = n_cols;
@@ -171,29 +178,20 @@ void EHVecTest::test_other_methods() {
   fftw_complex fftw_unit{1., 0.};
   fftw_complex fftw_imag_unit{0., 1.};
 
-  bool elements_set_correctly = is_close(eh[0][0][REAL], fftw_unit[REAL]) &&
-                                is_close(eh[0][0][IMAG], fftw_unit[IMAG]) &&
-                                is_close(eh[0][1][REAL], fftw_imag_unit[REAL]) &&
-                                is_close(eh[0][1][IMAG], fftw_imag_unit[IMAG]);
+  bool elements_set_correctly =
+          is_close(eh[0][0][REAL], fftw_unit[REAL]) &&
+          is_close(eh[0][0][IMAG], fftw_unit[IMAG]) &&
+          is_close(eh[0][1][REAL], fftw_imag_unit[REAL]) &&
+          is_close(eh[0][1][IMAG], fftw_imag_unit[IMAG]);
   REQUIRE(elements_set_correctly);
 }
 
-TEST_CASE("Matrix") {
-  MatrixTest().run_all_class_tests();
-}
+TEST_CASE("Matrix") { MatrixTest().run_all_class_tests(); }
 
-TEST_CASE("Vertices") {
-  VerticesTest().run_all_class_tests();
-}
+TEST_CASE("Vertices") { VerticesTest().run_all_class_tests(); }
 
-TEST_CASE("GratingStructure") {
-  GratingStructureTest().run_all_class_tests();
-}
+TEST_CASE("GratingStructure") { GratingStructureTest().run_all_class_tests(); }
 
-TEST_CASE("Pupil") {
-  PupilTest().run_all_class_tests();
-}
+TEST_CASE("Pupil") { PupilTest().run_all_class_tests(); }
 
-TEST_CASE("EHVec") {
-  EHVecTest().run_all_class_tests();
-}
+TEST_CASE("EHVec") { EHVecTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_Tensor3D.cpp
+++ b/tdms/tests/unit/array_tests/test_Tensor3D.cpp
@@ -1,14 +1,15 @@
 /**
  * @file test_Tensor3D.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests the functionality of the Tensor3D class, which is the building block for several further field classes
+ * @brief Tests the functionality of the Tensor3D class, which is the building
+ * block for several further field classes
  *
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "unit_test_utils.h"
 
 using tdms_tests::TOLERANCE;
@@ -16,7 +17,8 @@ using tdms_tests::TOLERANCE;
 void Tensor3DTest::test_correct_construction() {
   Tensor3D<double> *t3d;
   SECTION("Default constructor") {
-    // default constructor should assign all dimensions to 0, and the tensor itself should be a nullptr
+    // default constructor should assign all dimensions to 0, and the tensor
+    // itself should be a nullptr
     t3d = new Tensor3D<double>;
     // should have no elements
     REQUIRE(!(t3d->has_elements()));
@@ -30,10 +32,13 @@ void Tensor3DTest::test_correct_construction() {
     double ***p = (double ***) malloc(n_layers * sizeof(double **));
     for (int k = 0; k < n_layers; k++) {
       p[k] = (double **) malloc(n_cols * sizeof(double *));
-      for (int j = 0; j < n_cols; j++) { p[k][j] = (double *) malloc(n_rows * sizeof(double)); }
+      for (int j = 0; j < n_cols; j++) {
+        p[k][j] = (double *) malloc(n_rows * sizeof(double));
+      }
     }
     t3d = new Tensor3D(p, n_layers, n_cols, n_rows);
-    // this tensor should be flagged as "having elements", since we provided a pointer in the constructor
+    // this tensor should be flagged as "having elements", since we provided a
+    // pointer in the constructor
     REQUIRE(t3d->has_elements());
   }
   // tear down assigned memory
@@ -45,12 +50,14 @@ void Tensor3DTest::test_other_methods() {
   t3d.allocate(n_layers, n_cols, n_rows);
   t3d.zero();
   SECTION("allocate() and zero()") {
-    // we should be able to flag this tensor has elements, so the bool should be set to true
+    // we should be able to flag this tensor has elements, so the bool should be
+    // set to true
     bool allocated_and_zero = t3d.has_elements();
     for (int k = 0; k < n_layers; k++) {
       for (int j = 0; j < n_cols; j++) {
         for (int i = 0; i < n_rows; i++) {
-          allocated_and_zero = allocated_and_zero && (abs(t3d[k][j][i]) < TOLERANCE);
+          allocated_and_zero =
+                  allocated_and_zero && (abs(t3d[k][j][i]) < TOLERANCE);
         }
       }
     }
@@ -59,8 +66,9 @@ void Tensor3DTest::test_other_methods() {
   SECTION("frobenius()") {
     // frobenius norm should be zero after allocation and zero-ing
     REQUIRE(abs(t3d.frobenius()) < TOLERANCE);
-    // assign some values to this tensor. We'll go with =0 if i+j+k is even, and =1 if odd
-    // this gives us 4*8*16/2 = 4^4 = 256 non-zero entries, which are 1, so the analytic norm is 16.
+    // assign some values to this tensor. We'll go with =0 if i+j+k is even, and
+    // =1 if odd this gives us 4*8*16/2 = 4^4 = 256 non-zero entries, which are
+    // 1, so the analytic norm is 16.
     for (int k = 0; k < n_layers; k++) {
       for (int j = 0; j < n_cols; j++) {
         for (int i = 0; i < n_rows; i++) { t3d[k][j][i] = (i + j + k) % 2; }
@@ -73,6 +81,4 @@ void Tensor3DTest::test_other_methods() {
   }
 }
 
-TEST_CASE("Tensor3D: zero, frobenius") {
-  Tensor3DTest().run_all_class_tests();
-}
+TEST_CASE("Tensor3D: zero, frobenius") { Tensor3DTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_Vector.cpp
+++ b/tdms/tests/unit/array_tests/test_Vector.cpp
@@ -1,19 +1,20 @@
 /**
  * @file test_Vector.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Unit tests for the Vector class and its subclasses (FieldComponentsVector, FrequencyExtractVector)
+ * @brief Unit tests for the Vector class and its subclasses
+ * (FieldComponentsVector, FrequencyExtractVector)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "globals.h"
 #include "unit_test_utils.h"
 
 using namespace tdms_math_constants;
-using tdms_tests::TOLERANCE;
 using tdms_tests::is_close;
+using tdms_tests::TOLERANCE;
 
 void VectorTest::test_correct_construction() {
   // default constructor should not assign any elements or pointers
@@ -27,23 +28,28 @@ void VectorTest::test_correct_construction() {
     create_numeric_array(2, dimensions_2d);
     mxDouble *where_to_place_data = mxGetPr(matlab_input);
     // data is just the integers starting from 0
-    for (int i = 0; i < n_numeric_elements; i++) { where_to_place_data[i] = (double) i; }
+    for (int i = 0; i < n_numeric_elements; i++) {
+      where_to_place_data[i] = (double) i;
+    }
     // assign this MATLAB array to a vector
     Vector<double> v_from_matlab(matlab_input);
     bool has_elements_and_right_size =
-            (v_from_matlab.has_elements() && v_from_matlab.size() == n_numeric_elements);
+            (v_from_matlab.has_elements() &&
+             v_from_matlab.size() == n_numeric_elements);
     REQUIRE(has_elements_and_right_size);
     // check that the data is the _right_ data too
     bool correct_data_accessed = true;
     for (int i = 0; i < n_numeric_elements; i++) {
-      correct_data_accessed = correct_data_accessed && is_close(v_from_matlab[i], (double) i);
+      correct_data_accessed =
+              correct_data_accessed && is_close(v_from_matlab[i], (double) i);
     }
     REQUIRE(correct_data_accessed);
   }
 }
 
 void FieldComponentsVectorTest::test_correct_construction() {
-  // FieldComponentsVector can be initialised with the default constructor, then have initialise() called to assign values from a pre-existing MATLAB array
+  // FieldComponentsVector can be initialised with the default constructor, then
+  // have initialise() called to assign values from a pre-existing MATLAB array
   FieldComponentsVector fcv;
   bool fcv_ready = ((!fcv.has_elements()) && (fcv.size() == 0));
   REQUIRE(fcv_ready);
@@ -52,15 +58,17 @@ void FieldComponentsVectorTest::test_correct_construction() {
 void FieldComponentsVectorTest::test_initialise_method() {
   FieldComponentsVector fcv;
   // create a MATLAB struct with a "components" field to cast to
-  // the constructor shouldn't care whether or not the components field contains an n*1 or 1*n vector either
-  // struct with horizontal vector
+  // the constructor shouldn't care whether or not the components field contains
+  // an n*1 or 1*n vector either struct with horizontal vector
   create_1by1_struct(n_fields, fieldnames);
   mxArray *vector_array;
   SECTION("(horz)") {
-    vector_array = mxCreateNumericMatrix(1, n_numeric_elements, mxINT16_CLASS, mxREAL);
+    vector_array =
+            mxCreateNumericMatrix(1, n_numeric_elements, mxINT16_CLASS, mxREAL);
   }
   SECTION("(vert)") {
-    vector_array = mxCreateNumericMatrix(n_numeric_elements, 1, mxINT16_CLASS, mxREAL);
+    vector_array =
+            mxCreateNumericMatrix(n_numeric_elements, 1, mxINT16_CLASS, mxREAL);
   }
   mxSetField(matlab_input, 0, fieldnames[0], vector_array);
   // initialise
@@ -70,7 +78,8 @@ void FieldComponentsVectorTest::test_initialise_method() {
 }
 
 void FrequencyExtractVectorTest::test_empty_construction() {
-  // if passed in an empty pointer, creates a length-1 array with a single, predetermined element
+  // if passed in an empty pointer, creates a length-1 array with a single,
+  // predetermined element
   dimensions_2d[0] = 0;
   dimensions_2d[1] = n_numeric_elements;
   create_numeric_array(2, dimensions_2d);
@@ -92,16 +101,13 @@ void FrequencyExtractVectorTest::test_wrong_input_dimensions() {
     dimensions_3d[2] = 3;
     create_numeric_array(3, dimensions_3d);
   }
-  REQUIRE_THROWS_AS(FrequencyExtractVector(matlab_input, omega_an), std::runtime_error);
+  REQUIRE_THROWS_AS(FrequencyExtractVector(matlab_input, omega_an),
+                    std::runtime_error);
 }
 
 void FrequencyExtractVectorTest::test_correct_construction() {
-  SECTION("(horz)") {
-    dimensions_2d[1] = n_numeric_elements;
-  }
-  SECTION("(vert)") {
-    dimensions_2d[0] = n_numeric_elements;
-  }
+  SECTION("(horz)") { dimensions_2d[1] = n_numeric_elements; }
+  SECTION("(vert)") { dimensions_2d[0] = n_numeric_elements; }
   create_numeric_array(2, dimensions_2d);
   FrequencyExtractVector fev(matlab_input, omega_an);
   CHECK(fev.size() == n_numeric_elements);
@@ -115,13 +121,16 @@ void FrequencyExtractVectorTest::test_other_methods() {
     int target_max_index;
     SECTION("Find element n_numeric_elements-1") {
       for (int i = 0; i < n_numeric_elements; i++) {
-        data_placement[i] = ((double) i / (double) (n_numeric_elements - 1)) * omega_an * DCPI;
+        data_placement[i] = ((double) i / (double) (n_numeric_elements - 1)) *
+                            omega_an * DCPI;
       }
       target_max_index = n_numeric_elements - 1;
     }
     SECTION("Find element 0") {
       for (int i = 0; i < n_numeric_elements; i++) {
-        data_placement[i] = ((double) (n_numeric_elements - i) / (double) (n_numeric_elements - 1)) * omega_an * DCPI;
+        data_placement[i] = ((double) (n_numeric_elements - i) /
+                             (double) (n_numeric_elements - 1)) *
+                            omega_an * DCPI;
       }
       target_max_index = 0;
     }
@@ -132,9 +141,7 @@ void FrequencyExtractVectorTest::test_other_methods() {
   }
 }
 
-TEST_CASE("Vector") {
-  VectorTest().run_all_class_tests();
-}
+TEST_CASE("Vector") { VectorTest().run_all_class_tests(); }
 
 TEST_CASE("FieldComponentsVector") {
   FieldComponentsVectorTest().run_all_class_tests();

--- a/tdms/tests/unit/array_tests/test_XYZTensor3D.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZTensor3D.cpp
@@ -4,11 +4,11 @@
  * @brief Tests allocation, deallocation, and methods for the XYZTensor3D class
  */
 #include <catch2/catch_test_macros.hpp>
-#include <spdlog/spdlog.h>
 #include <complex>
+#include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "globals.h"
 #include "unit_test_utils.h"
 
@@ -18,8 +18,8 @@ using tdms_tests::is_close;
 void XYZTensor3DTest::test_correct_construction() {
   // try creating an XYZTensor3D using the default constructor
   XYZTensor3D<complex<double>> xyzt3d;
-  // check that, although this has been declared, its members still point to nullptrs
-  // we should be able to index this through AxialDirection
+  // check that, although this has been declared, its members still point to
+  // nullptrs we should be able to index this through AxialDirection
   bool all_nullptrs = (xyzt3d[AxialDirection::X] == nullptr) &&
                       (xyzt3d[AxialDirection::Y] == nullptr) &&
                       (xyzt3d[AxialDirection::Z] == nullptr);
@@ -39,19 +39,22 @@ void XYZTensor3DTest::test_other_methods() {
           for (int i = 0; i < n_rows; i++) {
             // shouldn't seg fault when assigning
             // cast type all at once
-            xyzt3d[component][k][j][i] = complex<double>((double) i * j, (double) i * k);
+            xyzt3d[component][k][j][i] =
+                    complex<double>((double) i * j, (double) i * k);
             // check real/imag part casting
-            assignments_succeeded = assignments_succeeded &&
-                                    is_close(xyzt3d[component][k][j][i].real(), (double) i * j) &&
-                                    is_close(xyzt3d[component][k][j][i].imag(), (double) i * k);
+            assignments_succeeded =
+                    assignments_succeeded &&
+                    is_close(xyzt3d[component][k][j][i].real(),
+                             (double) i * j) &&
+                    is_close(xyzt3d[component][k][j][i].imag(), (double) i * k);
           }
         }
       }
     }
     REQUIRE(assignments_succeeded);
     // at end, destructor should be called as appropriate
-    // but this class has no destructor --- it doesn't store the size of its arrays
-    // hence, manually deallocate here
+    // but this class has no destructor --- it doesn't store the size of its
+    // arrays hence, manually deallocate here
     for (char component : {'x', 'y', 'z'}) {
       for (int k = 0; k < n_layers; k++) {
         for (int j = 0; j < n_cols; j++) { free(xyzt3d[component][k][j]); }
@@ -62,6 +65,4 @@ void XYZTensor3DTest::test_other_methods() {
   }
 }
 
-TEST_CASE("XYZTensor") {
-  XYZTensor3DTest().run_all_class_tests();
-}
+TEST_CASE("XYZTensor") { XYZTensor3DTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_XYZVectors.cpp
+++ b/tdms/tests/unit/array_tests/test_XYZVectors.cpp
@@ -4,11 +4,11 @@
  * @brief Tests allocation, deallocation, and methods for the XYZVectors class
  */
 #include <catch2/catch_test_macros.hpp>
-#include <spdlog/spdlog.h>
 #include <numeric>
+#include <spdlog/spdlog.h>
 
-#include "arrays.h"
 #include "array_test_class.h"
+#include "arrays.h"
 #include "globals.h"
 #include "unit_test_utils.h"
 
@@ -17,7 +17,8 @@ using tdms_tests::is_close;
 
 void XYZVectorsTest::test_correct_construction() {
   XYZVectors v;
-  // check that, although this has been declared, its members still point to nullptrs
+  // check that, although this has been declared, its members still point to
+  // nullptrs
   bool are_nullptrs = (v.x == nullptr) && (v.y == nullptr) && (v.z == nullptr);
   REQUIRE(are_nullptrs);
 }
@@ -25,14 +26,16 @@ void XYZVectorsTest::test_correct_construction() {
 void XYZVectorsTest::test_other_methods() {
   XYZVectors v;
   // create some arrays to assign to the members
-  double x_vec[n_rows] = {0.}, y_vec[n_cols] = {2., 1.}, z_vec[n_layers] = {1., 2., 3., 4.};
+  double x_vec[n_rows] = {0.}, y_vec[n_cols] = {2., 1.},
+         z_vec[n_layers] = {1., 2., 3., 4.};
 
   SECTION("set_ptr()") {
     // now let's try assigning
     v.set_ptr(AxialDirection::X, x_vec);
     v.set_ptr(AxialDirection::Y, y_vec);
     v.set_ptr(AxialDirection::Z, z_vec);
-    bool are_not_nullptrs = (v.x != nullptr) && (v.y != nullptr) && (v.z != nullptr);
+    bool are_not_nullptrs =
+            (v.x != nullptr) && (v.y != nullptr) && (v.z != nullptr);
     REQUIRE(are_not_nullptrs);
 
     // and the components are what we expect
@@ -74,6 +77,4 @@ void XYZVectorsTest::test_other_methods() {
   }
 }
 
-TEST_CASE("XYZVectors") {
-  XYZVectorsTest().run_all_class_tests();
-}
+TEST_CASE("XYZVectors") { XYZVectorsTest().run_all_class_tests(); }

--- a/tdms/tests/unit/field_tests/test_Field.cpp
+++ b/tdms/tests/unit/field_tests/test_Field.cpp
@@ -1,13 +1,14 @@
 /**
  * @file test_Field.cpp
- * @brief Unit tests for the Field class and its subclasses (ElectricField, MagneticField).
+ * @brief Unit tests for the Field class and its subclasses (ElectricField,
+ * MagneticField).
  *
  * NOTE: Interpolation methods are checked in a separate file for readability.
  */
 #include "field.h"
 
-#include <complex>
 #include <catch2/catch_test_macros.hpp>
+#include <complex>
 
 #include "globals.h"
 #include "unit_test_utils.h"
@@ -15,13 +16,14 @@
 using namespace std;
 using namespace tdms_math_constants;
 
-using tdms_tests::TOLERANCE;
 using tdms_tests::is_close;
+using tdms_tests::TOLERANCE;
 
 TEST_CASE("Field: normalise_volume") {
 
   const int I_tot = 2, J_tot = 2, K_tot = 2;
-  // create a field (note electric or magnetic should be sufficient here as we are testing base class method)
+  // create a field (note electric or magnetic should be sufficient here as we
+  // are testing base class method)
   ElectricField F(I_tot, J_tot, K_tot);
   F.allocate_and_zero();
 
@@ -54,15 +56,18 @@ TEST_CASE("Field: normalise_volume") {
         // set x component to be 1 + i, so should normalise to 1.
         x_normalised_correctly =
                 (x_normalised_correctly &&
-                 (abs(F.real.x[k][j][i] - 1. + IMAGINARY_UNIT * (F.imag.x[k][j][i] - 0.)) < TOLERANCE));
+                 (abs(F.real.x[k][j][i] - 1. +
+                      IMAGINARY_UNIT * (F.imag.x[k][j][i] - 0.)) < TOLERANCE));
         // set y component to be 2, so should normalise to be 1 - i
         y_normalised_correctly =
                 (y_normalised_correctly &&
-                 (abs(F.real.y[k][j][i] - 1. + IMAGINARY_UNIT * (F.imag.y[k][j][i] + 1.)) < TOLERANCE));
+                 (abs(F.real.y[k][j][i] - 1. +
+                      IMAGINARY_UNIT * (F.imag.y[k][j][i] + 1.)) < TOLERANCE));
         // keep z components as 0
         z_normalised_correctly =
                 (z_normalised_correctly &&
-                 (abs(F.real.z[k][j][i] - 0. + IMAGINARY_UNIT * (F.imag.z[k][j][i] - 0.)) < TOLERANCE));
+                 (abs(F.real.z[k][j][i] - 0. +
+                      IMAGINARY_UNIT * (F.imag.z[k][j][i] - 0.)) < TOLERANCE));
       }
     }
   }
@@ -85,7 +90,8 @@ TEST_CASE("ElectricField: angular norm addition") {
   params.dt = DT;
 
   // z = e^(iω(n+1)dt) / N_t
-  auto expected = exp(OMEGA * ((double) N + 1) * DT * IMAGINARY_UNIT) / ((double) N_T);
+  auto expected =
+          exp(OMEGA * ((double) N + 1) * DT * IMAGINARY_UNIT) / ((double) N_T);
 
   E.add_to_angular_norm(N, N_T, params);
   REQUIRE(is_close(E.angular_norm, expected));
@@ -105,7 +111,8 @@ TEST_CASE("MagneticField: angular norm addition") {
   params.dt = DT;
 
   // z = e^(iω(n+1/2)dt) / N_t
-  auto expected = exp(OMEGA * ((double) N + 0.5) * DT * IMAGINARY_UNIT) / ((double) N_T);
+  auto expected = exp(OMEGA * ((double) N + 0.5) * DT * IMAGINARY_UNIT) /
+                  ((double) N_T);
 
   H.add_to_angular_norm(N, N_T, params);
   REQUIRE(is_close(H.angular_norm, expected));

--- a/tdms/tests/unit/field_tests/test_Field_interpolation.cpp
+++ b/tdms/tests/unit/field_tests/test_Field_interpolation.cpp
@@ -1,7 +1,8 @@
 /**
  * @file test_field_interpolation.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests interpolation of E- and H-fields and compares the errors against MATLAB benchmarks
+ * @brief Tests interpolation of E- and H-fields and compares the errors against
+ * MATLAB benchmarks
  */
 #include "field.h"
 
@@ -16,73 +17,88 @@
 
 using namespace tdms_math_constants;
 
-using tdms_tests::TOLERANCE;
 using tdms_tests::euclidean;
 using tdms_tests::is_close_or_better;
+using tdms_tests::TOLERANCE;
 
 /* Overview of Tests
 
-We will test the performance of BLi at interpolating a known field to the centre of each Yee cell, for both the E- and H- fields.
-The benchmark for success will be superior or equivalent error (Frobenius and 1D-dimension-wise norm) to that produced by MATLAB performing the same functionality.
-Frobenious error is the Frobenius norm of the 3D matrix whose (i,j,k)-th entry is the error in the interpolated value at Yee cell centre (i,j,k).
-The slice error, for a fixed j,k, is the norm-error of the 1D array of interpolated values along the axis (:,j,k).
-The maximum of this is then the max-slice error: keeping track of this ensures us that the behaviour of BLi is consistent, and does not dramaically over-compensate in some areas and under-compensate in others.
+We will test the performance of BLi at interpolating a known field to the centre
+of each Yee cell, for both the E- and H- fields. The benchmark for success will
+be superior or equivalent error (Frobenius and 1D-dimension-wise norm) to that
+produced by MATLAB performing the same functionality. Frobenious error is the
+Frobenius norm of the 3D matrix whose (i,j,k)-th entry is the error in the
+interpolated value at Yee cell centre (i,j,k). The slice error, for a fixed j,k,
+is the norm-error of the 1D array of interpolated values along the axis (:,j,k).
+The maximum of this is then the max-slice error: keeping track of this ensures
+us that the behaviour of BLi is consistent, and does not dramaically
+over-compensate in some areas and under-compensate in others.
 
-All tests will be performed with cell sizes Dx = 0.25, Dy = 0.1, Dz = 0.05, over the range [-2,2].
+All tests will be performed with cell sizes Dx = 0.25, Dy = 0.1, Dz = 0.05, over
+the range [-2,2].
 */
 
 // functional form for the {E,H}-field components
 inline double field_component(double t) {
-    return sin(2. * DCPI * t) * exp(-t * t);
+  return sin(2. * DCPI * t) * exp(-t * t);
 }
 
 /**
- * @brief Test the interpolation of the E-field components to the centre of the Yee cells
+ * @brief Test the interpolation of the E-field components to the centre of the
+ * Yee cells
  *
  * Each component of the E-field will take the form
  * E_t(tt) = sin(2\pi tt) * exp(-tt^2)
  *
- * We test both the Fro- and slice-norm metrics, since interpolation only happens along one axis
+ * We test both the Fro- and slice-norm metrics, since interpolation only
+ * happens along one axis
  */
 TEST_CASE("E-field interpolation check") {
   SPDLOG_INFO("===== Testing E-field BLi =====");
   // error tolerance, based on MATLAB performance
   // script: benchmark_test_field_interpolation_H.m
-  double Ex_fro_tol = 2.4535659128911650e-02, Ex_ms_tol = 1.0294466335592440e-03;
-  double Ey_fro_tol = 2.5021563893394754e-02, Ey_ms_tol = 1.6590813667643383e-03;
-  double Ez_fro_tol = 2.5181324617226587e-02, Ez_ms_tol = 1.7507103927894884e-03;
+  double Ex_fro_tol = 2.4535659128911650e-02,
+         Ex_ms_tol = 1.0294466335592440e-03;
+  double Ey_fro_tol = 2.5021563893394754e-02,
+         Ey_ms_tol = 1.6590813667643383e-03;
+  double Ez_fro_tol = 2.5181324617226587e-02,
+         Ez_ms_tol = 1.7507103927894884e-03;
 
   // fake domain setup
   double x_lower = -2., y_lower = -2., z_lower = -2.;
   double extent_x = 4., extent_y = 4., extent_z = 4.;
   double cellDims[3] = {0.25, 0.1, 0.05};
-  // The number of cells in each direction is then 16 = 4/0.25, 40 = 4/0.1, 80 = 4/0.05.
-  // Note that due to the possibility that Nx/cellDims[0] computing something that is not quite an integer, we need to use round() to get an int safely
+  // The number of cells in each direction is then 16 = 4/0.25, 40 = 4/0.1, 80 =
+  // 4/0.05. Note that due to the possibility that Nx/cellDims[0] computing
+  // something that is not quite an integer, we need to use round() to get an
+  // int safely
   int Nx = round(extent_x / cellDims[0]), Ny = round(extent_y / cellDims[1]),
       Nz = round(extent_z / cellDims[2]);
 
   // setup the "split" E-field components
-  ElectricSplitField E_split(Nx-1, Ny-1, Nz-1);
-  E_split.allocate(); // alocates Nx, Ny, Nz memory space here
-  E_split.tot += 1; // correct the "number of datapoints" variable for these fields
+  ElectricSplitField E_split(Nx - 1, Ny - 1, Nz - 1);
+  E_split.allocate();// alocates Nx, Ny, Nz memory space here
+  E_split.tot +=
+          1;// correct the "number of datapoints" variable for these fields
   // setup for non-split field components
   ElectricField E(Nx, Ny, Nz);
   E.allocate();
 
   /* Compute the exact field and the "split field" components
-  Ex[k][j][i] is the value of the field at position (x_lower,y_lower,z_lower) + (i,j+0.5,k+0.5)*cellDims
-  Ey[k][j][i] is the value of the field at position (x_lower,y_lower,z_lower) + (i+0.5,j,k+0.5)*cellDims
-  Ez[k][j][i] is the value of the field at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k)*cellDims
+  Ex[k][j][i] is the value of the field at position (x_lower,y_lower,z_lower) +
+  (i,j+0.5,k+0.5)*cellDims Ey[k][j][i] is the value of the field at position
+  (x_lower,y_lower,z_lower) + (i+0.5,j,k+0.5)*cellDims Ez[k][j][i] is the value
+  of the field at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k)*cellDims
   */
   for (int ii = 0; ii < Nx; ii++) {
     for (int jj = 0; jj < Ny; jj++) {
       for (int kk = 0; kk < Nz; kk++) {
-        double x_comp_value =
-                field_component(y_lower + ((double) jj + 0.5) * cellDims[1]);// Ex depends on y
-        double y_comp_value =
-                field_component(z_lower + ((double) kk + 0.5) * cellDims[2]);// Ey depends on z
-        double z_comp_value =
-                field_component(x_lower + ((double) ii + 0.5) * cellDims[0]);// Ez depends on x
+        double x_comp_value = field_component(
+                y_lower + ((double) jj + 0.5) * cellDims[1]);// Ex depends on y
+        double y_comp_value = field_component(
+                z_lower + ((double) kk + 0.5) * cellDims[2]);// Ey depends on z
+        double z_comp_value = field_component(
+                x_lower + ((double) ii + 0.5) * cellDims[0]);// Ez depends on x
         // assign to "freq domain" ElectricField
         E.real.x[kk][jj][ii] = x_comp_value;
         E.imag.x[kk][jj][ii] = 0.;
@@ -90,7 +106,8 @@ TEST_CASE("E-field interpolation check") {
         E.imag.y[kk][jj][ii] = 0.;
         E.real.z[kk][jj][ii] = z_comp_value;
         E.imag.z[kk][jj][ii] = 0.;
-        // assign to "time domain" ElectricSplitField - use weighting that sums to 1 to check addition is behaving as planned
+        // assign to "time domain" ElectricSplitField - use weighting that sums
+        // to 1 to check addition is behaving as planned
         E_split.xy[kk][jj][ii] = x_comp_value;
         E_split.xz[kk][jj][ii] = 0.;
         E_split.yx[kk][jj][ii] = y_comp_value * .5;
@@ -101,20 +118,26 @@ TEST_CASE("E-field interpolation check") {
     }
   }
 
-  /* In each axis, we will now interpolate to positions 1 through N{x,y,z}-1. Recall this means to the midpoint of the datapoints indexed by 0 and 1, then 1 and 2, ..., N{x,y,z}-3 and N{x,y,z}-2, and finally N{x,y,z}-2 and N{x,y,z}-1.
-  Ex_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
-  Ey_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
-  Ez_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
+  /* In each axis, we will now interpolate to positions 1 through N{x,y,z}-1.
+  Recall this means to the midpoint of the datapoints indexed by 0 and 1, then 1
+  and 2, ..., N{x,y,z}-3 and N{x,y,z}-2, and finally N{x,y,z}-2 and N{x,y,z}-1.
+  Ex_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower)
+  + (i+0.5,j+0.5,k+0.5)*cellDims Ey_exact[k][j][i] is the field component at
+  position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
+  Ez_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower)
+  + (i+0.5,j+0.5,k+0.5)*cellDims
   */
-  Tensor3D<double> Ex_error, Ex_split_error, Ey_error, Ey_split_error, Ez_error, Ez_split_error;
-  Ex_error.allocate(Nz, Ny, Nx-1);
-  Ex_split_error.allocate(Nz, Ny, Nx-1);
-  Ey_error.allocate(Nz, Ny-1, Nx);
-  Ey_split_error.allocate(Nz, Ny-1, Nx);
-  Ez_error.allocate(Nz-1, Ny, Nx);
-  Ez_split_error.allocate(Nz-1, Ny, Nx);
+  Tensor3D<double> Ex_error, Ex_split_error, Ey_error, Ey_split_error, Ez_error,
+          Ez_split_error;
+  Ex_error.allocate(Nz, Ny, Nx - 1);
+  Ex_split_error.allocate(Nz, Ny, Nx - 1);
+  Ey_error.allocate(Nz, Ny - 1, Nx);
+  Ey_split_error.allocate(Nz, Ny - 1, Nx);
+  Ez_error.allocate(Nz - 1, Ny, Nx);
+  Ez_split_error.allocate(Nz - 1, Ny, Nx);
   // now interpolate
-  // note that we aren't interpolating to position 0 (before 1st point) or N{x,y,z} (after last point)
+  // note that we aren't interpolating to position 0 (before 1st point) or
+  // N{x,y,z} (after last point)
   for (int ii = 0; ii < Nx; ii++) {
     for (int jj = 0; jj < Ny; jj++) {
       for (int kk = 0; kk < Nz; kk++) {
@@ -123,49 +146,56 @@ TEST_CASE("E-field interpolation check") {
         double y_eval_position = z_lower + ((double) kk + 0.5) * cellDims[2];
         double z_eval_position = x_lower + ((double) ii + 0.5) * cellDims[0];
         // current cell index
-        CellCoordinate current_cell {ii, jj, kk};
+        CellCoordinate current_cell{ii, jj, kk};
 
         // Ex interpolation
-        if (ii!=0) {
+        if (ii != 0) {
           double Ex_exact = field_component(x_eval_position);// Ex depends on y
-          double Ex_split_interp =
-                  E_split.interpolate_to_centre_of(AxialDirection::X, current_cell);
-          double Ex_interp = E.interpolate_to_centre_of(AxialDirection::X, current_cell).real();
-          Ex_error[kk][jj][ii-1] = Ex_interp - Ex_exact;
-          Ex_split_error[kk][jj][ii-1] = Ex_split_interp - Ex_exact;
+          double Ex_split_interp = E_split.interpolate_to_centre_of(
+                  AxialDirection::X, current_cell);
+          double Ex_interp =
+                  E.interpolate_to_centre_of(AxialDirection::X, current_cell)
+                          .real();
+          Ex_error[kk][jj][ii - 1] = Ex_interp - Ex_exact;
+          Ex_split_error[kk][jj][ii - 1] = Ex_split_interp - Ex_exact;
         }
 
         // Ey interpolation
-        if (jj!=0) {
+        if (jj != 0) {
           double Ey_exact = field_component(y_eval_position);// Ey depends on z
-          double Ey_split_interp =
-                  E_split.interpolate_to_centre_of(AxialDirection::Y, current_cell);
-          double Ey_interp = E.interpolate_to_centre_of(AxialDirection::Y, current_cell).real();
-          Ey_error[kk][jj-1][ii] = Ey_interp - Ey_exact;
-          Ey_split_error[kk][jj-1][ii] = Ey_split_interp - Ey_exact;
+          double Ey_split_interp = E_split.interpolate_to_centre_of(
+                  AxialDirection::Y, current_cell);
+          double Ey_interp =
+                  E.interpolate_to_centre_of(AxialDirection::Y, current_cell)
+                          .real();
+          Ey_error[kk][jj - 1][ii] = Ey_interp - Ey_exact;
+          Ey_split_error[kk][jj - 1][ii] = Ey_split_interp - Ey_exact;
         }
 
         // Ez interpolation
-        if (kk!=0) {
+        if (kk != 0) {
           double Ez_exact = field_component(z_eval_position);// Ez depends on x
-          double Ez_split_interp =
-                  E_split.interpolate_to_centre_of(AxialDirection::Z, current_cell);
-          double Ez_interp = E.interpolate_to_centre_of(AxialDirection::Z, current_cell).real();
-          Ez_error[kk-1][jj][ii] = Ez_interp - Ez_exact;
-          Ez_split_error[kk-1][jj][ii] = Ez_split_interp - Ez_exact;
+          double Ez_split_interp = E_split.interpolate_to_centre_of(
+                  AxialDirection::Z, current_cell);
+          double Ez_interp =
+                  E.interpolate_to_centre_of(AxialDirection::Z, current_cell)
+                          .real();
+          Ez_error[kk - 1][jj][ii] = Ez_interp - Ez_exact;
+          Ez_split_error[kk - 1][jj][ii] = Ez_split_interp - Ez_exact;
         }
       }
     }
   }
   // compute error-matrix Frobenius norms
   double Ex_fro_err = Ex_error.frobenius(), Ey_fro_err = Ey_error.frobenius(),
-         Ez_fro_err = Ez_error.frobenius(), Ex_split_fro_err = Ex_split_error.frobenius(),
+         Ez_fro_err = Ez_error.frobenius(),
+         Ex_split_fro_err = Ex_split_error.frobenius(),
          Ey_split_fro_err = Ey_split_error.frobenius(),
          Ez_split_fro_err = Ez_split_error.frobenius();
 
   // compute max-slice errors
-  double Ex_ms_err = 0., Ey_ms_err = 0., Ez_ms_err = 0., Ex_split_ms_err = 0., Ey_split_ms_err = 0.,
-         Ez_split_ms_err = 0.;
+  double Ex_ms_err = 0., Ey_ms_err = 0., Ez_ms_err = 0., Ex_split_ms_err = 0.,
+         Ey_split_ms_err = 0., Ez_split_ms_err = 0.;
   // Ex-slices
   for (int jj = 0; jj < Ny; jj++) {
     for (int kk = 0; kk < Nz; kk++) {
@@ -181,7 +211,9 @@ TEST_CASE("E-field interpolation check") {
              jk_split_slice_error = euclidean(jk_split_errors, Nx - 1);
       // if this exceeds the current recorded maximum error, record this
       if (jk_slice_error > Ex_ms_err) { Ex_ms_err = jk_slice_error; }
-      if (jk_split_slice_error > Ex_split_ms_err) { Ex_split_ms_err = jk_split_slice_error; }
+      if (jk_split_slice_error > Ex_split_ms_err) {
+        Ex_split_ms_err = jk_split_slice_error;
+      }
     }
   }
   // Ey-slices
@@ -195,7 +227,9 @@ TEST_CASE("E-field interpolation check") {
       double ik_slice_error = euclidean(ik_errors, Ny - 1),
              ik_split_slice_error = euclidean(ik_split_errors, Ny - 1);
       if (ik_slice_error > Ey_ms_err) { Ey_ms_err = ik_slice_error; }
-      if (ik_split_slice_error > Ey_split_ms_err) { Ey_split_ms_err = ik_split_slice_error; }
+      if (ik_split_slice_error > Ey_split_ms_err) {
+        Ey_split_ms_err = ik_split_slice_error;
+      }
     }
   }
   // Ez-slices
@@ -209,7 +243,9 @@ TEST_CASE("E-field interpolation check") {
       double ij_slice_error = euclidean(ij_errors, Nz - 1),
              ij_split_slice_error = euclidean(ij_split_errors, Nz - 1);
       if (ij_slice_error > Ez_ms_err) { Ez_ms_err = ij_slice_error; }
-      if (ij_split_slice_error > Ez_split_ms_err) { Ez_split_ms_err = ij_split_slice_error; }
+      if (ij_split_slice_error > Ez_split_ms_err) {
+        Ez_split_ms_err = ij_split_slice_error;
+      }
     }
   }
 
@@ -230,31 +266,36 @@ TEST_CASE("E-field interpolation check") {
   CHECK(is_close_or_better(Ez_split_ms_err, Ez_ms_tol));
 
   // print information to the debugger/log
-  SPDLOG_INFO(" Component | Frobenius err. : (  benchmark   ) | Max-slice err. : (  benchmark   )");
-  SPDLOG_INFO("    x      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ex_fro_err, Ex_fro_tol,
-              Ex_ms_err, Ex_ms_tol);
-  SPDLOG_INFO("    y      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ey_fro_err, Ey_fro_tol,
-              Ey_ms_err, Ey_ms_tol);
-  SPDLOG_INFO("    z      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ez_fro_err, Ez_fro_tol,
-              Ez_ms_err, Ez_ms_tol);
-  SPDLOG_INFO(" [Split] Component | Frobenius err. : (  benchmark   ) | Max-slice err. : (  "
+  SPDLOG_INFO(" Component | Frobenius err. : (  benchmark   ) | Max-slice err. "
+              ": (  benchmark   )");
+  SPDLOG_INFO("    x      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ex_fro_err, Ex_fro_tol, Ex_ms_err, Ex_ms_tol);
+  SPDLOG_INFO("    y      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ey_fro_err, Ey_fro_tol, Ey_ms_err, Ey_ms_tol);
+  SPDLOG_INFO("    z      | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ez_fro_err, Ez_fro_tol, Ez_ms_err, Ez_ms_tol);
+  SPDLOG_INFO(" [Split] Component | Frobenius err. : (  benchmark   ) | "
+              "Max-slice err. : (  "
               "benchmark   )");
-  SPDLOG_INFO("        x          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ex_split_fro_err,
-              Ex_fro_tol, Ex_split_ms_err, Ex_ms_tol);
-  SPDLOG_INFO("        y          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ey_split_fro_err,
-              Ey_fro_tol, Ey_split_ms_err, Ey_ms_tol);
-  SPDLOG_INFO("        z          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})", Ez_split_fro_err,
-              Ez_fro_tol, Ez_split_ms_err, Ez_ms_tol);
+  SPDLOG_INFO("        x          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ex_split_fro_err, Ex_fro_tol, Ex_split_ms_err, Ex_ms_tol);
+  SPDLOG_INFO("        y          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ey_split_fro_err, Ey_fro_tol, Ey_split_ms_err, Ey_ms_tol);
+  SPDLOG_INFO("        z          | {0:.8e} : ({1:.8e}) | {2:.8e} : ({3:.8e})",
+              Ez_split_fro_err, Ez_fro_tol, Ez_split_ms_err, Ez_ms_tol);
 }
 
 /**
- * @brief Test the interpolation of the H-field components to the centre of the Yee cells
+ * @brief Test the interpolation of the H-field components to the centre of the
+ * Yee cells
  *
  * Each component of the H-field will take the form
  * H_t(tt) = sin(2\pi tt) * exp(-tt^2)
- * The decision to make this function wholey imaginary is just to test whether the imaginary part of the field is correctly picked up and worked with.
+ * The decision to make this function wholey imaginary is just to test whether
+ * the imaginary part of the field is correctly picked up and worked with.
  *
- * We only test Fro-norm error metrics, since interpolation must occur along two axes for each component.
+ * We only test Fro-norm error metrics, since interpolation must occur along two
+ * axes for each component.
  */
 TEST_CASE("H-field interpolation check") {
   SPDLOG_INFO("===== Testing H-field BLi =====");
@@ -269,7 +310,8 @@ TEST_CASE("H-field interpolation check") {
   double extent_x = 4., extent_y = 4., extent_z = 4.;
   double cellDims[3] = {0.1, 0.05, 0.025};
   // The number of cells in each direction is then 40, 80,  160 respectively
-  // Note that due to the possibility that Nx/cellDims[0] computing something that is not quite an integer, we need to use round() to get an int safely
+  // Note that due to the possibility that Nx/cellDims[0] computing something
+  // that is not quite an integer, we need to use round() to get an int safely
   int Nx = round(extent_x / cellDims[0]), Ny = round(extent_y / cellDims[1]),
       Nz = round(extent_z / cellDims[2]);
 
@@ -277,24 +319,27 @@ TEST_CASE("H-field interpolation check") {
   MagneticSplitField H_split(Nx - 1, Ny - 1, Nz - 1);
   H_split.allocate();// alocates Nx, Ny, Nz memory space here
   // setup the non-split field components
-  H_split.tot += 1; // correct the "number of datapoints" variable for these fields
+  H_split.tot +=
+          1;// correct the "number of datapoints" variable for these fields
   MagneticField H(Nx, Ny, Nz);
   H.allocate();
 
   /* Compute the exact field and the "split field" components
-  Hx_exact[k-1][j-1][i] is the value of the field at position (x_lower,y_lower,z_lower) + (i+0.5,j,k)*cellDims
-  Hy_exact[k-1][j][i-1] is the value of the field at position (x_lower,y_lower,z_lower) + (i,j+0.5,k)*cellDims
-  Hz_exact[k][j-1][i-1] is the value of the field at position (x_lower,y_lower,z_lower) + (i,j,k+0.5)*cellDims
+  Hx_exact[k-1][j-1][i] is the value of the field at position
+  (x_lower,y_lower,z_lower) + (i+0.5,j,k)*cellDims Hy_exact[k-1][j][i-1] is the
+  value of the field at position (x_lower,y_lower,z_lower) +
+  (i,j+0.5,k)*cellDims Hz_exact[k][j-1][i-1] is the value of the field at
+  position (x_lower,y_lower,z_lower) + (i,j,k+0.5)*cellDims
   */
   for (int ii = 0; ii < Nx; ii++) {
     for (int jj = 0; jj < Ny; jj++) {
       for (int kk = 0; kk < Nz; kk++) {
-        double x_comp_value =
-                field_component(y_lower + ((double) jj + 1.) * cellDims[1]);// Hx depends on y
-        double y_comp_value =
-                field_component(z_lower + ((double) kk + 1.) * cellDims[2]);// Hy depends on z
-        double z_comp_value =
-                field_component(x_lower + ((double) ii + 1.) * cellDims[0]);// Hz depends on x
+        double x_comp_value = field_component(
+                y_lower + ((double) jj + 1.) * cellDims[1]);// Hx depends on y
+        double y_comp_value = field_component(
+                z_lower + ((double) kk + 1.) * cellDims[2]);// Hy depends on z
+        double z_comp_value = field_component(
+                x_lower + ((double) ii + 1.) * cellDims[0]);// Hz depends on x
         // assign to "freq domain" ElectricField
         H.imag.x[kk][jj][ii] = x_comp_value;
         H.real.x[kk][jj][ii] = 0.;
@@ -302,7 +347,8 @@ TEST_CASE("H-field interpolation check") {
         H.real.y[kk][jj][ii] = 0.;
         H.imag.z[kk][jj][ii] = z_comp_value;
         H.real.z[kk][jj][ii] = 0.;
-        // assign to "time domain" ElectricSplitField - use weighting that sums to 1 to check addition is behaving as planned
+        // assign to "time domain" ElectricSplitField - use weighting that sums
+        // to 1 to check addition is behaving as planned
         H_split.xy[kk][jj][ii] = x_comp_value;
         H_split.xz[kk][jj][ii] = 0.;
         H_split.yx[kk][jj][ii] = y_comp_value * .25;
@@ -313,12 +359,17 @@ TEST_CASE("H-field interpolation check") {
     }
   }
 
-  /* In each axis, we will now interpolate to positions 1 through N{x,y,z}-1. Recall this means to the midpoint of the datapoints indexed by 0 and 1, then 1 and 2, ..., N{x,y,z}-3 and N{x,y,z}-2, and finally N{x,y,z}-2 and N{x,y,z}-1.
-  Ex_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
-  Ey_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
-  Ez_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
+  /* In each axis, we will now interpolate to positions 1 through N{x,y,z}-1.
+  Recall this means to the midpoint of the datapoints indexed by 0 and 1, then 1
+  and 2, ..., N{x,y,z}-3 and N{x,y,z}-2, and finally N{x,y,z}-2 and N{x,y,z}-1.
+  Ex_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower)
+  + (i+0.5,j+0.5,k+0.5)*cellDims Ey_exact[k][j][i] is the field component at
+  position (x_lower,y_lower,z_lower) + (i+0.5,j+0.5,k+0.5)*cellDims
+  Ez_exact[k][j][i] is the field component at position (x_lower,y_lower,z_lower)
+  + (i+0.5,j+0.5,k+0.5)*cellDims
   */
-  Tensor3D<double> Hx_error, Hx_split_error, Hy_error, Hy_split_error, Hz_error, Hz_split_error;
+  Tensor3D<double> Hx_error, Hx_split_error, Hy_error, Hy_split_error, Hz_error,
+          Hz_split_error;
   Hx_error.allocate(Nz - 1, Ny - 1, Nx);
   Hx_split_error.allocate(Nz - 1, Ny - 1, Nx);
   Hy_error.allocate(Nz - 1, Ny, Nx - 1);
@@ -327,7 +378,8 @@ TEST_CASE("H-field interpolation check") {
   Hz_split_error.allocate(Nz, Ny - 1, Nx - 1);
 
   // now interpolate
-  // note that we aren't interpolating to position 0 (before 1st point) or N{x,y,z} (after last point)
+  // note that we aren't interpolating to position 0 (before 1st point) or
+  // N{x,y,z} (after last point)
   for (int ii = 0; ii < Nx; ii++) {
     for (int jj = 0; jj < Ny; jj++) {
       for (int kk = 0; kk < Nz; kk++) {
@@ -336,43 +388,48 @@ TEST_CASE("H-field interpolation check") {
         double y_eval_position = z_lower + ((double) kk + 0.5) * cellDims[2];
         double z_eval_position = x_lower + ((double) ii + 0.5) * cellDims[0];
         // current cell index
-        CellCoordinate current_cell {ii, jj, kk};
+        CellCoordinate current_cell{ii, jj, kk};
 
         // Hx interpolation
         if (jj != 0 && kk != 0) {
           double Hx_exact = field_component(x_eval_position);// Hx depends on y
-          double Hx_split_interp =
-                  H_split.interpolate_to_centre_of(AxialDirection::X, current_cell);
-          double Hx_interp = H.interpolate_to_centre_of(AxialDirection::X, current_cell).imag();
-          Hx_error[kk-1][jj-1][ii] = Hx_interp - Hx_exact;
-          Hx_split_error[kk-1][jj-1][ii] = Hx_split_interp - Hx_exact;
+          double Hx_split_interp = H_split.interpolate_to_centre_of(
+                  AxialDirection::X, current_cell);
+          double Hx_interp =
+                  H.interpolate_to_centre_of(AxialDirection::X, current_cell)
+                          .imag();
+          Hx_error[kk - 1][jj - 1][ii] = Hx_interp - Hx_exact;
+          Hx_split_error[kk - 1][jj - 1][ii] = Hx_split_interp - Hx_exact;
         }
 
         // Hy interpolation
         if (ii != 0 && kk != 0) {
           double Hy_exact = field_component(y_eval_position);// Hy depends on z
-          double Hy_split_interp =
-                  H_split.interpolate_to_centre_of(AxialDirection::Y, current_cell);
-          double Hy_interp = H.interpolate_to_centre_of(AxialDirection::Y, current_cell).imag();
-          Hy_error[kk-1][jj][ii-1] = Hy_interp - Hy_exact;
-          Hy_split_error[kk-1][jj][ii-1] = Hy_split_interp - Hy_exact;
+          double Hy_split_interp = H_split.interpolate_to_centre_of(
+                  AxialDirection::Y, current_cell);
+          double Hy_interp =
+                  H.interpolate_to_centre_of(AxialDirection::Y, current_cell)
+                          .imag();
+          Hy_error[kk - 1][jj][ii - 1] = Hy_interp - Hy_exact;
+          Hy_split_error[kk - 1][jj][ii - 1] = Hy_split_interp - Hy_exact;
         }
 
         // Hz interpolation
         if (ii != 0 && jj != 0) {
           double Hz_exact = field_component(z_eval_position);// Hz depends on x
-          double Hz_split_interp =
-                  H_split.interpolate_to_centre_of(AxialDirection::Z, current_cell);
-          double Hz_interp = H.interpolate_to_centre_of(AxialDirection::Z, current_cell).imag();
-          Hz_error[kk][jj-1][ii-1] = Hz_interp - Hz_exact;
-          Hz_split_error[kk][jj-1][ii-1] = Hz_split_interp - Hz_exact;
+          double Hz_split_interp = H_split.interpolate_to_centre_of(
+                  AxialDirection::Z, current_cell);
+          double Hz_interp =
+                  H.interpolate_to_centre_of(AxialDirection::Z, current_cell)
+                          .imag();
+          Hz_error[kk][jj - 1][ii - 1] = Hz_interp - Hz_exact;
+          Hz_split_error[kk][jj - 1][ii - 1] = Hz_split_interp - Hz_exact;
         }
       }
     }
   }
   // compute Frobenius norms
-  double Hx_fro_err = Hx_error.frobenius(),
-         Hy_fro_err = Hy_error.frobenius(),
+  double Hx_fro_err = Hx_error.frobenius(), Hy_fro_err = Hy_error.frobenius(),
          Hz_fro_err = Hz_error.frobenius(),
          Hx_split_fro_err = Hx_split_error.frobenius(),
          Hy_split_fro_err = Hy_split_error.frobenius(),
@@ -392,7 +449,10 @@ TEST_CASE("H-field interpolation check") {
   SPDLOG_INFO("    y      | {0:.8e} : ({1:.8e})", Hy_fro_err, Hy_fro_tol);
   SPDLOG_INFO("    z      | {0:.8e} : ({1:.8e})", Hz_fro_err, Hz_fro_tol);
   SPDLOG_INFO(" [Split] Component | Frobenius err. : (  benchmark   )");
-  SPDLOG_INFO("        x          | {0:.8e} : ({1:.8e})", Hx_split_fro_err, Hx_fro_tol);
-  SPDLOG_INFO("        y          | {0:.8e} : ({1:.8e})", Hy_split_fro_err, Hy_fro_tol);
-  SPDLOG_INFO("        z          | {0:.8e} : ({1:.8e})", Hz_split_fro_err, Hz_fro_tol);
+  SPDLOG_INFO("        x          | {0:.8e} : ({1:.8e})", Hx_split_fro_err,
+              Hx_fro_tol);
+  SPDLOG_INFO("        y          | {0:.8e} : ({1:.8e})", Hy_split_fro_err,
+              Hy_fro_tol);
+  SPDLOG_INFO("        z          | {0:.8e} : ({1:.8e})", Hz_split_fro_err,
+              Hz_fro_tol);
 }

--- a/tdms/tests/unit/field_tests/test_SplitField.cpp
+++ b/tdms/tests/unit/field_tests/test_SplitField.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_SplitField.cpp
- * @brief Unit tests for the SplitField class and its subclasses (ElectricSplitField, MagneticSplitField)
+ * @brief Unit tests for the SplitField class and its subclasses
+ * (ElectricSplitField, MagneticSplitField)
  */
 #include "field.h"
 
@@ -10,16 +11,18 @@
 
 using tdms_tests::is_close;
 
-// NOTE: MagneticSplitField and ElectricSplitField inherit these methods from SplitField, so we can use either here
+// NOTE: MagneticSplitField and ElectricSplitField inherit these methods from
+// SplitField, so we can use either here
 
 TEST_CASE("SplitField: allocate and zero") {
 
   ElectricSplitField field(2, 1, 0);
   field.allocate_and_zero();
 
-  bool all_components_have_elements = field.xy.has_elements() && field.xz.has_elements() &&
-                                      field.yx.has_elements() && field.yz.has_elements() &&
-                                      field.zx.has_elements() && field.zy.has_elements();
+  bool all_components_have_elements =
+          field.xy.has_elements() && field.xz.has_elements() &&
+          field.yx.has_elements() && field.yz.has_elements() &&
+          field.zx.has_elements() && field.zy.has_elements();
   REQUIRE(all_components_have_elements);
 
   // NOTE: the allocated field is actually [I_tot+1, J_tot+1, K_tot+1] in size

--- a/tdms/tests/unit/matlab_benchmark_scripts/.clang-format
+++ b/tdms/tests/unit/matlab_benchmark_scripts/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
+++ b/tdms/tests/unit/test_BLi_vs_cubic_interpolation.cpp
@@ -1,7 +1,8 @@
 /**
  * @file test_BLi_vs_cubic_interpolation.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests the performance of band-limited interpolation against cubic interpolation
+ * @brief Tests the performance of band-limited interpolation against cubic
+ * interpolation
  */
 #include "interpolation_methods.h"
 
@@ -14,121 +15,140 @@
 #include "unit_test_utils.h"
 
 using namespace std;
-using tdms_tests::order_of_magnitude;
 using tdms_tests::euclidean;
+using tdms_tests::order_of_magnitude;
 
 // function to interpolate
-inline double f_BLi_vs_Cubic(double x) {
-    return 1. / ((10. * x * x) + 1.);
-}
+inline double f_BLi_vs_Cubic(double x) { return 1. / ((10. * x * x) + 1.); }
 
 /**
- * @brief We will check that BLi gives a better approximation than cubic interpolation.
+ * @brief We will check that BLi gives a better approximation than cubic
+ * interpolation.
  *
  * The metric we will use is the norm of the error-vector.
- * As the cell-size becomes larger (across the same domain), BLi should begin to perform better than cubic interpolation.
+ * As the cell-size becomes larger (across the same domain), BLi should begin to
+ * perform better than cubic interpolation.
  *
- * For the following cell sizes, over the range -2 to 2, and for the function f(x) = 1/(10x^2+1), MATLAB predicts the following errors:
- * Cell size    | BLi err           | Cubic err
- *  0.25        | 1.25953429e-02    | 3.28105674e-02
- *  0.1         | 7.10587711e-04    | 5.49601748e-03
- *  0.05        | 7.80325615e-04    | 5.53430587e-04
- *  0.01        | 1.97562511e-03    | 2.06917814e-06
- * Values computed via the benchmark_test_BLi_vs_cubic.m script.
+ * For the following cell sizes, over the range -2 to 2, and for the function
+ * f(x) = 1/(10x^2+1), MATLAB predicts the following errors: Cell size    | BLi
+ * err           | Cubic err 0.25 | 1.25953429e-02    | 3.28105674e-02 0.1
+ * | 7.10587711e-04    | 5.49601748e-03 0.05 | 7.80325615e-04 | 5.53430587e-04
+ * 0.01        | 1.97562511e-03    | 2.06917814e-06 Values computed via the
+ * benchmark_test_BLi_vs_cubic.m script.
  *
  * We will test the following:
  * - The norm-error of BLi is lesser/greater than cubic in each case
- * - The order of the magnitude (of BOTH) errors is the same as that obtained from MATLAB (for validation reasons)
+ * - The order of the magnitude (of BOTH) errors is the same as that obtained
+ * from MATLAB (for validation reasons)
  */
 TEST_CASE("Benchmark: BLi is better than cubic interpolation") {
-    SPDLOG_INFO("===== Benchmarking BLi against cubic interpolation =====");
-    // number of cell sizes to test at
-    const int n_trials = 4;
-    // Yee cell sizes to test across
-    double cell_sizes[n_trials] = {0.25, 0.1, 0.05, 0.01};
-    // Flags for whether or not we expect BLi to perform better
-    bool BLi_is_better[n_trials] = {true, true, false, false};
-    // MATLAB errors for BLi
-    double MATLAB_BLi_errs[n_trials] = {1.25953429e-02, 7.10587711e-04, 7.80325615e-04,
-                                        1.97562511e-03};
-    // MATLAB errors for cubic interp
-    double MATLAB_cub_errs[n_trials] = {3.28105674e-02, 5.49601748e-03, 5.53430587e-04,
-                                        2.06917814e-06};
-    // coordinate of the LHS of the first Yee cell
-    double x_lower = -2.;
-    // spatial extent of the domain will be [x_lower, x_lower+extent]
-    double extent = 4.;
-    // norm errors recorded across runs
-    double BLi_norm_errs[n_trials], cub_norm_errs[n_trials];
+  SPDLOG_INFO("===== Benchmarking BLi against cubic interpolation =====");
+  // number of cell sizes to test at
+  const int n_trials = 4;
+  // Yee cell sizes to test across
+  double cell_sizes[n_trials] = {0.25, 0.1, 0.05, 0.01};
+  // Flags for whether or not we expect BLi to perform better
+  bool BLi_is_better[n_trials] = {true, true, false, false};
+  // MATLAB errors for BLi
+  double MATLAB_BLi_errs[n_trials] = {1.25953429e-02, 7.10587711e-04,
+                                      7.80325615e-04, 1.97562511e-03};
+  // MATLAB errors for cubic interp
+  double MATLAB_cub_errs[n_trials] = {3.28105674e-02, 5.49601748e-03,
+                                      5.53430587e-04, 2.06917814e-06};
+  // coordinate of the LHS of the first Yee cell
+  double x_lower = -2.;
+  // spatial extent of the domain will be [x_lower, x_lower+extent]
+  double extent = 4.;
+  // norm errors recorded across runs
+  double BLi_norm_errs[n_trials], cub_norm_errs[n_trials];
 
-    for (int trial = 0; trial < n_trials; trial++) {
-        // Yee cell "size" to use
-        double cellSize = cell_sizes[trial];
-        // the number of datapoints that we have, the number of "cells" we have is one less than this
-        int n_datapts = round(extent / cellSize);
-        CHECK(n_datapts > 8); // BLi cannot run otherwise
+  for (int trial = 0; trial < n_trials; trial++) {
+    // Yee cell "size" to use
+    double cellSize = cell_sizes[trial];
+    // the number of datapoints that we have, the number of "cells" we have is
+    // one less than this
+    int n_datapts = round(extent / cellSize);
+    CHECK(n_datapts > 8);// BLi cannot run otherwise
 
-        // the centres of the Yee cells
-        double cell_centres[n_datapts - 1];
-        // the exact field values at the Yee cell centres
-        double exact_field_values[n_datapts - 1];
-        // the spatial coordinates of the samples of our field
-        double field_positions[n_datapts];
-        // the field values at the sample positions
-        double field_samples[n_datapts];
-        for (int i = 0; i < n_datapts; i++) {
-          if (i != n_datapts - 1) { cell_centres[i] = x_lower + (((double) i) + 0.5) * cellSize; }
-          field_positions[i] = x_lower + ((double) i) * cellSize;
+    // the centres of the Yee cells
+    double cell_centres[n_datapts - 1];
+    // the exact field values at the Yee cell centres
+    double exact_field_values[n_datapts - 1];
+    // the spatial coordinates of the samples of our field
+    double field_positions[n_datapts];
+    // the field values at the sample positions
+    double field_samples[n_datapts];
+    for (int i = 0; i < n_datapts; i++) {
+      if (i != n_datapts - 1) {
+        cell_centres[i] = x_lower + (((double) i) + 0.5) * cellSize;
+      }
+      field_positions[i] = x_lower + ((double) i) * cellSize;
 
-          exact_field_values[i] = f_BLi_vs_Cubic(cell_centres[i]);
-          field_samples[i] = f_BLi_vs_Cubic(field_positions[i]);
-        }
-
-        // the interpolated field values via BLi
-        double BLi_interp[n_datapts - 1];
-        // the interpolated field values via cubic interp
-        double cub_interp[n_datapts - 1];
-
-        // pointwise-interpolation error in BLi
-        double BLi_err[n_datapts - 1];
-        // pointwise-interpolation error in cubic
-        double cub_err[n_datapts - 1];
-
-        // perform interpolation - this is manual since best_interp_scheme will always want to do BLi
-        // cubic interpolation only changes at the first and last cells
-        cub_interp[0] = CBFst.interpolate(field_samples);
-        for (int i = 1; i < n_datapts - 2; i++) {
-            cub_interp[i] = CBMid.interpolate(field_samples, i + 1 - CBMid.number_of_datapoints_to_left);
-        }
-        cub_interp[n_datapts - 2] = CBLst.interpolate(field_samples, n_datapts - 1 - CBLst.number_of_datapoints_to_left);
-
-        // BLi interpolation
-        for (int i = 0; i < n_datapts - 1; i++) {
-            // we checked earlier that BLi should always be available, so this is always a BLi scheme
-            InterpolationScheme use_scheme = best_scheme(n_datapts - 1, i);
-            // to be on the safe side, check that we have a BLi scheme. BLi schemes are always strictly better than CUBIC_INTERP_MIDDLE, and not equal or worse.
-            CHECK(use_scheme.is_better_than(CUBIC_INTERP_MIDDLE));
-            // interpolate using the cell data we have provided
-            // i + 1 - use_scheme.number_of_datapoints_to_left is the index of field_samples to read as the point v[0] in the schemes
-            BLi_interp[i] = use_scheme.interpolate(field_samples, i + 1 - use_scheme.number_of_datapoints_to_left);
-        }
-
-        // compare to exact values - again ignore cell 0 for the time being
-        for (int i = 0; i < n_datapts - 1; i++) {
-            BLi_err[i] = abs(BLi_interp[i] - exact_field_values[i]);
-            cub_err[i] = abs(cub_interp[i] - exact_field_values[i]);
-        }
-        // compute square-norm error
-        BLi_norm_errs[trial] = euclidean(BLi_err, n_datapts - 2);
-        cub_norm_errs[trial] = euclidean(cub_err, n_datapts - 2);
-
-        // value-testing commences: the better method should be superior, and the worse method should be worse.
-        // assert this is the case for each cellSize we used.
-        CHECK((BLi_norm_errs[trial] <= cub_norm_errs[trial]) == BLi_is_better[trial]);
-        SPDLOG_INFO("BLi err: {0:.8e} | Cubic err : {1:.8e} | Expected BLi to be better: {2:d}", BLi_norm_errs[trial], cub_norm_errs[trial], BLi_is_better[trial]);
-
-        // in all cases, assert that the order of magnitude of error is what we expect, if we had used MATLAB
-        CHECK(order_of_magnitude(BLi_norm_errs[trial]) == order_of_magnitude(MATLAB_BLi_errs[trial]));
-        CHECK(order_of_magnitude(cub_norm_errs[trial]) == order_of_magnitude(MATLAB_cub_errs[trial]));
+      exact_field_values[i] = f_BLi_vs_Cubic(cell_centres[i]);
+      field_samples[i] = f_BLi_vs_Cubic(field_positions[i]);
     }
+
+    // the interpolated field values via BLi
+    double BLi_interp[n_datapts - 1];
+    // the interpolated field values via cubic interp
+    double cub_interp[n_datapts - 1];
+
+    // pointwise-interpolation error in BLi
+    double BLi_err[n_datapts - 1];
+    // pointwise-interpolation error in cubic
+    double cub_err[n_datapts - 1];
+
+    // perform interpolation - this is manual since best_interp_scheme will
+    // always want to do BLi cubic interpolation only changes at the first and
+    // last cells
+    cub_interp[0] = CBFst.interpolate(field_samples);
+    for (int i = 1; i < n_datapts - 2; i++) {
+      cub_interp[i] = CBMid.interpolate(
+              field_samples, i + 1 - CBMid.number_of_datapoints_to_left);
+    }
+    cub_interp[n_datapts - 2] = CBLst.interpolate(
+            field_samples, n_datapts - 1 - CBLst.number_of_datapoints_to_left);
+
+    // BLi interpolation
+    for (int i = 0; i < n_datapts - 1; i++) {
+      // we checked earlier that BLi should always be available, so this is
+      // always a BLi scheme
+      InterpolationScheme use_scheme = best_scheme(n_datapts - 1, i);
+      // to be on the safe side, check that we have a BLi scheme. BLi schemes
+      // are always strictly better than CUBIC_INTERP_MIDDLE, and not equal or
+      // worse.
+      CHECK(use_scheme.is_better_than(CUBIC_INTERP_MIDDLE));
+      // interpolate using the cell data we have provided
+      // i + 1 - use_scheme.number_of_datapoints_to_left is the index of
+      // field_samples to read as the point v[0] in the schemes
+      BLi_interp[i] = use_scheme.interpolate(
+              field_samples, i + 1 - use_scheme.number_of_datapoints_to_left);
+    }
+
+    // compare to exact values - again ignore cell 0 for the time being
+    for (int i = 0; i < n_datapts - 1; i++) {
+      BLi_err[i] = abs(BLi_interp[i] - exact_field_values[i]);
+      cub_err[i] = abs(cub_interp[i] - exact_field_values[i]);
+    }
+    // compute square-norm error
+    BLi_norm_errs[trial] = euclidean(BLi_err, n_datapts - 2);
+    cub_norm_errs[trial] = euclidean(cub_err, n_datapts - 2);
+
+    // value-testing commences: the better method should be superior, and the
+    // worse method should be worse. assert this is the case for each cellSize
+    // we used.
+    CHECK((BLi_norm_errs[trial] <= cub_norm_errs[trial]) ==
+          BLi_is_better[trial]);
+    SPDLOG_INFO("BLi err: {0:.8e} | Cubic err : {1:.8e} | Expected BLi to be "
+                "better: {2:d}",
+                BLi_norm_errs[trial], cub_norm_errs[trial],
+                BLi_is_better[trial]);
+
+    // in all cases, assert that the order of magnitude of error is what we
+    // expect, if we had used MATLAB
+    CHECK(order_of_magnitude(BLi_norm_errs[trial]) ==
+          order_of_magnitude(MATLAB_BLi_errs[trial]));
+    CHECK(order_of_magnitude(cub_norm_errs[trial]) ==
+          order_of_magnitude(MATLAB_cub_errs[trial]));
+  }
 }

--- a/tdms/tests/unit/test_FieldSample.cpp
+++ b/tdms/tests/unit/test_FieldSample.cpp
@@ -19,8 +19,9 @@ void FieldSampleTest::test_empty_construction() {
   // attempt construction
   FieldSample empty_fs(matlab_input);
   // should still be unassigned vectors
-  bool no_vectors_set = (!empty_fs.i.has_elements()) && (!empty_fs.j.has_elements()) &&
-                        (!empty_fs.k.has_elements()) && (!empty_fs.n.has_elements());
+  bool no_vectors_set =
+          (!empty_fs.i.has_elements()) && (!empty_fs.j.has_elements()) &&
+          (!empty_fs.k.has_elements()) && (!empty_fs.n.has_elements());
   REQUIRE(no_vectors_set);
 }
 
@@ -33,7 +34,8 @@ void FieldSampleTest::test_wrong_input_type() {
 
 void FieldSampleTest::test_incorrect_number_of_fields() {
   SECTION("Struct with too many fields") {
-    const char *too_many_names[5] = {"field1", "field2", "field3", "field4", "field5"};
+    const char *too_many_names[5] = {"field1", "field2", "field3", "field4",
+                                     "field5"};
     create_1by1_struct(5, too_many_names);
     CHECK_THROWS_AS(FieldSample(matlab_input), runtime_error);
   }
@@ -49,17 +51,18 @@ void FieldSampleTest::test_correct_construction() {
     // create the struct
     create_1by1_struct(n_fields, fieldnames);
     // create vectors to place in the fields of the struct
-    mxArray *i_vector =
-            mxCreateNumericArray(2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *j_vector =
-            mxCreateNumericArray(2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *k_vector =
-            mxCreateNumericArray(2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
-    mxArray *n_vector =
-            mxCreateNumericArray(2, (const mwSize *) vector_dimensions, mxDOUBLE_CLASS, mxREAL);
+    mxArray *i_vector = mxCreateNumericArray(
+            2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *j_vector = mxCreateNumericArray(
+            2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *k_vector = mxCreateNumericArray(
+            2, (const mwSize *) vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *n_vector = mxCreateNumericArray(
+            2, (const mwSize *) vector_dimensions, mxDOUBLE_CLASS, mxREAL);
     // populate the vectors with some information
     mxDouble *place_i_data = mxGetPr(i_vector);//< 0,1,2,...
-    mxDouble *place_j_data = mxGetPr(j_vector);//< number_of_vector_elements-1, -2, -3...
+    mxDouble *place_j_data =
+            mxGetPr(j_vector);//< number_of_vector_elements-1, -2, -3...
     mxDouble *place_k_data = mxGetPr(k_vector);//< 0,1,2,...,N/2,0,1,2,...
     mxDouble *place_n_data = mxGetPr(n_vector);//< 1, 1/2, 1/3, ...
     for (int i = 0; i < 4; i++) {
@@ -88,20 +91,22 @@ void FieldSampleTest::test_correct_construction() {
     }
   }
 
-  // alternatively, we can pass in empty vectors to the constructor and it should create an empty 4D tensor
+  // alternatively, we can pass in empty vectors to the constructor and it
+  // should create an empty 4D tensor
   SECTION("Expected inputs (empty vectors)") {
     const int empty_vector_dimensions[2] = {1, 0};
     // create the struct
     create_1by1_struct(n_fields, fieldnames);
     // create vectors to place in the fields of the struct
-    mxArray *empty_i_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
-                                                   mxINT32_CLASS, mxREAL);
-    mxArray *empty_j_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
-                                                   mxINT32_CLASS, mxREAL);
-    mxArray *empty_k_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
-                                                   mxINT32_CLASS, mxREAL);
-    mxArray *empty_n_vector = mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
-                                                   mxDOUBLE_CLASS, mxREAL);
+    mxArray *empty_i_vector = mxCreateNumericArray(
+            2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *empty_j_vector = mxCreateNumericArray(
+            2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *empty_k_vector = mxCreateNumericArray(
+            2, (const mwSize *) empty_vector_dimensions, mxINT32_CLASS, mxREAL);
+    mxArray *empty_n_vector =
+            mxCreateNumericArray(2, (const mwSize *) empty_vector_dimensions,
+                                 mxDOUBLE_CLASS, mxREAL);
     mxSetField(matlab_input, 0, fieldnames[0], empty_i_vector);
     mxSetField(matlab_input, 0, fieldnames[1], empty_j_vector);
     mxSetField(matlab_input, 0, fieldnames[2], empty_k_vector);
@@ -112,11 +117,10 @@ void FieldSampleTest::test_correct_construction() {
     // check that all vectors are empty flags as being true
     CHECK(!fs_from_empty_vectors.all_vectors_are_non_empty());
     // check that the tensor attribute is the correct size
-    const mwSize *empty_tensor_dimensions = mxGetDimensions(fs_from_empty_vectors.mx);
+    const mwSize *empty_tensor_dimensions =
+            mxGetDimensions(fs_from_empty_vectors.mx);
     for (int i = 0; i < 4; i++) { CHECK(empty_tensor_dimensions[i] == 0); }
   }
 }
 
-TEST_CASE("FieldSample") {
-  FieldSampleTest().run_all_class_tests();
-}
+TEST_CASE("FieldSample") { FieldSampleTest().run_all_class_tests(); }

--- a/tdms/tests/unit/test_VertexPhasors.cpp
+++ b/tdms/tests/unit/test_VertexPhasors.cpp
@@ -7,8 +7,8 @@
 #include <spdlog/spdlog.h>
 
 #include "array_test_class.h"
-#include "vertex_phasors.h"
 #include "globals.h"
+#include "vertex_phasors.h"
 
 using namespace std;
 
@@ -16,9 +16,10 @@ void VertexPhasorsTest::test_empty_construction() {
   create_empty_struct();
   CHECK_NOTHROW(VertexPhasors(matlab_input));
   VertexPhasors empty_test(matlab_input);
-  // n_vertices should return 0, since Vector has not been set so should default initialise to 0-vertex matrix
-  // vector & components should be flagged as having no elements
-  // the object should also flag that there are no vertices to extract at (since there are 0 vertices listed)
+  // n_vertices should return 0, since Vector has not been set so should default
+  // initialise to 0-vertex matrix vector & components should be flagged as
+  // having no elements the object should also flag that there are no vertices
+  // to extract at (since there are 0 vertices listed)
   CHECK(empty_test.n_vertices() == 0);
   CHECK(!empty_test.there_are_vertices_to_extract_at());
   CHECK(!empty_test.there_are_elements_in_arrays());
@@ -32,9 +33,11 @@ void VertexPhasorsTest::test_correct_construction() {
   create_struct_array(2, dimensions_2d, 2, fieldnames);
   // each entry is a numeric array, setup for vertices and components
   // array for "vertices" field
-  mxArray *vertices_array = mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
+  mxArray *vertices_array =
+          mxCreateNumericMatrix(n_numeric_elements, 3, mxINT32_CLASS, mxREAL);
   // array for "components" field
-  mxArray *components_vector = mxCreateNumericMatrix(1, n_components, mxINT16_CLASS, mxREAL);
+  mxArray *components_vector =
+          mxCreateNumericMatrix(1, n_components, mxINT16_CLASS, mxREAL);
   // add fields to struct that will be passed to CAS constructor function
   mxSetField(matlab_input, 0, fieldnames[0], vertices_array);
   mxSetField(matlab_input, 0, fieldnames[1], components_vector);

--- a/tdms/tests/unit/test_interpolation_determination.cpp
+++ b/tdms/tests/unit/test_interpolation_determination.cpp
@@ -1,7 +1,8 @@
 /**
  * @file test_interpolation_determination.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests the logic that determines which interpolation schemes are appropriate.
+ * @brief Tests the logic that determines which interpolation schemes are
+ * appropriate.
  */
 #include "interpolation_methods.h"
 
@@ -11,21 +12,25 @@
 using namespace std;
 
 /**
- * @brief Test whether best_scheme correctly determines the appropriate interpolation scheme to use, given the number of Yee cells either side of cell (i,j,k)
+ * @brief Test whether best_scheme correctly determines the appropriate
+ * interpolation scheme to use, given the number of Yee cells either side of
+ * cell (i,j,k)
  *
  */
 TEST_CASE("best_interp_scheme: correct interpolation chosen") {
   int N = 10;
   bool all_schemes_correct = true;
 
-  // should throw out_of_range exception if interpolation is impossible (<3 Yee cells in direction)
+  // should throw out_of_range exception if interpolation is impossible (<3 Yee
+  // cells in direction)
   SECTION("Too few cells to interpolate") {
     REQUIRE_THROWS_AS(best_scheme(1, 0), out_of_range);
     REQUIRE_THROWS_AS(best_scheme(2, 0), out_of_range);
     REQUIRE_THROWS_AS(best_scheme(2, 1), out_of_range);
   }
 
-  /* Suppose we have N >= 8 Yee cells in a dimension. The program should determine:
+  /* Suppose we have N >= 8 Yee cells in a dimension. The program should
+    determine:
     - cell_id <  0 : Interpolation impossible
     - cell_id == 0 : BAND_LIMITED_CELL_ZERO
     - cell_id == 1,2,3 : Use BAND_LIMITED_(0,1,2) scheme respectively
@@ -38,30 +43,36 @@ TEST_CASE("best_interp_scheme: correct interpolation chosen") {
 
     REQUIRE_THROWS_AS(best_scheme(N, -1), out_of_range);
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 0).get_priority() == BAND_LIMITED_CELL_ZERO);
-    all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 1).get_priority() == BAND_LIMITED_0);
-    all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 2).get_priority() == BAND_LIMITED_1);
-    all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 3).get_priority() == BAND_LIMITED_2);
+            all_schemes_correct &&
+            (best_scheme(N, 0).get_priority() == BAND_LIMITED_CELL_ZERO);
+    all_schemes_correct = all_schemes_correct &&
+                          (best_scheme(N, 1).get_priority() == BAND_LIMITED_0);
+    all_schemes_correct = all_schemes_correct &&
+                          (best_scheme(N, 2).get_priority() == BAND_LIMITED_1);
+    all_schemes_correct = all_schemes_correct &&
+                          (best_scheme(N, 3).get_priority() == BAND_LIMITED_2);
     for (int i = 4; i <= N - 4; i++) {
       all_schemes_correct =
-              all_schemes_correct && (best_scheme(N, i).get_priority() == BAND_LIMITED_3);
+              all_schemes_correct &&
+              (best_scheme(N, i).get_priority() == BAND_LIMITED_3);
     }
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N - 3).get_priority() == BAND_LIMITED_4);
+            all_schemes_correct &&
+            (best_scheme(N, N - 3).get_priority() == BAND_LIMITED_4);
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N - 2).get_priority() == BAND_LIMITED_5);
+            all_schemes_correct &&
+            (best_scheme(N, N - 2).get_priority() == BAND_LIMITED_5);
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N - 1).get_priority() == BAND_LIMITED_6);
-    all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N).get_priority() == BAND_LIMITED_7);
+            all_schemes_correct &&
+            (best_scheme(N, N - 1).get_priority() == BAND_LIMITED_6);
+    all_schemes_correct = all_schemes_correct &&
+                          (best_scheme(N, N).get_priority() == BAND_LIMITED_7);
     REQUIRE(all_schemes_correct);
     REQUIRE_THROWS_AS(best_scheme(N, N + 1), out_of_range);
   }
 
-  /* Suppose we have N >= 8 Yee cells in a dimension. Then if we are restricted to the cubic interpolation functions, the program should determine:
+  /* Suppose we have N >= 8 Yee cells in a dimension. Then if we are restricted
+    to the cubic interpolation functions, the program should determine:
     - cell_id <= 0 : Interpolation impossible
     - cell_id == 1 : CUBIC_INTERP_FIRST
     - cell_id == 2,3,...,N-2 : Use CUBIC_INTERP_MIDDLE
@@ -73,13 +84,16 @@ TEST_CASE("best_interp_scheme: correct interpolation chosen") {
     PreferredInterpolationMethods pim = Cubic;
     REQUIRE_THROWS_AS(best_scheme(N, 0, pim), out_of_range);
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 1, pim).get_priority() == CUBIC_INTERP_FIRST);
+            all_schemes_correct &&
+            (best_scheme(N, 1, pim).get_priority() == CUBIC_INTERP_FIRST);
     for (int i = 2; i <= N - 2; i++) {
       all_schemes_correct =
-              all_schemes_correct && (best_scheme(N, i, pim).get_priority() == CUBIC_INTERP_MIDDLE);
+              all_schemes_correct &&
+              (best_scheme(N, i, pim).get_priority() == CUBIC_INTERP_MIDDLE);
     }
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N - 1, pim).get_priority() == CUBIC_INTERP_LAST);
+            all_schemes_correct &&
+            (best_scheme(N, N - 1, pim).get_priority() == CUBIC_INTERP_LAST);
     REQUIRE(all_schemes_correct);
     REQUIRE_THROWS_AS(best_scheme(N, N, pim), out_of_range);
   }
@@ -95,13 +109,16 @@ TEST_CASE("best_interp_scheme: correct interpolation chosen") {
     N = 6;
     REQUIRE_THROWS_AS(best_scheme(N, 0), out_of_range);
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, 1).get_priority() == CUBIC_INTERP_FIRST);
+            all_schemes_correct &&
+            (best_scheme(N, 1).get_priority() == CUBIC_INTERP_FIRST);
     for (int i = 2; i <= N - 2; i++) {
       all_schemes_correct =
-              all_schemes_correct && (best_scheme(N, i).get_priority() == CUBIC_INTERP_MIDDLE);
+              all_schemes_correct &&
+              (best_scheme(N, i).get_priority() == CUBIC_INTERP_MIDDLE);
     }
     all_schemes_correct =
-            all_schemes_correct && (best_scheme(N, N - 1).get_priority() == CUBIC_INTERP_LAST);
+            all_schemes_correct &&
+            (best_scheme(N, N - 1).get_priority() == CUBIC_INTERP_LAST);
     REQUIRE(all_schemes_correct);
     REQUIRE_THROWS_AS(best_scheme(N, N), out_of_range);
   }

--- a/tdms/tests/unit/test_interpolation_functions.cpp
+++ b/tdms/tests/unit/test_interpolation_functions.cpp
@@ -1,7 +1,8 @@
 /**
  * @file test_interpolation_functions.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
- * @brief Tests the performance of the interpolation functions, using 1D data mimicing a coordinate axes
+ * @brief Tests the performance of the interpolation functions, using 1D data
+ * mimicing a coordinate axes
  */
 #include "interpolation_methods.h"
 
@@ -19,9 +20,9 @@
 #include "unit_test_utils.h"
 
 using namespace tdms_math_constants;
-using tdms_tests::is_close_or_better;
-using tdms_tests::euclidean;
 using Catch::Approx;
+using tdms_tests::euclidean;
+using tdms_tests::is_close_or_better;
 using namespace std;
 
 /**
@@ -29,84 +30,87 @@ using namespace std;
  * polynomial fields up to cubic order are interpolated exactly (to within
  * machine error)
  *
- * Checks are run on both the old interp{1,2,3} functions and newer const Interp_scheme instances. Old cubic methods will be redundant upon integration of BLi into the codebase.
+ * Checks are run on both the old interp{1,2,3} functions and newer const
+ * Interp_scheme instances. Old cubic methods will be redundant upon integration
+ * of BLi into the codebase.
  */
 TEST_CASE("Cubic interpolation: exact for polynomials of degree <= 3") {
-    // equidistant points
-    double x[] = {0., 1., 2., 3.};
-    // test acceptence tolerance. Allow for FLOP imprecision and rounding errors
-    // error should be \approx 4 max(c_i) x^2 __DBL__EPSILON, so order 40 * __DBL__EPSILON__
-    double tol = 4e1 * __DBL_EPSILON__;
+  // equidistant points
+  double x[] = {0., 1., 2., 3.};
+  // test acceptence tolerance. Allow for FLOP imprecision and rounding errors
+  // error should be \approx 4 max(c_i) x^2 __DBL__EPSILON, so order 40 *
+  // __DBL__EPSILON__
+  double tol = 4e1 * __DBL_EPSILON__;
 
-    // constant field
-    double c0 = M_PI;
-    // array that will be passed to Interp_scheme::interpolate
-    double interp_data[4] = {c0, c0, c0, c0};
+  // constant field
+  double c0 = M_PI;
+  // array that will be passed to Interp_scheme::interpolate
+  double interp_data[4] = {c0, c0, c0, c0};
 
-    double v1 = c0, v2 = c0, v3 = c0, v4 = c0;
-    double v12 = c0, v23 = c0, v34 = c0;
+  double v1 = c0, v2 = c0, v3 = c0, v4 = c0;
+  double v12 = c0, v23 = c0, v34 = c0;
 
-    // check Interp_scheme class method
-    CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
-    CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
-    CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
+  // check Interp_scheme class method
+  CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
+  CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
+  CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
 
-    // linear
-    double c1 = -2.7182818;
-    v1 += c1 * x[0];
-    interp_data[0] += c1 * x[0];
-    v2 += c1 * x[1];
-    interp_data[1] += c1 * x[1];
-    v3 += c1 * x[2];
-    interp_data[2] += c1 * x[2];
-    v4 += c1 * x[3];
-    interp_data[3] += c1 * x[3];
-    v12 += c1 * (x[1] + x[0]) / 2.;
-    v23 += c1 * (x[2] + x[1]) / 2.;
-    v34 += c1 * (x[3] + x[2]) / 2.;
+  // linear
+  double c1 = -2.7182818;
+  v1 += c1 * x[0];
+  interp_data[0] += c1 * x[0];
+  v2 += c1 * x[1];
+  interp_data[1] += c1 * x[1];
+  v3 += c1 * x[2];
+  interp_data[2] += c1 * x[2];
+  v4 += c1 * x[3];
+  interp_data[3] += c1 * x[3];
+  v12 += c1 * (x[1] + x[0]) / 2.;
+  v23 += c1 * (x[2] + x[1]) / 2.;
+  v34 += c1 * (x[3] + x[2]) / 2.;
 
-    // check Interp_scheme class method
-    CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
-    CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
-    CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
+  // check Interp_scheme class method
+  CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
+  CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
+  CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
 
-    // quadratic
-    double c2 = 9.81;
-    v1 += c2 * x[0] * x[0];
-    interp_data[0] += c2 * x[0] * x[0];
-    v2 += c2 * x[1] * x[1];
-    interp_data[1] += c2 * x[1] * x[1];
-    v3 += c2 * x[2] * x[2];
-    interp_data[2] += c2 * x[2] * x[2];
-    v4 += c2 * x[3] * x[3];
-    interp_data[3] += c2 * x[3] * x[3];
-    v12 += c2 * (x[1] + x[0]) * (x[1] + x[0]) / 4.;
-    v23 += c2 * (x[2] + x[1]) * (x[2] + x[1]) / 4.;
-    v34 += c2 * (x[3] + x[2]) * (x[3] + x[2]) / 4.;
+  // quadratic
+  double c2 = 9.81;
+  v1 += c2 * x[0] * x[0];
+  interp_data[0] += c2 * x[0] * x[0];
+  v2 += c2 * x[1] * x[1];
+  interp_data[1] += c2 * x[1] * x[1];
+  v3 += c2 * x[2] * x[2];
+  interp_data[2] += c2 * x[2] * x[2];
+  v4 += c2 * x[3] * x[3];
+  interp_data[3] += c2 * x[3] * x[3];
+  v12 += c2 * (x[1] + x[0]) * (x[1] + x[0]) / 4.;
+  v23 += c2 * (x[2] + x[1]) * (x[2] + x[1]) / 4.;
+  v34 += c2 * (x[3] + x[2]) * (x[3] + x[2]) / 4.;
 
-    // check Interp_scheme class method
-    CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
-    CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
-    CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
+  // check Interp_scheme class method
+  CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
+  CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
+  CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
 
-    // cubic
-    double c3 = 4.2;
-    v1 += c3 * x[0] * x[0] * x[0];
-    interp_data[0] += c3 * x[0] * x[0] * x[0];
-    v2 += c3 * x[1] * x[1] * x[1];
-    interp_data[1] += c3 * x[1] * x[1] * x[1];
-    v3 += c3 * x[2] * x[2] * x[2];
-    interp_data[2] += c3 * x[2] * x[2] * x[2];
-    v4 += c3 * x[3] * x[3] * x[3];
-    interp_data[3] += c3 * x[3] * x[3] * x[3];
-    v12 += c3 * (x[1] + x[0]) * (x[1] + x[0]) * (x[1] + x[0]) / 8.;
-    v23 += c3 * (x[2] + x[1]) * (x[2] + x[1]) * (x[2] + x[1]) / 8.;
-    v34 += c3 * (x[3] + x[2]) * (x[3] + x[2]) * (x[3] + x[2]) / 8.;
+  // cubic
+  double c3 = 4.2;
+  v1 += c3 * x[0] * x[0] * x[0];
+  interp_data[0] += c3 * x[0] * x[0] * x[0];
+  v2 += c3 * x[1] * x[1] * x[1];
+  interp_data[1] += c3 * x[1] * x[1] * x[1];
+  v3 += c3 * x[2] * x[2] * x[2];
+  interp_data[2] += c3 * x[2] * x[2] * x[2];
+  v4 += c3 * x[3] * x[3] * x[3];
+  interp_data[3] += c3 * x[3] * x[3] * x[3];
+  v12 += c3 * (x[1] + x[0]) * (x[1] + x[0]) * (x[1] + x[0]) / 8.;
+  v23 += c3 * (x[2] + x[1]) * (x[2] + x[1]) * (x[2] + x[1]) / 8.;
+  v34 += c3 * (x[3] + x[2]) * (x[3] + x[2]) * (x[3] + x[2]) / 8.;
 
-    // check Interp_scheme class method
-    CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
-    CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
-    CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
+  // check Interp_scheme class method
+  CHECK(v12 == Approx(CBFst.interpolate(interp_data)).epsilon(tol));
+  CHECK(v23 == Approx(CBMid.interpolate(interp_data)).epsilon(tol));
+  CHECK(v34 == Approx(CBLst.interpolate(interp_data)).epsilon(tol));
 }
 
 /**
@@ -116,47 +120,58 @@ TEST_CASE("Cubic interpolation: exact for polynomials of degree <= 3") {
  * Note - the coefficients are not required to sum to unity!
  */
 TEST_CASE("BLi: interpolation-coefficient sums match") {
-    /* Tolerance to accept imprecision to
+  /* Tolerance to accept imprecision to
     max. 16 FLOPs implies max discrepency of 8*_DBL_EPSILON__ error
     (8 additions, error in each number max __DBL_EPSILON__).
     tol should be \approx 10 * __DBL_EPSILON__ ,
     after accounting for funny-business multiplying everything by 1
     */
-    double tol = 1e1 * __DBL_EPSILON__;
-    double coeff_sums[8];
-    double a[8] = {1., 1., 1., 1., 1., 1., 1., 1.};
+  double tol = 1e1 * __DBL_EPSILON__;
+  double coeff_sums[8];
+  double a[8] = {1., 1., 1., 1., 1., 1., 1., 1.};
 
-    // fast way to sum the coefficients is to "interpolate" the constant function 1
-    coeff_sums[0] = BL0.interpolate(a);
-    coeff_sums[1] = BL1.interpolate(a);
-    coeff_sums[2] = BL2.interpolate(a);
-    coeff_sums[3] = BL3.interpolate(a);
-    coeff_sums[4] = BL4.interpolate(a);
-    coeff_sums[5] = BL5.interpolate(a);
-    coeff_sums[6] = BL6.interpolate(a);
-    coeff_sums[7] = BL7.interpolate(a);
-    // now check that the entries of coeff_sums are the same
-    int n = 8;
-    while (--n > 0 && abs(coeff_sums[n] - coeff_sums[0]) < tol)
-      ;
-    // we only reach the end of the while loop, IE get to n==0, when all elements in the array are the same
-    REQUIRE(n == 0);
+  // fast way to sum the coefficients is to "interpolate" the constant function
+  // 1
+  coeff_sums[0] = BL0.interpolate(a);
+  coeff_sums[1] = BL1.interpolate(a);
+  coeff_sums[2] = BL2.interpolate(a);
+  coeff_sums[3] = BL3.interpolate(a);
+  coeff_sums[4] = BL4.interpolate(a);
+  coeff_sums[5] = BL5.interpolate(a);
+  coeff_sums[6] = BL6.interpolate(a);
+  coeff_sums[7] = BL7.interpolate(a);
+  // now check that the entries of coeff_sums are the same
+  int n = 8;
+  while (--n > 0 && abs(coeff_sums[n] - coeff_sums[0]) < tol)
+    ;
+  // we only reach the end of the while loop, IE get to n==0, when all elements
+  // in the array are the same
+  REQUIRE(n == 0);
 }
 
 /**
- * @brief We will check that BLi interpolation data gives comparible error to the equivalent functions in MATLAB
+ * @brief We will check that BLi interpolation data gives comparible error to
+ * the equivalent functions in MATLAB
  *
- *  * For 100 sample points, we will use BLi to interpolate the following complex-valued function with 100 sample points:
- * real part of sin(2\pi x)
- * imag part of pulse function.
+ *  * For 100 sample points, we will use BLi to interpolate the following
+ * complex-valued function with 100 sample points: real part of sin(2\pi x) imag
+ * part of pulse function.
  *
- * Interoplation will then be tested against over the range [0,1], the max element-wise error (by absolute value) will be determined. We will then check that this is of the same order of magnitude as the error produced by MATLAB, 5.35317432e-04.
+ * Interoplation will then be tested against over the range [0,1], the max
+ * element-wise error (by absolute value) will be determined. We will then check
+ * that this is of the same order of magnitude as the error produced by
+ * MATLAB, 5.35317432e-04.
  *
- * For 100 sample points, we will use BLi to interpolate the following functions with 100 sample points:
- * - The constant function 1    : range 0,1 : max. element-wise error (MATLAB) 2.82944733e-04
- * - sin(2\pi x)                : range 0,1 : max. element-wise error (MATLAB) 2.63468327e-04
- * - pulse function             : range 0,1 : max. element-wise error (MATLAB) 4.87599933e-04
- * - complex function           : range 0,1 : max. element-wise error (MATLAB) 5.35317432e-04
+ * For 100 sample points, we will use BLi to interpolate the following functions
+ * with 100 sample points:
+ * - The constant function 1    : range 0,1 : max. element-wise error
+ * (MATLAB) 2.82944733e-04
+ * - sin(2\pi x)                : range 0,1 : max. element-wise error
+ * (MATLAB) 2.63468327e-04
+ * - pulse function             : range 0,1 : max. element-wise error
+ * (MATLAB) 4.87599933e-04
+ * - complex function           : range 0,1 : max. element-wise error
+ * (MATLAB) 5.35317432e-04
  *
  * MATLAB norm-errors:
  * constant function norm error: 2.81526454e-03
@@ -165,7 +180,8 @@ TEST_CASE("BLi: interpolation-coefficient sums match") {
  * complex fn norm error:        2.08892374e-03
  *
  * Error values produced from benchmark_test_interpolation_functions.m
- * The complex function has real part sin(2\pi x) and its imaginary part is the pulse function.
+ * The complex function has real part sin(2\pi x) and its imaginary part is the
+ * pulse function.
  */
 
 // Hardcode MATLAB errors from benchmark_test_interpolation_functions.m
@@ -173,8 +189,10 @@ inline const double ML_const_fn_max_pointwise_error = 2.82944733e-04,
                     ML_sin_max_pointwise_error = 2.63468327e-04,
                     ML_pulse_max_pointwise_error = 4.87599933e-04,
                     ML_complex_fn_max_pointwise_error = 5.35317432e-04;
-inline const double ML_cont_fn_norm_error = 2.81526454e-03, ML_sin_norm_error = 1.85845330e-03,
-                    ML_pulse_norm_error = 9.65609916e-04, ML_complex_fn_norm_error = 2.08892374e-03;
+inline const double ML_cont_fn_norm_error = 2.81526454e-03,
+                    ML_sin_norm_error = 1.85845330e-03,
+                    ML_pulse_norm_error = 9.65609916e-04,
+                    ML_complex_fn_norm_error = 2.08892374e-03;
 
 // Evalutes f(x) = 1, for consistency with test sectioning
 inline double constant_1(double x) { return 1.; }
@@ -183,7 +201,8 @@ inline double constant_1(double x) { return 1.; }
 inline double s2pi(double x) { return sin(2. * DCPI * x); }
 
 /**
- * @brief Evaluates the smooth pulse/ mollifier Kernel function, supported between 0 and 1
+ * @brief Evaluates the smooth pulse/ mollifier Kernel function, supported
+ * between 0 and 1
  *
  * The smooth mollifier \phi(x) is the function
  * \phi(x) =
@@ -192,7 +211,8 @@ inline double s2pi(double x) { return sin(2. * DCPI * x); }
  *  e^{-1/(1-|x|^2)}    &   when |x| < 1
  * \end{cases}
  * This function is compactly supported over the interval [-1,1].
- * By evaluating pulse(x) = \phi(3[2x-1]), we obtain a smooth function with support in [1/3,2/3] \subset [0,1]
+ * By evaluating pulse(x) = \phi(3[2x-1]), we obtain a smooth function with
+ * support in [1/3,2/3] \subset [0,1]
  *
  * @param x Point of evaluation
  * @return double Evaluted value
@@ -206,18 +226,21 @@ inline double pulse(double x) {
   }
 }
 
-// Evalutes the complex function we will be using as a benchmark, f(x) = sin(2\pi x) + i * pulse(x)
-inline complex<double> complex_fn(double x) { return s2pi(x) + IMAGINARY_UNIT * pulse(x); }
+// Evalutes the complex function we will be using as a benchmark, f(x) =
+// sin(2\pi x) + i * pulse(x)
+inline complex<double> complex_fn(double x) {
+  return s2pi(x) + IMAGINARY_UNIT * pulse(x);
+}
 
 TEST_CASE("BLi: MATLAB benchmarking") {
   // setup test logging information
   stringstream logging_string;
   logging_string << scientific << setprecision(8);
 
-  int nSamples = 100;                           //< number of datapooints in this dimension
+  int nSamples = 100;//< number of datapooints in this dimension
   double spacing = 1. / (double) (nSamples - 1);//< spacing between datapoints
   double xi[nSamples];                          //< coordinates of the samples
-  double xi5[nSamples - 1];                     //< coordinates of the interpolation points
+  double xi5[nSamples - 1];//< coordinates of the interpolation points
   // setup cell centres (xi5) and data sample positions (xi)
   for (int i = 0; i < nSamples - 1; i++) {
     xi[i] = ((double) i) * spacing;
@@ -256,7 +279,8 @@ TEST_CASE("BLi: MATLAB benchmarking") {
       analytic_function = &pulse;
     }
 
-    // Setup sample points (xi), Yee cell centres (xi5), and function values at these points (sampled data & exact values)
+    // Setup sample points (xi), Yee cell centres (xi5), and function values at
+    // these points (sampled data & exact values)
     for (int i = 0; i < nSamples - 1; i++) {
       f_data[i] = analytic_function(xi[i]);
       f_exact[i] = analytic_function(xi5[i]);
@@ -265,7 +289,8 @@ TEST_CASE("BLi: MATLAB benchmarking") {
     // perform interpolation
     for (int i = 0; i < nSamples - 1; i++) {
       InterpolationScheme scheme = best_scheme(nSamples, i + 1);
-      f_interp[i] = scheme.interpolate(f_data, i + 1 - scheme.number_of_datapoints_to_left);
+      f_interp[i] = scheme.interpolate(
+              f_data, i + 1 - scheme.number_of_datapoints_to_left);
       // Compare interpolated values to the true values
       f_errors[i] = abs(f_exact[i] - f_interp[i]);
     }
@@ -279,7 +304,8 @@ TEST_CASE("BLi: MATLAB benchmarking") {
     MATLAB_max_error = ML_complex_fn_max_pointwise_error;
     MATLAB_norm_error = ML_complex_fn_norm_error;
 
-    // Setup sample points (xi), Yee cell centres (xi5), and function values at these points (sampled data & exact values)
+    // Setup sample points (xi), Yee cell centres (xi5), and function values at
+    // these points (sampled data & exact values)
     for (int i = 0; i < nSamples - 1; i++) {
       f_data[i] = complex_fn(xi[i]);
       f_exact[i] = complex_fn(xi5[i]);
@@ -288,7 +314,8 @@ TEST_CASE("BLi: MATLAB benchmarking") {
     // perform interpolation
     for (int i = 0; i < nSamples - 1; i++) {
       InterpolationScheme scheme = best_scheme(nSamples, i + 1);
-      f_interp[i] = scheme.interpolate(f_data, i + 1 - scheme.number_of_datapoints_to_left);
+      f_interp[i] = scheme.interpolate(
+              f_data, i + 1 - scheme.number_of_datapoints_to_left);
       // Compare interpolated values to the true values
       f_errors[i] = abs(f_exact[i] - f_interp[i]);
     }
@@ -302,7 +329,9 @@ TEST_CASE("BLi: MATLAB benchmarking") {
   REQUIRE(is_close_or_better(norm_error, MATLAB_norm_error));
 
   // report test results
-  logging_string << "Max ptwise error: " << max_error << " (" << MATLAB_max_error << ") | ";
-  logging_string << "Norm error: " << norm_error << " (" << MATLAB_norm_error << ")";
+  logging_string << "Max ptwise error: " << max_error << " ("
+                 << MATLAB_max_error << ") | ";
+  logging_string << "Norm error: " << norm_error << " (" << MATLAB_norm_error
+                 << ")";
   SPDLOG_INFO(logging_string.str());
 }

--- a/tdms/tests/unit/test_numerical_derivative.cpp
+++ b/tdms/tests/unit/test_numerical_derivative.cpp
@@ -4,10 +4,10 @@
  */
 #include "numerical_derivative.h"
 
-#include <fftw3.h>
-#include <spdlog/spdlog.h>
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <fftw3.h>
+#include <spdlog/spdlog.h>
 
 #include "unit_test_utils.h"
 
@@ -15,7 +15,7 @@ using Catch::Approx;
 using tdms_tests::near_zero;
 
 // fftw_complex is typdef to a double[2] - first element is Re, second Im.
-const int REAL=0, IMAG=1;
+const int REAL = 0, IMAG = 1;
 
 /**
  * @brief Test complex number multilication (internally used for numerical
@@ -23,24 +23,32 @@ const int REAL=0, IMAG=1;
  */
 TEST_CASE("Element-by-element multiplication of array of complex numbers") {
 
-    // setup
-    fftw_complex a[3] = { {0, 1}, {1, 1}, {0, 1}, };
-    fftw_complex b[3] = { {0, 1}, {1, 1}, {1, -1}, };
-    fftw_complex expected[3] = {
-        {-1, 0}, // i² = -1
-        {0, 2},  // (1+i)² = 2i
-        {1, 1}   // i(1-i) = 1+i
-    };
+  // setup
+  fftw_complex a[3] = {
+          {0, 1},
+          {1, 1},
+          {0, 1},
+  };
+  fftw_complex b[3] = {
+          {0, 1},
+          {1, 1},
+          {1, -1},
+  };
+  fftw_complex expected[3] = {
+          {-1, 0},// i² = -1
+          {0, 2}, // (1+i)² = 2i
+          {1, 1}  // i(1-i) = 1+i
+  };
 
-    // call
-    fftw_complex output[3];
-    complex_mult_vec(a, b, output, 3);
+  // call
+  fftw_complex output[3];
+  complex_mult_vec(a, b, output, 3);
 
-    // check the output matches the expected values
-    for (int i=0; i<3; i++) {
-        REQUIRE(output[i][REAL] == expected[i][REAL]);
-        REQUIRE(output[i][IMAG] == expected[i][IMAG]);
-    }
+  // check the output matches the expected values
+  for (int i = 0; i < 3; i++) {
+    REQUIRE(output[i][REAL] == expected[i][REAL]);
+    REQUIRE(output[i][IMAG] == expected[i][IMAG]);
+  }
 }
 
 /**
@@ -48,52 +56,52 @@ TEST_CASE("Element-by-element multiplication of array of complex numbers") {
  *
  * The cosine should have negative sine as a derivative. This test involves a
  * bit of trickery because the normalisation is arbitrary. So the ratio of the
- * expected function (-sinθ) and the output (k dcosθ / dx) should be a constant (k)
- * modulo the places where either function is a zero. So calculate the mean
+ * expected function (-sinθ) and the output (k dcosθ / dx) should be a constant
+ * (k) modulo the places where either function is a zero. So calculate the mean
  * ratio of the expected to the output, and check the ratio ~= it's mean value.
  */
 TEST_CASE("Numerical derivative") {
 
-    // array size
-    const int NSAMPLES=64;
+  // array size
+  const int NSAMPLES = 64;
 
-    // setup buffers and fft plans
-    fftw_complex sampled_cosine[NSAMPLES], output[NSAMPLES], dk[NSAMPLES] = { 0. };
-    double minus_sine[NSAMPLES];
-    fftw_plan pf = fftw_plan_dft_1d(NSAMPLES, sampled_cosine, output, FFTW_FORWARD, FFTW_ESTIMATE);
-    fftw_plan pb = fftw_plan_dft_1d(NSAMPLES, sampled_cosine, output, FFTW_BACKWARD, FFTW_ESTIMATE);
+  // setup buffers and fft plans
+  fftw_complex sampled_cosine[NSAMPLES], output[NSAMPLES], dk[NSAMPLES] = {0.};
+  double minus_sine[NSAMPLES];
+  fftw_plan pf = fftw_plan_dft_1d(NSAMPLES, sampled_cosine, output,
+                                  FFTW_FORWARD, FFTW_ESTIMATE);
+  fftw_plan pb = fftw_plan_dft_1d(NSAMPLES, sampled_cosine, output,
+                                  FFTW_BACKWARD, FFTW_ESTIMATE);
 
-    // sample cosθ and its derivative (-sinθ)
-    for (int i=0; i<NSAMPLES; i++) {
-        double theta = 100.*i / (double)NSAMPLES * M_PI;
-        sampled_cosine[i][REAL] = std::cos(theta);
-        minus_sine[i] = -1.0*std::sin(theta);
+  // sample cosθ and its derivative (-sinθ)
+  for (int i = 0; i < NSAMPLES; i++) {
+    double theta = 100. * i / (double) NSAMPLES * M_PI;
+    sampled_cosine[i][REAL] = std::cos(theta);
+    minus_sine[i] = -1.0 * std::sin(theta);
+  }
+
+  // call
+  first_derivative(sampled_cosine, output, dk, NSAMPLES, pf, pb);
+
+  // output has arbitrary normalisation so take the ratio at each sample
+  double ratio[NSAMPLES], total = 0;
+  int zeroes = 0;
+  for (int i = 0; i < NSAMPLES; i++) {
+
+    // skip the zeros of either function - send to NaN
+    if (near_zero(output[i][REAL]) || near_zero(minus_sine[i])) {
+      ratio[i] = std::numeric_limits<double>::quiet_NaN();
+      zeroes++;
+    } else {
+      ratio[i] = minus_sine[i] / output[i][REAL];
+      total += ratio[i];
     }
+    spdlog::trace("expected: {} \t calculate: {} \t ratio: {}", minus_sine[i],
+                  output[i][REAL], ratio[i]);
+  }
+  double mean = total / (NSAMPLES - zeroes);
 
-    // call
-    first_derivative(sampled_cosine, output, dk, NSAMPLES, pf, pb);
-
-    // output has arbitrary normalisation so take the ratio at each sample
-    double ratio[NSAMPLES], total = 0;
-    int zeroes = 0;
-    for (int i = 0; i < NSAMPLES; i++) {
-
-        // skip the zeros of either function - send to NaN
-        if (near_zero(output[i][REAL]) || near_zero(minus_sine[i])) {
-            ratio[i] = std::numeric_limits<double>::quiet_NaN();
-            zeroes++;
-        } else {
-            ratio[i] = minus_sine[i] / output[i][REAL];
-            total += ratio[i];
-        }
-        spdlog::trace("expected: {} \t calculate: {} \t ratio: {}",
-                      minus_sine[i], output[i][REAL], ratio[i]);
-    }
-    double mean = total / (NSAMPLES-zeroes);
-
-    // every element of the ratio should be close to the mean
-    for (int i=0; i<NSAMPLES; i++)
-        if (not std::isnan(ratio[i]))
-            REQUIRE(ratio[i] == Approx(mean));
-
+  // every element of the ratio should be close to the mean
+  for (int i = 0; i < NSAMPLES; i++)
+    if (not std::isnan(ratio[i])) REQUIRE(ratio[i] == Approx(mean));
 }


### PR DESCRIPTION
:1st_place_medal: Here's every single warning: [pre-commit-on-all.txt](https://github.com/UCL/TDMS/files/10511267/pre-commit-on-all.txt)

#### `linting.yaml`
Workflow renamed to "Run code linting" (previously "Run python code linting").

#### `.pre-commit-config.yaml`

Invokes [pocc/pre-commit-hooks](https://github.com/pocc/pre-commit-hooks) to force `C++` linting:
- `clang-format` is pointed at our [`.clang-format`](https://github.com/UCL/TDMS/blob/wgraham-cpp-linter/.clang-format)

#### Future considerations:
We looked at a bunch of other pre-commit tools. Here's some stuff about them that we ended up not including in this PR but might be wanted going forward.

- `clang-tidy` can be pointed to our compile commands. This requires `compile_commands.json` to be present. Can be done by passing `DCMAKE_EXPORT_COMPILE_COMMANDS=ON` when invoking `cmake`.
- `cpplint` filters `whitespace/comments` due to a conflict with `Doxygen` and `clang-tidy` standards. Suppresses `legal/copyright` because our developer docs don't require a copyright notice in header files. Runs quietly so we don't know its there if it has nothing to say.