### PR TITLE
Bugfix GitHub cli new tests

### DIFF
--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -41,9 +41,10 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
 
-      - name: Check MATLAB is on the PATH
+      - name: Check MATLAB is on the PATH and can be invoked
         run: |
           echo $(which matlab)
+          matlab -r -nosplash -nodesktop -nodisplay -r "disp('hello world')"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check MATLAB is on the PATH and can be invoked
         run: |
           echo $(which matlab)
-          matlab -r -nosplash -nodesktop -nodisplay -r "disp('hello world')"
+          matlab -nosplash -nodesktop -nodisplay -r "disp('hello world')"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -41,11 +41,6 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
 
-      - name: Check MATLAB is on the PATH and can be invoked
-        run: |
-          echo $(which matlab)
-          matlab -nosplash -nodesktop -nodisplay -r "disp('hello world')"
-
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -51,6 +51,12 @@ jobs:
         run: |
           pip install -r ${GITHUB_WORKSPACE}/tdms/tests/requirements.txt
 
+      - name: MATLAB engine things
+        shell: bash
+        run: |
+          pip install matlabengine
+          python ${GITHUB_WORKSPACE}/tdms/tests/system/test_matlabengine.py
+
       - name: Create Build Environment
         run: |
           cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
 
+      - name: Check MATLAB is on the PATH
+        run: |
+          echo $(which matlab)
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/tdms/tests/requirements.txt
+++ b/tdms/tests/requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-check
 h5py
 pyyaml
+matlabengine

--- a/tdms/tests/requirements.txt
+++ b/tdms/tests/requirements.txt
@@ -3,4 +3,3 @@ pytest
 pytest-check
 h5py
 pyyaml
-matlabengine

--- a/tdms/tests/system/data/input_generation/generate_test_input.py
+++ b/tdms/tests/system/data/input_generation/generate_test_input.py
@@ -1,14 +1,14 @@
 import os
 from glob import glob
 from pathlib import Path
-from subprocess import PIPE, Popen
+from subprocess import PIPE, Popen, run
 from typing import Union
 
 import yaml
 
 LOCATION_OF_THIS_FILE = os.path.dirname(os.path.abspath(__file__))
-# MATLAB executable path
-MATLAB_PATH = "matlab"
+# MATLAB executable path - need to locate this...
+MATLAB_PATH = run(["which", "matlab"], stdout=PIPE).stdout.decode().removesuffix("\n")
 # Additional options for running matlab on the command-line
 MATLAB_OPTS = ["-nodisplay", "-nodesktop", "-nosplash", "-r"]
 # Paths to matlab functions not in LOCATION_OF_THIS_FILE

--- a/tdms/tests/system/data/input_generation/regenerate_all.py
+++ b/tdms/tests/system/data/input_generation/regenerate_all.py
@@ -12,11 +12,11 @@ TESTS_TO_REGEN = glob(LOCATION_OF_THIS_FILE + "/*.yaml")
 N_TESTS_TO_REGEN = len(TESTS_TO_REGEN)
 
 
-def regenerate_test(config_file_location: Union[Path, str]) -> int:
+def regenerate_test(config_file_location: Union[Path, str]) -> tuple[int, str]:
     """Given the config file of a particular test, regenerate the input data for that test."""
     regenerator = GenerationData(config_file_location)
     return_code = regenerator.generate()
-    return return_code
+    return return_code, regenerator.matlab_command.stdout
 
 
 def regenerate_all() -> None:

--- a/tdms/tests/system/test_matlabengine.py
+++ b/tdms/tests/system/test_matlabengine.py
@@ -1,0 +1,11 @@
+import sys
+
+import matlab.engine as matlab
+
+if __name__ == "__main__":
+
+    eng = matlab.start_matlab("-nodesktop -nodisplay -nosplash -r")
+    x = eng.sqrt(4.0)
+    assert x == 2.0
+    eng.quit()
+    sys.exit(0)

--- a/tdms/tests/system/test_regen.py
+++ b/tdms/tests/system/test_regen.py
@@ -55,9 +55,12 @@ def workflow(test_id: str) -> None:
             )
         run_information = INFO["tests"]
 
-    # Regenerate the input data for arc_{test_id}, fail test if unsuccessful
-    regeneration_success = regenerate_test(config_file_path)
-    assert regeneration_success == 0, f"Data regeneration for arc_{test_id} failed!"
+    # Regenerate the input data for arc_{test_id}
+    regeneration_success, stdout_dump = regenerate_test(config_file_path)
+    # Fail test if regeneration was unsuccessful
+    assert (
+        regeneration_success == 0
+    ), f"Data regeneration for arc_{test_id} failed! Dumping stdout below:\n {stdout_dump}"
 
     # Perform each run of TDMS as specified by the config file
     system_test = TDMSSystemTest(yaml_test_id, run_information)


### PR DESCRIPTION
Getting an error unique to GitHub actions - tests pass locally.

Investigating...
1. ~Is MATLAB actually on the path in the place that I think it is?~ Yes, `which matlab` returns the correct path on the runner, so we _can_ find MATLAB...
2. Does `setup-matlab` actually allow you to _run_ `matlab` from the command-line? Maybe? See update below.

Update:
It looks like MATLAB wants to use display variables (even if you ask it to be suppressed :imp:), but since the `setup-matlab` action presumably setups up MATLAB as `root`, there are no display variables. And even if there were, runners don't have user accounts. For example, trying to run
```bash
matlab -nodisplay -nosplash -nodesktop -r "disp('hello world');exit;"
```
will error on `matlab`'s startup, requesting a display variable. Will try using `matlabengine`, which is the module that allows Python to call MATLAB within `.py` scripts to bypass this issue.

TDLR; you're not allowed to use `matlab -r` or invoke calls to `matlabengine` in Python on GitHub runners. Solutions are:
- Use our own self-hosted runner for the system tests. Will need to have a licensed version of `matlab2022b` and `python{3.10,3.9}` installed for our workflow to operate correctly.
- (Maybe) we can get matlab to read in our config files and run a matlab script that generates the input data. This is a pain because we can no longer link the generation of input data and the system test it corresponds to (we will have to regenerate _all_ of the input data files via the hypothetical `matlab` script, before then running all the system tests via `pytest`.