### PR TITLE
Clang-format replaces in file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       rev: v1.3.5
       hooks:
         - id: clang-format
-          args: ["--style=file"]
+          args: ["--style=file", "-i"]
       # - id: cppcheck
       #   args: ["--project=tdms/build/compile_commands.json"]
       # - id: cpplint


### PR DESCRIPTION
Clang-format during `pre-commit` now edits your files that it doesn't like with the correct code formatting, rather than just telling you what you're doing wrong.