### PR TITLE
Track generation for `arc_02` and `arc_03`

### DIFF
--- a/doc/developers.md
+++ b/doc/developers.md
@@ -252,6 +252,7 @@ Subsequent runs of the tests will not re-download unless you manually delete the
 
 The system tests for `tdms` are configured with yaml files in the `data/input_generation/` directory.
 They are named `config_XX.yaml` where `XX` matches the ID of the system test, which themselves are named `arc_XX` by historical convention.
+These config files define a number of variables, parameters, and filenames that will be required when running the system tests - for a detailed breakdown of their syntax, see the annotated `config_01.yaml` file.
 This should also match the `test_id` field in the configuration file itself.
 The _reference outputs_ or _reference data_ are a collection of `.mat` files, produced from the _reference inputs_ by a trusted version of the `tdms` executable.
 We test for regression using these reference files.
@@ -264,9 +265,8 @@ In the scripts, a given execution is called by `tests.utils.run_tdms` which wrap
 #### Workflow of a System Test
 
 The workflow of a particular system test `arc_XX` is:
-- Locally generate the reference inputs using `data/input_generation/WHATISTHESCRIPTNAME.py`.
+- Locally generate the reference inputs using functionality in `data/input_generation/generate_test_data.py`.
     - `arc_XX` fails if its reference input cannot be successfully generated.
