### PR TITLE
Remove 'python-version'...

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,5 +11,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: ucl/composite-actions/pre-commit@v1
-        with:
-          python-version: '3.10'


### PR DESCRIPTION
... from the pre-commit action.

We were getting warnings because UCL's [pre-commit action](https://github.com/UCL/composite-actions/blob/main/pre-commit/action.yml) doesn't take any inputs.

> Warning: Unexpected input(s) 'python-version', valid inputs are ['']

So let's solve that, at least.