### PR TITLE
Add to Doxygen pages, and use doxygen as a CI check.

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -36,13 +36,6 @@ jobs:
       run: touch html/.nojekyll
       shell: bash
 
-    - name: Manually copy over assets
-      # Preserve their directory structure to keep README's image references!
-      run: |
-        mkdir -p html/doc/assets
-        cp -R doc/assets/*.png html/doc/assets
-      shell: bash
-
     - name: Upload the website
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,15 +1,74 @@
-name: Doxygen GitHub Pages Deploy Action
+name: Run Doxygen and publish to GitHub pages
+
+# Generate the documentation on all merges to main, all pull requests, or by
+# manual workflow dispatch. The Doxygen job can be used as a CI check that all
+# functions are documented. The publish job only runs on new commits to the main
+# branch and actually pushes the generated html to the gh-pages branch (which
+# triggers a GitHub pages deployment). When things are a bit more stable, we can
+# only publish the website on release tags.
 on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
+
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  doxygen:
+    runs-on: macos-latest
     steps:
-      - uses: DenverCoder1/doxygen-github-pages-action@v1.2.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          folder: html
-          config_file: doc/Doxyfile
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        submodules: "true"
+
+    - name: Install Doxygen
+      run: brew install doxygen graphviz
+      shell: bash
+
+    - name: Run Doxygen
+      run: doxygen doc/Doxyfile
+      shell: bash
+
+    # Disabling jekyll ensures pages with underscores work on gh pages.
+    - name: Create .nojekyll
+      run: touch html/.nojekyll
+      shell: bash
+
+    - name: Manually copy over assets
+      # Preserve their directory structure to keep README's image references!
+      run: |
+        mkdir -p html/doc/assets
+        cp -R doc/assets/*.png html/doc/assets
+      shell: bash
+
+    - name: Upload the website
+      uses: actions/upload-artifact@v3
+      with:
+        name: tdms_website
+        path: html/*
+        retention-days: 1
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: doxygen
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Download the content for deployment
+      uses: actions/download-artifact@v3
+      with:
+        name: tdms_website
+        path: html
+        # Recreate and download to the html directory just for tidiness sake.
+
+    - name: Commit to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages
+        folder: html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!-- \cond -->
+<!-- 👆 this comment and the endcond below, tells doxygen to ignore the badges
+and title at the top of README.md when building the project page (the title
+would be duplicated) everything else in README.md is also the project homepage. -->
+
 [![Linux tests](https://github.com/UCL/TDMS/actions/workflows/linux_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/linux_tests.yml)
 [![Windows tests](https://github.com/UCL/TDMS/actions/workflows/windows_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/windows_tests.yml)
 [![MATLAB tests](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml)
@@ -8,8 +13,9 @@
 > **Warning**
 > This repository is a _work in progress_. The API will change without notice
 
-***
-## Introduction
+<!-- \endcond -->
+
+# Time-Domain Maxwell Solver
 
 TDMS, the Time Domain Maxwell Solver, is a hybrid C++ and MATLAB tool for solving
 Maxwell's equations to simulate light propagation through a medium. See the
@@ -17,7 +23,6 @@ Maxwell's equations to simulate light propagation through a medium. See the
 further details.
 
 
-***
 ## Compilation
 
 TDMS needs to be built against [FFTW](https://www.fftw.org/) and
@@ -59,7 +64,6 @@ where lines need to be commented in and the paths modified if cmake cannot
 </details>
 
 
-***
 ## Usage
 
 Once the executable has been compiled and installed, `tdms` should be in the `PATH`.
@@ -72,7 +76,7 @@ $ tdms -h
 You can invoke it directly or call it from a MATLAB script.
 We recommend that beginners with MATLAB installed start with the demonstration MATLAB script.
 
-#### To run the demonstration code
+### To run the demonstration code
 
 Move into directory [`examples/arc_01`](./examples/arc_01/),
 launch MATLAB and run the MATLAB script:
@@ -82,7 +86,7 @@ launch MATLAB and run the MATLAB script:
 This script will generate the input to the executable, run the executable and
 display sample output.
 
-#### To run standalone
+### To run standalone
 
 You can also run `tdms` from the command line...
 
@@ -102,7 +106,7 @@ The basic workflow is with two arguments, an input file as specified by [`iterat
 
 You can choose two possible solver methods: either pseudo-spectral time-domain (PSTD, the default) or finite-difference (FDTD, with option `--finite-difference`).
 
-#### Parallelism
+### Parallelism
 
 TDMS is parallelised with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The maximum
 number of threads can be set with the `OMP_NUM_THREADS` environment variable.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-<!-- \cond -->
+<!-- \cond
+ -->
 <!-- 👆 this comment and the endcond below, tells doxygen to ignore the badges
 and title at the top of README.md when building the project page (the title
 would be duplicated) everything else in README.md is also the project homepage. -->
@@ -17,10 +18,10 @@ would be duplicated) everything else in README.md is also the project homepage. 
 
 # Time-Domain Maxwell Solver
 
-TDMS, the Time Domain Maxwell Solver, is a hybrid C++ and MATLAB tool for solving
-Maxwell's equations to simulate light propagation through a medium. See the
-[pdf documentation](https://github.com/UCL/TDMS/blob/gh-doc/masterdoc.pdf) for
-further details.
+TDMS, the Time Domain Maxwell Solver, is a hybrid C++ and MATLAB tool for
+solving Maxwell's equations to simulate light propagation through a medium. See
+the [pdf documentation](https://github.com/UCL/TDMS/blob/gh-doc/masterdoc.pdf)
+for further details.
 
 
 ## Compilation
@@ -39,42 +40,42 @@ $ cmake .. \
 # -DBUILD_TESTING=ON
 $ make install
 ```
-where lines need to be commented in and the paths modified if cmake cannot
-(1) find MATLAB, (2) find FFTW or (3) install to the default install prefix.
+where lines need to be commented in and the paths modified if cmake cannot (1)
+find MATLAB, (2) find FFTW or (3) install to the default install prefix.
 
-- <details>
-    <summary>Mac specific instructions</summary>
+<details>
+<summary>Mac specific instructions</summary>
 
-    To compile on a Mac an x86 compiler with libraries for OpenMP are required,
-    which can be installed using [brew](https://brew.sh/) with `brew install llvm`
-    then (optionally) set the following cmake arguments
+To compile on a Mac an x86 compiler with libraries for OpenMP are required,
+which can be installed using [brew](https://brew.sh/) with `brew install llvm`
+then (optionally) set the following cmake arguments
 
-    ```
-    -DCMAKE_CXX_COMPILER=/Users/username/.local/homebrew/opt/llvm/bin/clang++
-    -DOMP_ROOT=/Users/username/.local/homebrew/opt/llvm/
-    -DCXX_ROOT=/Users/username/.local/homebrew/opt/llvm
-    ```
+```{sh}
+-DCMAKE_CXX_COMPILER=/Users/username/.local/homebrew/opt/llvm/bin/clang++
+-DOMP_ROOT=/Users/username/.local/homebrew/opt/llvm/
+-DCXX_ROOT=/Users/username/.local/homebrew/opt/llvm
+```
 
-    On an ARM Mac install the x86 version of brew with
-    ```bash
-    arch -x86_64 zsh
-    arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    arch -x86_64 /usr/local/bin/brew install llvm
-    ```
+On an ARM Mac install the x86 version of brew with
+```bash
+arch -x86_64 zsh
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+arch -x86_64 /usr/local/bin/brew install llvm
+```
 </details>
 
 
 ## Usage
 
-Once the executable has been compiled and installed, `tdms` should be in the `PATH`.
-Check that installation worked with
+Once the executable has been compiled and installed, `tdms` should be in the
+`PATH`.  Check that installation worked with
 
 ```bash
 $ tdms -h
 ```
 
-You can invoke it directly or call it from a MATLAB script.
-We recommend that beginners with MATLAB installed start with the demonstration MATLAB script.
+You can invoke it directly or call it from a MATLAB script.  We recommend that
+beginners with MATLAB installed start with the demonstration MATLAB script.
 
 ### To run the demonstration code
 
@@ -102,15 +103,19 @@ Options:
 -m:	Minimise output file size by not saving vertex and facet information
 ```
 
-The basic workflow is with two arguments, an input file as specified by [`iterate_fdtd_matrix.m`](./tdms/matlab/iteratefdtd_matrix.m), and an output file name to be created.
+The basic workflow is with two arguments, an input file as specified by
+[`iterate_fdtd_matrix.m`](./tdms/matlab/iteratefdtd_matrix.m), and an output
+file name to be created.
 
-You can choose two possible solver methods: either pseudo-spectral time-domain (PSTD, the default) or finite-difference (FDTD, with option `--finite-difference`).
+You can choose two possible solver methods: either pseudo-spectral time-domain
+(PSTD, the default) or finite-difference (FDTD, with option
+`--finite-difference`).
 
 ### Parallelism
 
-TDMS is parallelised with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The maximum
-number of threads can be set with the `OMP_NUM_THREADS` environment variable.
-For example, to use 4 threads, in a bash shell, use:
+TDMS is parallelised with [OpenMP](https://en.wikipedia.org/wiki/OpenMP). The
+maximum number of threads can be set with the `OMP_NUM_THREADS` environment
+variable.  For example, to use 4 threads, in a bash shell, use:
 
 ```bash
 $ export OMP_NUM_THREADS=4
@@ -118,6 +123,7 @@ $ export OMP_NUM_THREADS=4
 
 Before calling the `tdms` executable.
 
-## Contributing
+## Want to contribute?
 
-You are welcome to report new issues or submit pull requests.  For more information about how to contribute, please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) file and we have developer documentation on our [`gh-pages` site](https://github-pages.ucl.ac.uk/TDMS).
+We're very grateful for bug reports, feature requests and pull requests. Please
+see our [contribution guidelines](./CONTRIBUTING.md).

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -35,5 +35,7 @@ GENERATE_TREEVIEW      = YES
 HTML_EXTRA_STYLESHEET  = doc/doxygen-awesome-css/doxygen-awesome.css
 
 # 'mainpage' gets put on the index page
+INPUT += README.md
+INPUT += CONTRIBUTING.md
 INPUT += doc/developers.md
-USE_MDFILE_AS_MAINPAGE = doc/developers.md
+USE_MDFILE_AS_MAINPAGE = README.md


### PR DESCRIPTION
This PR is the first part of #230. It makes three changes:

1. Adds README.md and CONTRIBUTING.md to the web pages (they appear in _that_ order in the ToC followed by the developer docs 👍). Screenshot below, and [live dev version over on my personal fork](https://scnlf.me/TDMS).
2. Uses MacOS/homebrew to install and run Doxygen 1.9.6 which is much cooler 😎 than the version we were previously using in ubuntu (1.9.2 👎 ). Amongst other improvements: the cool version correctly renders the `<details>` HTML tags.
3. Splits the Doxygen workflow into two steps: `doxygen` and `publish`. This has a couple of benefits...
    * We can [run the first step (not the second)](https://github.com/samcunliffe/TDMS/actions/runs/4244369222) on all PRs and use it as an additional check that C++ code is documented.
    * The webpages are a build artifact and can be downloaded and browsed and debugged from the action.
    * The [second step can run whenever we want to publish](https://github.com/samcunliffe/TDMS/actions/runs/4244372711). For now, this is on pushes to `main`, but it could be release tags (for example).

In particular for the first step, when we've got everything documented, we can set Doxygen to **fail** when it encounters an undocumented warning. This would then fail the CI.

## Too many words? Here's a screenshot...
![Screenshot 2023-02-22 at 21 11 34](https://user-images.githubusercontent.com/1836192/220764203-80a030b5-e123-4186-82d3-95bbdfaa2daa.png)


## Next planned steps:

* Introduce logos and a citation link.
* Reword README and CONTRIBUTING to avoid duplication of information.
* Turn the Doxygen warnings into GH Actions annotations(?)
* Actually fix Doxygen warnings (there aren't too many of them) and turn Doxygen warnings → build errors.