-        This indicates a failure in the scripts and/or functions in the `data/input_generation/{bscan,matlab}` directories.
 - Fetch the reference outputs from [Zenodo](https://zenodo.org/record/7440616/files).
 - For each run, named `run_id` in `arc_XX`:
     - Execute the call to `tdms` corresponding to `run_id`.
@@ -301,6 +301,6 @@ The `matlab/` directory contains functions that `run_bscan` will need to call on
 
 The `generate_test_input.py` file contains `.py` files that the system tests can invoke to regenerate the input data. Since the system test framework uses `pytest`, but the data generation requires `MATLAB` (for now), we use `Python` to read in and process the information that each test requires, and then call `run_bscan` with the appropriate commands from within Python.
 
-The `regenerate_all.py` file will work through all of the `config_tc.yaml` files in the directory and regenerate the input `.mat` data corresponding to each.
+The `regenerate_all.py` file will work through all of the `config_XX.yaml` files in the directory and regenerate the input `.mat` data corresponding to each.
 
 The remaining `config_XX.yaml` and `input_file_XX.m` files are as mentioned in [the previous section](#regeneration-of-the-data). These contain the information about each test that Python and `run_bscan` will need to regenerate the input files.

--- a/tdms/tests/system/data/input_generation/bscan/run_bscan.m
+++ b/tdms/tests/system/data/input_generation/bscan/run_bscan.m
@@ -1,11 +1,13 @@
-function [] = run_bscan(test_directory, input_filename, non_fs_obstacle, illfile_extra_file)
+function [] = run_bscan(test_directory, input_filename, non_fs_obstacle, illfile_extra_file, obstacle_radius)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%This function generates the files used as input to the executeable
+%This function generates the files used as input to the executeable.
+% It is an overarching hope that the system tests will be converted to Python after MATLAB header dependency removal from the tdms source code. In which case, this function will become part of the Python BScanArguments class, and will not need the long list of input arguments that it currently depends on.
 
 % test_directory : Path to directory into which to place generated input files
 % input_filename : Path to the input file, defining run-specific dimensions, functions, etc
 % non_fs_obstacle: String, either 'sph', 'cyl', defining the shape of the obstacle present in the non-free-space simulation
 % illfile_extra_file: If present, we need to call iteratefdtd_matrix twice, once to setup the illumination and again to setup the .mat inputs. input_filename must be passed when iteratefdtd_matrix is in illsetup mode, and this file must be passed when it is in filesetup mode. If this variable contains an empty string, we simply need to pass input_filename to iteratefdtd_matrix in filesetup mode as usual.
+% obstacle_radius: The radius in microns of the obstacle (radius of the circular face for a cyl, radius of the sphere for sph)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Create directory into which to place the input files, if it doesn't exist already
@@ -19,15 +21,13 @@ end
 % Define coordinates of the computational grid
 [x,y,z,lambda] = fdtd_bounds(input_filename);
 
-% 15 micron radius
-rad = 15e-6;
 % Refractive index of obstacle
 refind = 1.42;
 
 % Insert obstacle, typically at the origin, by introducing the scattering matrix
 y = 0;
 [X,Y,Z] = ndgrid(x,y,z);
-I = scattering_matrix(X, Y, Z, rad, non_fs_obstacle);
+I = scattering_matrix(X, Y, Z, obstacle_radius, non_fs_obstacle);
 
 % Generate additional matrices
 inds = find(I(:));

--- a/tdms/tests/system/data/input_generation/bscan/run_bscan.m
+++ b/tdms/tests/system/data/input_generation/bscan/run_bscan.m
@@ -1,6 +1,11 @@
-function [] = run_bscan(test_directory, input_filename)
+function [] = run_bscan(test_directory, input_filename, non_fs_obstacle, illfile_extra_file)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %This function generates the files used as input to the executeable
+
+% test_directory : Path to directory into which to place generated input files
+% input_filename : Path to the input file, defining run-specific dimensions, functions, etc
+% non_fs_obstacle: String, either 'sph', 'cyl', defining the shape of the obstacle present in the non-free-space simulation
+% illfile_extra_file: If present, we need to call iteratefdtd_matrix twice, once to setup the illumination and again to setup the .mat inputs. input_filename must be passed when iteratefdtd_matrix is in illsetup mode, and this file must be passed when it is in filesetup mode. If this variable contains an empty string, we simply need to pass input_filename to iteratefdtd_matrix in filesetup mode as usual.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% Create directory into which to place the input files, if it doesn't exist already
@@ -9,38 +14,55 @@ if ~exist(dir_to_place_input_mats, 'dir')
     mkdir(dir_to_place_input_mats);
 end
 
-%% Generate the input file
+%% Generate auxillary arrays / matrices needed to setup the inputs
 
-%start by defining the coordinates of the computational grid
+% Define coordinates of the computational grid
 [x,y,z,lambda] = fdtd_bounds(input_filename);
 
-%15 micron radius cylinder
+% 15 micron radius
 rad = 15e-6;
-%refractive index of cylinder
+% Refractive index of obstacle
 refind = 1.42;
 
-%insert a cylinder at the origin
+% Insert obstacle, typically at the origin, by introducing the scattering matrix
 y = 0;
 [X,Y,Z] = ndgrid(x,y,z);
+I = scattering_matrix(X, Y, Z, rad, non_fs_obstacle);
 
-%generate scattering matrix
-I = zeros(size(X));
-%set all Yee cells within the cylinder to have index of 1
-I( (X.^2 + Z.^2) < rad^2 ) = 1;
-I( (end-3):end,1,:) = 0;
-I( :, 1, (end-3):end) = 0;
+% Generate additional matrices
 inds = find(I(:));
 [ii,jj,kk] = ind2sub(size(I), inds);
 composition_matrix = [ii jj kk ones(size(ii))];
 material_matrix = [1 refind^2 1 0 0 0 0 0 0 0 0];
 
-save('gridfile_cyl', 'composition_matrix', 'material_matrix');
-%setup free space matrix and save
+% Save obstacle matrices
+obstacle_gridfile = sprintf('gridfile_%s.mat',non_fs_obstacle);
+save(obstacle_gridfile, 'composition_matrix', 'material_matrix');
+% Setup & save freespace matrix
 composition_matrix = [];
 save('gridfile_fs', 'composition_matrix', 'material_matrix');
 
-%generate tdms executable input files
-iteratefdtd_matrix(input_filename,'filesetup',strcat(dir_to_place_input_mats,'/pstd_cyl_input'),'gridfile_cyl.mat','');
-iteratefdtd_matrix(input_filename,'filesetup',strcat(dir_to_place_input_mats,'/pstd_fs_input'),'gridfile_fs.mat','');
+%% Generate TDMS executable input files
+
+% This is the file that should be passed to iteratefdtd_matrix in filesetup mode
+filesetup_input_file = '';
+% Setup illumination file if necessary
+if strcmp(illfile_extra_file, "")
+    % This is empty, so we just call iteratefdtd_matrix immediately using input_filename
+    filesetup_input_file = input_filename;
+else
+    % We need a call to iteratefdtd_matrix in illsetup mode first
+    iteratefdtd_matrix(input_filename,'illsetup','illfile',obstacle_gridfile,'');
+    % Then call iteratefdtd_matrix in filesetup mode using illfile_extra_file as the input file
+    filesetup_input_file = illfile_extra_file;
+end
+
+% Names to save .mat files under
+obstacle_output_file = sprintf('%s/pstd_%s_input',dir_to_place_input_mats, non_fs_obstacle);
+freespace_output_file = sprintf('%s/pstd_fs_input',dir_to_place_input_mats);
+
+% Call iteratefdtd_matrix in filesetup mode to generate input .mat files for tdms executable
+iteratefdtd_matrix(filesetup_input_file,'filesetup',obstacle_output_file,obstacle_gridfile,'');
+iteratefdtd_matrix(filesetup_input_file,'filesetup',freespace_output_file,'gridfile_fs.mat','');
 
 end

--- a/tdms/tests/system/data/input_generation/config_01.yaml
+++ b/tdms/tests/system/data/input_generation/config_01.yaml
@@ -1,8 +1,21 @@
+# A string containing the test_id
 test_id: '01'
+# Indicates that what follows is information needed when performing the runs that make up this system test.
+# Tags within this block correspond to one run that forms part of this system test
+# The tags themselves are used as the names for each run, and should be unique
+# Paths to files must be relative to their location in the Zenodo .zip files this is to be downloaded
 tests:
+  # Indiates the start of another block, the information is which is only applied when performing this run of tdms
   fs_bli:
+    # The name of the .mat inut file that should be passed to the tdms executable
     input_file: pstd_fs_input.mat
+    # The name of the reference .mat output to comapre the output of the local tdms run to
     reference: pstd_fs_bli_reference.mat
+    # A bool indicating whether or not tdms should use the cubic interpolation switch -c or not in this run. Defaults to False if not present
+    cubic_interpolation: False
+    # A bool indicating whether or not tdms should use the fdtd solver method or not (in which case pstd is used). Defaults to False if not present.
+    fdtd_solver: False
+  # This defines another, independent run of tdms that is still part of the same system test.
   fs_cubic:
     input_file: pstd_fs_input.mat
     reference: pstd_fs_cubic_reference.mat
@@ -14,7 +27,14 @@ tests:
     input_file: pstd_cyl_input.mat
     reference: pstd_cyl_cubic_reference.mat
     cubic_interpolation: True
+# Indicates that what follows is information needed when regenerating the .mat inputs that are passed to tdms in the runs that consistute this test.
+# Paths to files should be relative to the tdms/tests/system/data/input_generation directory.
 input_generation:
+  # The file that is passed to iteratefdtd_matrix in run_bscan
   input_file: input_file_01.m
+  # List of strings specifying the spatial obstacles to setup for this test. One of these should be 'fs' for "freespace". The other obstacle(s) can be any of "sph" (sphere), "cyl" (cylindrical), "sc" (point-source)
   spatial_obstacles: ["fs", "cyl"]
-  illsetup:
+  # Whether iteratefdtd_matrix must be called in illsetup mode to setup the illumination file, prior to its call in filesetup mode. Defaults to False if not present or unpopulated
+  illsetup: False
+  # The radius of the non-freespace obstacle in microns. For "sph", the radius of the sphere. For "cyl", the radius of the circular faces. Defaults to 15.e-6 if not set.
+  obstacle_radius: 15.e-6

--- a/tdms/tests/system/data/input_generation/config_01.yaml
+++ b/tdms/tests/system/data/input_generation/config_01.yaml
@@ -1,9 +1,8 @@
 # A string containing the test_id
 test_id: '01'
-# Indicates that what follows is information needed when performing the runs that make up this system test.
-# Tags within this block correspond to one run that forms part of this system test
-# The tags themselves are used as the names for each run, and should be unique
-# Paths to files must be relative to their location in the Zenodo .zip files this is to be downloaded
+# This section contains information required for running the system test.
+# Each tag within this block corresponds to a unique run in the system test and is used as the name for that run.
+# When specifying file paths, please use relative paths with respect to their location in the downloaded Zenodo .zip files.
 tests:
   # Indiates the start of another block, the information is which is only applied when performing this run of tdms
   fs_bli:

--- a/tdms/tests/system/data/input_generation/config_01.yaml
+++ b/tdms/tests/system/data/input_generation/config_01.yaml
@@ -17,4 +17,4 @@ tests:
 input_generation:
   input_file: input_file_01.m
   spatial_obstacles: ["fs", "cyl"]
-  illumination_input_file:
+  illsetup:

--- a/tdms/tests/system/data/input_generation/config_02.yaml
+++ b/tdms/tests/system/data/input_generation/config_02.yaml
@@ -1,0 +1,20 @@
+test_id: '02'
+tests:
+  fs_bli:
+    input_file: pstd_fs_input.mat
+    reference: pstd_fs_bli_reference.mat
+  fs_cubic:
+    input_file: pstd_fs_input.mat
+    reference: pstd_fs_cubic_reference.mat
+    cubic_interpolation: True
+  cyl_bli:
+    input_file: pstd_cyl_input.mat
+    reference: pstd_cyl_bli_reference.mat
+  cyl_cubic:
+    input_file: pstd_cyl_input.mat
+    reference: pstd_cyl_cubic_reference.mat
+    cubic_interpolation: True
+input_generation:
+  input_file: input_file_02.m
+  spatial_obstacles: ["fs", "cyl"]
+  illumination_input_file:

--- a/tdms/tests/system/data/input_generation/config_02.yaml
+++ b/tdms/tests/system/data/input_generation/config_02.yaml
@@ -17,4 +17,4 @@ tests:
 input_generation:
   input_file: input_file_02.m
   spatial_obstacles: ["fs", "cyl"]
-  illumination_input_file:
+  illsetup:

--- a/tdms/tests/system/data/input_generation/config_03.yaml
+++ b/tdms/tests/system/data/input_generation/config_03.yaml
@@ -18,3 +18,4 @@ input_generation:
   input_file: input_file_03.m
   spatial_obstacles: ["fs", "sph"]
   illsetup: True
+  obstacle_radius: 5.e-6

--- a/tdms/tests/system/data/input_generation/config_03.yaml
+++ b/tdms/tests/system/data/input_generation/config_03.yaml
@@ -1,0 +1,20 @@
+test_id: '03'
+tests:
+  fs_bli:
+    input_file: pstd_fs_input.mat
+    reference: pstd_fs_bli_reference.mat
+  fs_cubic:
+    input_file: pstd_fs_input.mat
+    reference: pstd_fs_cubic_reference.mat
+    cubic_interpolation: True
+  sph_bli:
+    input_file: pstd_sph_input.mat
+    reference: pstd_sph_bli_reference.mat
+  sph_cubic:
+    input_file: pstd_sph_input.mat
+    reference: pstd_sph_cubic_reference.mat
+    cubic_interpolation: True
+input_generation:
+  input_file: input_file_03.m
+  spatial_obstacles: ["fs", "sph"]
+  illsetup: True

--- a/tdms/tests/system/data/input_generation/config_03.yaml
+++ b/tdms/tests/system/data/input_generation/config_03.yaml
@@ -18,4 +18,4 @@ input_generation:
   input_file: input_file_03.m
   spatial_obstacles: ["fs", "sph"]
   illsetup: True
-  obstacle_radius: 5.e-6
+  obstacle_radius: 5e-6

--- a/tdms/tests/system/data/input_generation/generate_test_input.py
+++ b/tdms/tests/system/data/input_generation/generate_test_input.py
@@ -36,7 +36,7 @@ def _create_temporary_filesetup(input_filename, temp_filesetup_name) -> None:
     return
 
 def run_bscan(
-    test_directory: Path | str, input_filename: Path | str, engine: MatlabEngine, obstacle: str = 'fs', illfile_required: bool = False) -> None:
+    test_directory: Path | str, input_filename: Path | str, engine: MatlabEngine, obstacle: str = 'fs', obstacle_radius: float = 15.e-6, illfile_required: bool = False) -> None:
     """Wrapper for running the run_bscan MATLAB function in the MATLAB engine provided.
 
     MatlabEngine cannot parse Path objects so file and directory paths must be cast to string when calling.
@@ -56,8 +56,8 @@ def run_bscan(
         # Otherwise, the "input" file to the illsetup and input file for the .mat creation are identical. As such, the optimal way to get around this is to have Python pass the input_file via 'illsetup', then copy this file, remove the definition of the efname & hfname variables, then run 'filesetp' mode. We can then cleanup our "extra" file that we created.
         illfile_extra_file = os.path.splitext(input_filename)[0] + "temp_filesetup_file____.m"
         _create_temporary_filesetup(input_filename, illfile_extra_file)
-    # function [] = run_bscan(test_directory, input_filename, non_fs_obstacle, illfile_extra_file)
-    engine.run_bscan(str(test_directory), str(input_filename), obstacle, illfile_extra_file, nargout=0)
+    # function [] = run_bscan(test_directory, input_filename, non_fs_obstacle, illfile_extra_file, obstacle_radius)
+    engine.run_bscan(str(test_directory), str(input_filename), obstacle, illfile_extra_file, obstacle_radius, nargout=0)
 
     # Cleanup the illfile_extra_file, if it was created
     if illfile_required:

--- a/tdms/tests/system/data/input_generation/generate_test_input.py
+++ b/tdms/tests/system/data/input_generation/generate_test_input.py
@@ -24,8 +24,8 @@ DEFAULT_VALUES = {
 
 
 def _create_temporary_filesetup(input_filename, temp_filesetup_name) -> None:
-    """Generates a temporary file that will be used as input to iteratefdtd_matrix in filesetup mode, along with an illumination file. 
-    
+    """Generates a temporary file that will be used as input to iteratefdtd_matrix in filesetup mode, along with an illumination file.
+
     The file in filesetup mode is almost identical to the original input file, but with empty strings set for the efname and hfname variables. To achieve this, the input file (used to set up the illumination) is copied by Python, and the efname and hfname variables are modified to create the file in filesetup mode.
     """
     # Copy the input_file (illumination-input) line-by-line to a temporary location for the filesetup-input
@@ -37,7 +37,9 @@ def _create_temporary_filesetup(input_filename, temp_filesetup_name) -> None:
                 # This avoids funny business if there's whitespace around the = symbol where {ef,hf}name are defined
                 stripped_line = line.replace(" ", "")
                 # Write line, provided efname or hfname are not defined on it
-                if (("efname=" not in stripped_line) and ("hfname=" not in stripped_line)):
+                if ("efname=" not in stripped_line) and (
+                    "hfname=" not in stripped_line
+                ):
                     filesetup_input.write(line)
                 elif "efname=" in stripped_line:
                     filesetup_input.write("efname = '';\n")

--- a/tdms/tests/system/data/input_generation/generate_test_input.py
+++ b/tdms/tests/system/data/input_generation/generate_test_input.py
@@ -24,9 +24,9 @@ DEFAULT_VALUES = {
 
 
 def _create_temporary_filesetup(input_filename, temp_filesetup_name) -> None:
-    """Generate the temporary file to be passed to iteratefdtd_matrix in filesetup mode when an illumination file has also been specified.
-
-    The "filesetup" mode-file is essentially identical to it's counterpart, but needs the efname and hfname variables TO to be present, but set to empty strings. As such, the optimal way to get around this is to have Python copy the input_file (which in this instance is what needs to be used to setup the illumination), and then change the definition of the efname & hfname variables to empty strings in the copied file to create the "filesetup" input.
+    """Generates a temporary file that will be used as input to iteratefdtd_matrix in filesetup mode, along with an illumination file. 
+    
+    The file in filesetup mode is almost identical to the original input file, but with empty strings set for the efname and hfname variables. To achieve this, the input file (used to set up the illumination) is copied by Python, and the efname and hfname variables are modified to create the file in filesetup mode.
     """
     # Copy the input_file (illumination-input) line-by-line to a temporary location for the filesetup-input
     # Do not copy across the lines that define the efname and hfname variables
@@ -37,7 +37,7 @@ def _create_temporary_filesetup(input_filename, temp_filesetup_name) -> None:
                 # This avoids funny business if there's whitespace around the = symbol where {ef,hf}name are defined
                 stripped_line = line.replace(" ", "")
                 # Write line, provided efname or hfname are not defined on it
-                if not (("efname=" in stripped_line) or ("hfname=" in stripped_line)):
+                if (("efname=" not in stripped_line) and ("hfname=" not in stripped_line)):
                     filesetup_input.write(line)
                 elif "efname=" in stripped_line:
                     filesetup_input.write("efname = '';\n")

--- a/tdms/tests/system/data/input_generation/input_file_02.m
+++ b/tdms/tests/system/data/input_generation/input_file_02.m
@@ -1,0 +1,149 @@
+%these are not involved in the formal input file spec
+lambda = 1300e-9;
+
+%size of Yee cell in metres
+delta.x = lambda/4;
+delta.y = lambda/4;
+delta.z = lambda/4;
+
+
+%define the grid size, a square of side 1.5 wavelengths
+I = 256;
+J = 0;
+K = 256;
+%K = 5500;
+
+%order of the PML conductivity profile curve
+n = 4;
+
+%maximum reflection at PML
+R0 = 1e-7;
+
+%number of PML cells in each direction
+Dxl = 10;
+Dxu = 10;
+Dyl = 0;
+Dyu = 0;
+Dzl = 10;
+Dzu = 10;
+
+%courant time step
+dt = 2/sqrt(2)/pi*delta.x/(3e8/1.35)*.95;
+
+%define the number of time steps
+Nt = 500;
+%Nt=12000;
+
+%water
+epsr = [1.35^2];
+mur = [1];
+kappa_max = [1];
+multilayer = [];
+
+%frequency in Hz
+f_an = asin( 2*pi/1300e-9*2.997924580105029e+08*dt/2)/(pi*dt);
+
+%This is where we define the planes where the incident waveforms
+%are introduced. The variable interface has 6 members, I0, I1, J0,
+%J1, K0, K1 which are 1x2 vectors. The first entry is the position
+%of the plane, in local coordinates and the second entry os whether
+%or not to apply the interface condition at that plane
+interface.I0 = [5 0];
+interface.I1 = [I-5 0];
+interface.J0 = [5 0];
+interface.J1 = [J-5 0];
+interface.K0 = [10 1];
+interface.K1 = [K-5 0];
+
+%not used as run mode is complete
+outputs_array ={};
+
+%these are the function names used to generate the field
+efname = 'efield_gauss';
+hfname = 'hfield_focused_equiv';
+
+%this is the z value at which the field is launched, in metres
+z_launch = 0;
+
+
+%this defines the point about which the illumination is centred in
+%the so called 'interior' coordinate system
+illorigin = [floor(I/2) floor(J/2) floor(K/2)];
+
+%the wavelength width (in m). This corresponds to the FWHM of the
+wavelengthwidth = 120e-9;
+
+%this defines the run mode of the simulation, can be 'analyse' or
+%'complete'. 'analyse' means that sub results can be saved using
+%the statements in outputs_array. When complete is specified, only
+%the final results will be saved using the outputs_array statements.
+%runmode = 'analyse';
+runmode = 'complete';
+
+
+%this is the kind of source mode, can be 'steadystate' or
+sourcemode = 'pulsed';
+
+%this determines whether or not to extract phasors in the volume of
+%the grid
+exphasorsvolume = 1;
+
+%this determines whether or not to extract phasors around a
+%specified surface
+exphasorssurface = 1;
+
+%this specifies a surface to extract the phasors at. These
+%quantities are in interior coordinate system;
+%has the form [I0 I1 J0 J1 K0 K1] which defines the extremes of a
+%cuboid wihch defines the surface to extract phasors at
+%These should be set so that the interpolation scheme can work
+phasorsurface = [5 I-5 1 1 20 K-5];
+
+%could be '3' 'TE' or 'TM'
+dimension = '3';
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+fieldsample.i = (128-4):(128+4);
+fieldsample.j = 1;
+fieldsample.k = (128-4):(128+4);
+fieldsample.n = [2 4];
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+[ii,jj,kk] = ndgrid([20 120],1,[50 150]);
+campssample.vertices = [ii(:) jj(:) kk(:)];
+campssample.components = [1 2 3];
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Nlambda = 16;
+lambda0 = 1300e-9;
+dlambda = 170e-9;
+b = 4*sqrt(log(2))*lambda0^2/(2*pi*3e8*dlambda);
+omega0 = 2*pi*3e8/lambda0;
+%omega1 = 2*pi*3e8/(lambda0-dlambda/2);
+
+omega_min = omega0 - sqrt(4/b^2*log(10^3));
+omega_max = omega0 + sqrt(4/b^2*log(10^3));
+
+lambda_min = 3e8*2*pi/omega_max;
+lambda_max = 3e8*2*pi/omega_min;
+
+
+omega_vec = linspace(omega_min,omega_max,Nlambda);
+k_vec = omega_vec/2.997924580105029e+08;
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+f_ex_vec = asin( k_vec*2.997924580105029e+08*dt/2)/(pi*dt);
+
+%ignore all below here
+exdetintegral=0;
+k_det_obs=10;
+%k_obs = k_det_obs;
+NA_det=(7e-3/2)/36e-3;
+%NA = NA_det;
+beta_det=25/36;
+detmodevec=1:3;
+detsensefun='gaussian_d_telesto_matlab';
+air_interface = [];
+
+det_trans_x = (-30:2:30)*1e-6;
+det_trans_y = (-30:2:30)*1e-6;
+
+illspecfun = '';

--- a/tdms/tests/system/data/input_generation/input_file_03.m
+++ b/tdms/tests/system/data/input_generation/input_file_03.m
@@ -1,0 +1,149 @@
+%these are not involved in the formal input file spec
+lambda = 1300e-9;
+
+%size of Yee cell in metres
+delta.x = lambda/4;
+delta.y = lambda/4;
+delta.z = lambda/4;
+
+
+%define the grid size, a square of side 1.5 wavelengths
+I = 128;
+J = 128;
+K = 64;
+%K = 5500;
+
+%order of the PML conductivity profile curve
+n = 4;
+
+%maximum reflection at PML
+R0 = 1e-7;
+
+%number of PML cells in each direction
+Dxl = 10;
+Dxu = 10;
+Dyl = 0;
+Dyu = 0;
+Dzl = 10;
+Dzu = 10;
+
+%courant time step
+dt = 2/sqrt(3)/pi*delta.x/(3e8/1.35)*.95;
+
+%define the number of time steps
+Nt = 200;
+%Nt=12000;
+
+%water
+epsr = [1.35^2];
+mur = [1];
+kappa_max = [1];
+multilayer = [];
+
+%frequency in Hz
+f_an = asin( 2*pi/1300e-9*2.997924580105029e+08*dt/2)/(pi*dt);
+
+%This is where we define the planes where the incident waveforms
+%are introduced. The variable interface has 6 members, I0, I1, J0,
+%J1, K0, K1 which are 1x2 vectors. The first entry is the position
+%of the plane, in local coordinates and the second entry os whether
+%or not to apply the interface condition at that plane
+interface.I0 = [5 0];
+interface.I1 = [I-5 0];
+interface.J0 = [5 0];
+interface.J1 = [J-5 0];
+interface.K0 = [10 1];
+interface.K1 = [K-5 0];
+
+%not used as run mode is complete
+outputs_array ={};
+
+%these are the function names used to generate the field
+efname = 'efield_gauss';
+hfname = 'hfield_focused_equiv';
+
+%this is the z value at which the field is launched, in metres
+z_launch = 0;
+
+
+%this defines the point about which the illumination is centred in
+%the so called 'interior' coordinate system
+illorigin = [floor(I/2) floor(J/2) floor(K/2)];
+
+%the wavelength width (in m). This corresponds to the FWHM of the
+wavelengthwidth = 120e-9;
+
+%this defines the run mode of the simulation, can be 'analyse' or
+%'complete'. 'analyse' means that sub results can be saved using
+%the statements in outputs_array. When complete is specified, only
+%the final results will be saved using the outputs_array statements.
+%runmode = 'analyse';
+runmode = 'complete';
+
+
+%this is the kind of source mode, can be 'steadystate' or
+sourcemode = 'pulsed';
+
+%this determines whether or not to extract phasors in the volume of
+%the grid
+exphasorsvolume = 1;
+
+%this determines whether or not to extract phasors around a
+%specified surface
+exphasorssurface = 1;
+
+%this specifies a surface to extract the phasors at. These
+%quantities are in interior coordinate system;
+%has the form [I0 I1 J0 J1 K0 K1] which defines the extremes of a
+%cuboid wihch defines the surface to extract phasors at
+%These should be set so that the interpolation scheme can work
+phasorsurface = [5 I-5 5 J-5 5 K-5];
+
+%could be '3' 'TE' or 'TM'
+dimension = '3';
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+fieldsample.i = (I/2-4):(I/2+4);
+fieldsample.j = (J/2-4):(J/2+4);
+fieldsample.k = (K/2-4):(K/2+4);
+fieldsample.n = [2 4];
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+[ii,jj,kk] = ndgrid((I/2-4):(I/2+4),(J/2-4):(J/2+4),(K/2-4):(K/2+4));
+campssample.vertices = [ii(:) jj(:) kk(:)];
+campssample.components = [1 2 3];
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Nlambda = 16;
+lambda0 = 1300e-9;
+dlambda = 170e-9;
+b = 4*sqrt(log(2))*lambda0^2/(2*pi*3e8*dlambda);
+omega0 = 2*pi*3e8/lambda0;
+%omega1 = 2*pi*3e8/(lambda0-dlambda/2);
+
+omega_min = omega0 - sqrt(4/b^2*log(10^3));
+omega_max = omega0 + sqrt(4/b^2*log(10^3));
+
+lambda_min = 3e8*2*pi/omega_max;
+lambda_max = 3e8*2*pi/omega_min;
+
+
+omega_vec = linspace(omega_min,omega_max,Nlambda);
+k_vec = omega_vec/2.997924580105029e+08;
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+f_ex_vec = asin( k_vec*2.997924580105029e+08*dt/2)/(pi*dt);
+
+%ignore all below here
+exdetintegral=0;
+k_det_obs=10;
+%k_obs = k_det_obs;
+NA_det=(7e-3/2)/36e-3;
+%NA = NA_det;
+beta_det=25/36;
+detmodevec=1:3;
+detsensefun='gaussian_d_telesto_matlab';
+air_interface = [];
+
+det_trans_x = (-30:2:30)*1e-6;
+det_trans_y = (-30:2:30)*1e-6;
+
+illspecfun = '';

--- a/tdms/tests/system/data/input_generation/matlab/scattering_matrix.m
+++ b/tdms/tests/system/data/input_generation/matlab/scattering_matrix.m
@@ -1,13 +1,23 @@
-function [I] = scattering_matrix(X, Y, Z, rad, obj_shape)
+function [I] = scattering_matrix(file_with_coordinates, rad, obj_shape)
     %% Setup the scattering matrix for the given object shape and grid cooordinates.
-    % X, Y, Z: Outputs of ndgrid, the coordinates of the Yee cells we will be using
+    % x, y, z: Vectors, the tensor/outer product of which forms the set of coordinates of the Yee cells we will be using
     % rad: Radius of the sph object, or circular-face of a cyl object
     % obj_shape: The shape of the scattering object. Options are;
     %       sph : sphere
     %       cyl : cylinder
 
+    % Obtain coordinates of the computational grid
+    [x,y,z,lambda] = fdtd_bounds(file_with_coordinates);
+    % Account for the possibility that we are defining a cylindrical object, so we need to "loose" a dimension
+    if strcmp(obj_shape, 'cyl')
+        y = 0;
+    end
+    % Generate Yee cell coords
+    [X,Y,Z] = ndgrid(x,y,z);
+    % Create scattering matrix of shape (x \otimes y \otimes z)
     I = zeros(size(X));
 
+    % I_{jk} = 1 if this Yee cell is part of the scattering object, 0 otherwise
     if strcmp(obj_shape, 'sph')
         %set all Yee cells within the sphere to have index of 1
         I( X.^2 + Y.^2 + Z.^2 < rad^2 ) = 1;

--- a/tdms/tests/system/data/input_generation/matlab/scattering_matrix.m
+++ b/tdms/tests/system/data/input_generation/matlab/scattering_matrix.m
@@ -1,0 +1,22 @@
+function [I] = scattering_matrix(X, Y, Z, rad, obj_shape)
+    %% Setup the scattering matrix for the given object shape and grid cooordinates.
+    % X, Y, Z: Outputs of ndgrid, the coordinates of the Yee cells we will be using
+    % rad: Radius of the sph object, or circular-face of a cyl object
+    % obj_shape: The shape of the scattering object. Options are;
+    %       sph : sphere
+    %       cyl : cylinder
+
+    I = zeros(size(X));
+
+    if strcmp(obj_shape, 'sph')
+        %set all Yee cells within the sphere to have index of 1
+        I( X.^2 + Y.^2 + Z.^2 < rad^2 ) = 1;
+        I((end-3):end, 1, :) = 0;
+        I(:, 1, (end-3):end) = 0;
+    elseif strcmp(obj_shape, 'cyl')
+        %set all Yee cells within the cylinder to have index of 1
+        I( X.^2 + Z.^2 < rad^2 ) = 1;
+        I((end-3):end, 1, :) = 0;
+        I(:, 1, (end-3):end) = 0;
+    end
+end

--- a/tdms/tests/system/data/pyproject.toml
+++ b/tdms/tests/system/data/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/tdms/tests/system/data/pyproject.toml
+++ b/tdms/tests/system/data/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"

--- a/tdms/tests/system/test_regen.py
+++ b/tdms/tests/system/test_regen.py
@@ -26,7 +26,7 @@ ZENODO_URL = "https://zenodo.org/record/7440616/files"
 ZIP_DESTINATION = Path(os.path.dirname(os.path.abspath(__file__)), "data")
 
 # Find all config_XX.yaml files and hence infer all test cases that need to be run
-TEST_IDS = glob(str(path_to_input_generation / "config_*.yaml"))
+TEST_IDS = sorted(glob(str(path_to_input_generation / "config_*.yaml")))
 for i, id in enumerate(TEST_IDS):
     # remove everything bar the ID from what we found
     id = id.removeprefix(str(path_to_input_generation / "config_"))


### PR DESCRIPTION
Continues #240 |

Adds `arc_02` and `arc_03` to the list of tests which are now covered by the input data regeneration scripts.

Modifications on top of #236:
- `run_bscan` now handles different spatial objects, obstacle radii, and when `illsetup` is required on top of the usual `filesetup`.
- `config_XX.yaml` and `input_file_XX.m` are added to the `data/input_generation` folder appropriately
- ~`generate_input_data.py` has been split into `bscan_arguments.py` and `generation_data.py` containing classes of the same name, to separate functionality.~
- ~Reduces the number of variables and input parameters that were stored more than once across the test classes~ (this is redundant because the classes now no longer exist in the base branch)
- `test_regen.py` will run tests in numerical order when called locally, which is nice.

Force-push changes here :point_right: https://github.com/UCL/TDMS/pull/241#issuecomment-1521771053