### PR TITLE
General tidy up of `matlab` directory

### DIFF
--- a/tdms/tests/matlab/test_fdtdduration.m
+++ b/tdms/tests/matlab/test_fdtdduration.m
@@ -1,7 +1,7 @@
 
 % Define the tests as all the locally defined functions
 function tests = test_iteratefdtd_matrix_function
-    addpath('../system/data/input_generation/matlab', 'data/');
+    addpath('../system/data/input_generation/matlab')
     tests = functiontests(localfunctions);
 end
 
@@ -9,7 +9,7 @@ end
 function testGaussianPulseParameters(testCase)
 
     % ? and Half width at half maximum (HWHM)
-    [to_actual hwhm_actual] = fdtdduration('pstd_input_file_2D.m');
+    [to_actual hwhm_actual] = fdtdduration('data/pstd_input_file_2D.m');
 
     % Check that these are the expected values
     verifyEqual(testCase, 3.035046893364502e-14, hwhm_actual, "AbsTol", 1e-10);
@@ -21,7 +21,7 @@ function testMinStepsFDTD(testCase)
 
     n_expected = 1483;
     % This also tests fdtdts, which computes the upper limit of the number of timesteps
-    n_acual = minsteps_fdtd('pstd_input_file_2D.m');
+    n_acual = minsteps_fdtd('data/pstd_input_file_2D.m');
 
     verifyEqual(testCase, n_expected, n_acual);
 end
@@ -30,7 +30,7 @@ end
 function testMinStepsPSTD(testCase)
 
     n_expected = 891;
-    n_acual = minsteps_pstd('pstd_input_file_2D.m');
+    n_acual = minsteps_pstd('data/pstd_input_file_2D.m');
 
     verifyEqual(testCase, n_expected, n_acual);
 end

--- a/tdms/tests/matlab/test_iteratefdtd_matrix.m
+++ b/tdms/tests/matlab/test_iteratefdtd_matrix.m
@@ -54,7 +54,7 @@ function testFileSetupInvalidIlluminationFile2DExi(testCase)
 end
 
 function runInTempoaryDirectory(testCase, func, exception)
-    addpath('../../matlab/', 'data/');
+    addpath('../system/data/input_generation/matlab', 'data/');
 
     oldFolder = cd(createTemporaryFolder(testCase));
     if (strlength(exception) > 0)

--- a/tdms/tests/system/data/input_generation/matlab/calc_field_tdfield.m
+++ b/tdms/tests/system/data/input_generation/matlab/calc_field_tdfield.m
@@ -1,14 +1,21 @@
 function [saveas] = calc_field_tdfield(input_filename, saveas)
+    %% Computes a time-domain illumination field that will be passed as an input to iteratefdtd_matrix.
+    %% The field is a plane wave, linearly polarised in the x-direction.
+    % input_filename : Name of the input file to read variables from
+    % saveas         : Name to save the resulting time-domain field to. Defaults to eivars.mat if not set.
 
+    %% Deduce optional inputs
     if ~exist('saveas', 'var')
         saveas = 'eivars.mat';
     end
 
+    %% Setup constants
     [~, ~, c] = import_constants;
     lambda0 = 1300e-9;
     omega0 = 2*pi*c/lambda0;
 
-    [ex_coords, ey_coords, tvec_E, fvec_E, f_an, hwhm, to_l] = getsourcecoords(input_filename);
+    % Pull information that we need from the input file (discard ey_coords and tvec_E)
+    [ex_coords, ~, ~, fvec_E, f_an, hwhm, to_l] = getsourcecoords(input_filename);
 
     lambdavec_E = c./fvec_E;
 
@@ -20,7 +27,7 @@ function [saveas] = calc_field_tdfield(input_filename, saveas)
     Exi = zeros(numel(ex_coords.x),numel(ex_coords.y),numel(ex_coords.z),numel(fvec_E));
     Eyi = zeros(numel(ex_coords.x),numel(ex_coords.y),numel(ex_coords.z),numel(fvec_E));
 
-    % Setup a plane wave, linearly polarised in the x-direction,
+    %% Setup a plane wave, linearly polarised in the x-direction
     for il=1:numel(lambdavec_E)
         Exi(:,1,1,il) = 2*exp(sqrt(-1)*2*pi/lambdavec_E(il)*1.35*(ex_coords.z-dz));
     end
@@ -44,6 +51,6 @@ function [saveas] = calc_field_tdfield(input_filename, saveas)
     eyi = zeros( size(eyi_store,1), size(eyi_store,2), size(eyi_store,4) );
     eyi(:,:,:) = eyi_store(:,:,1,:);
 
-    % Save to desired output file
+    %% Save to desired output file
     save(saveas, 'exi', 'eyi');
 end

--- a/tdms/tests/system/data/input_generation/matlab/efield_gauss_base.m
+++ b/tdms/tests/system/data/input_generation/matlab/efield_gauss_base.m
@@ -1,5 +1,13 @@
 function [E] = efield_gauss_base(X, Y, Z, tight, gauss_pol_method)
-    % Check for defaults MATLAB-style
+    %% Sets up a Gaussian electric field over the spatial grid X, Y, Z that is passed. Optional parameters can be passed to change the default behaviour.
+    % X, Y, Z           : Vectors defining the coordinate grid, output of ndgrid(x, y, z)
+    % tight             : Boolean, when set to true, a tighter Gaussian is produced but the number of lens angles is increased. Defaults to false.
+    % gauss_pol_method  : Function handle wrapping gauss_pol_base - determines detailed shape of the Gaussian field.
+    %                     gauss_pol_based is used as the default.
+    %
+    % E                 : The gaussian electric field produced, defined over the spatial grid.
+
+    %% Check for optional arguments
     if ~exist('tight', 'var')
         tight = false;
     end
@@ -7,13 +15,17 @@ function [E] = efield_gauss_base(X, Y, Z, tight, gauss_pol_method)
         gauss_pol_method = @(th, ph) gauss_pol_base(th, ph, false);
     end
 
+    %% Prepare output field storage
     [m,n] = size(X);
     E = cell(1,2);
     E{1} = zeros(m,n);
     E{2} = zeros(m,n);
+
+    %% Define constants
     lambda = 1300e-9;
     k=2*pi/lambda;
     refind = 1.35;
+    % Adjust depending on tight-ness
     if tight
         dz = lambda/4;
         ntheta = 100;
@@ -23,19 +35,18 @@ function [E] = efield_gauss_base(X, Y, Z, tight, gauss_pol_method)
         ntheta = 200;
         nphi = [];
     end
-    %dz/2 term due to the modified source condition
+    % dz/2 term due to the modified source condition
     vertices = [X(:) Y(:) Z(:)-dz/2];
     nvec = refind;
     hvec = [];
     NA = 1;
 
-    %first calculate normalisation
+    %% Compute the field
+    % Compute the normalisation of the field
     [EpN,Em] = focstratfield([0 0 0],nvec,hvec,NA,lambda,ntheta,nphi,gauss_pol_method);
-
-    %calculate the field at the interface
+    % Then calculate the field at the interface
     [Ep,Em] = focstratfield(vertices,nvec,hvec,NA,lambda,ntheta,nphi,gauss_pol_method);
-
-    %factor of 2 due to the modified source condition
+    % Multiply by due to the modified source condition
     E{1} = 2*reshape(Ep(:,1)/EpN(1),size(X));
     E{2} = 2*reshape(Ep(:,2)/EpN(1),size(X));
 end

--- a/tdms/tests/system/data/input_generation/matlab/efield_plane.m
+++ b/tdms/tests/system/data/input_generation/matlab/efield_plane.m
@@ -1,18 +1,24 @@
 function [E] = efield_plane(X,Y,Z)
+    %% Sets up a plane-wave electric field propagating in the z-direction, over the spatial grid X, Y, Z.
+    % X, Y, Z           : Vectors defining the coordinate grid, output of ndgrid(x, y, z)
+    %
+    % E                 : The gaussian electric field produced, defined over the spatial grid.
 
+    %% Preallocate storage
     [m,n] = size(X);
     E = cell(1,2);
     E{1} = zeros(m,n);
     E{2} = zeros(m,n);
+
+    %% Define constants
     lambda = 1300e-9;
     refind = 1.35;
     dz = lambda/10;
-
     k=2*pi/lambda;
-
-    %dz/2 term due to the modified source condition
+    % dz/2 term due to the modified source condition
     vertices = [X(:) Y(:) Z(:)-dz/2];
 
+    %% Compute field
     E{1} = 2*exp(sqrt(-1)*k*refind*(Z-dz/2));
     E{2} = 2*zeros(size(Z));
 end

--- a/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
@@ -7,36 +7,8 @@ function [x,y,z,lambda] = fdtd_bounds(input_file)
 	% lambda		: Wavelength of light in the dielectric material.
 
 %% Fetch the configuration information for this test
-
-% Check that the input file can be found on the path
-if isfile(input_file)
-	% Run input file as a script to import variables into the workspace
-	run(input_file);
-else
-	% Throw error - config file cannot be found
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-% Check required variables have been set in the config file, and loaded
-% Note that lambda will be returned once it is imported from the input file
-required_variables = {'delta','I','J','K','illorigin','lambda'};
-n_required_variables = length(required_variables);
-i = 1;
-% Search through all required variables and check they exist in the workspace
-% Throw error (and break loop early) if they are not found
-while i<=n_required_variables
-	if ~exist(required_variables{i}, 'var')
-		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
-		break
-	end
-	i = i + 1;
-end
-
-% These variables have default values if they are not defined in the input_file
-if ~exist('z_launch', 'var')
-	% z_launch defines an additional "height" above the illumination origin
-	z_launch = 0;
-end
+[delta,I,J,K,illorigin,lambda,z_launch] = get_from_input_file(input_file, struct('z_launch', 0), ...
+														'delta','I','J','K','illorigin','lambda','z_launch');
 
 %% Now compute the fdtd grid coordinates along each axis. Values are (respective to each axial direction):
 % I, J, K 		: Number of gridpoints
@@ -45,5 +17,4 @@ end
 x = ((1:I) - illorigin(1))*delta.x;
 y = ((1:J) - illorigin(2))*delta.y;
 z = ((1:K) - illorigin(3))*delta.z + z_launch;
-
 end

--- a/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
@@ -19,7 +19,7 @@ end
 
 % Check required variables have been set in the config file, and loaded
 % Note that lambda will be returned once it is imported from the input file
-required_variables = {'delta','I','J','K','z_launch','illorigin','lambda'};
+required_variables = {'delta','I','J','K','illorigin','lambda'};
 n_required_variables = length(required_variables);
 i = 1;
 % Search through all required variables and check they exist in the workspace

--- a/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtd_bounds.m
@@ -1,50 +1,49 @@
-%function [x,y,z,lambda] = fdtd_bounds(input_file)
-%
-%input_file - file with input configuration information
-%
-%x, y and z are the grid labels of the interior space of the FDTD
-%grid.
-%
-%lambda is the wavelength in dielectric material
 function [x,y,z,lambda] = fdtd_bounds(input_file)
+	%% Compute vectors x, y, z defining the coordinates of the fdtd grid in the respective axial direction.
+	%% That is, the Cartesian product x \otimes y \otimes z is the set of all gridpoints (xi, yj, zk) in the fdtd grid.
+	% input_file	: The input file with configuration information.
+	%
+	% x, y, z		: Grid labels (spatial coodinates) of the interior space of the FDTD grid.
+	% lambda		: Wavelength of light in the dielectric material.
 
-%input the configuration information
-[fid_input,message] = fopen(input_file,'r');
+%% Fetch the configuration information for this test
 
-%check if file was opened successfully
-if fid_input== -1
+% Check that the input file can be found on the path
+if isfile(input_file)
+	% Run input file as a script to import variables into the workspace
+	run(input_file);
+else
+	% Throw error - config file cannot be found
     error(sprintf('File %s could not be opened for reading',input_file));
 end
 
-%proceed to_l read in config information
-current_line = fgets(fid_input);
-
-while current_line ~= -1
-    eval(current_line);
-    current_line = fgets(fid_input);
-end
-
-%now need to check that all of the required variables have been set
-variables = {'delta','I','J','K','z_launch','illorigin','lambda'};
-must_abort = 0; %assumes all variables have been defined
-for lvar = 1:length(variables)
-    if exist(variables{lvar}) ~= 1
-	if strncmp(variables(lvar),'z_launch',8)
-	    fprintf(1,'Failed to define %s, setting it to 0\n',variables{lvar});
-	    z_launch = 0;
-	else
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort = 1;
+% Check required variables have been set in the config file, and loaded
+% Note that lambda will be returned once it is imported from the input file
+required_variables = {'delta','I','J','K','z_launch','illorigin','lambda'};
+n_required_variables = length(required_variables);
+i = 1;
+% Search through all required variables and check they exist in the workspace
+% Throw error (and break loop early) if they are not found
+while i<=n_required_variables
+	if ~exist(required_variables{i}, 'var')
+		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
+		break
 	end
-    end
+	i = i + 1;
 end
 
-if must_abort
-    error('Not all variables were defined');
+% These variables have default values if they are not defined in the input_file
+if ~exist('z_launch', 'var')
+	% z_launch defines an additional "height" above the illumination origin
+	z_launch = 0;
 end
 
-
+%% Now compute the fdtd grid coordinates along each axis. Values are (respective to each axial direction):
+% I, J, K 		: Number of gridpoints
+% delta,{x,y,z} : Spatial separation of the gridpoints
+% illorigin		: Location of the origin of the source field
 x = ((1:I) - illorigin(1))*delta.x;
 y = ((1:J) - illorigin(2))*delta.y;
 z = ((1:K) - illorigin(3))*delta.z + z_launch;
-lambda = lambda;
+
+end

--- a/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
@@ -1,44 +1,45 @@
-%function [to hwhm] = fdtdduration(inputfile)
-%
-%Calculates the parameters for the gaussian pulse employed in the
-%fdtd code according to:
-%
-%G(t) = exp( -pi((t-to)/hwhm)^2 )
-% where hwhm is the half width at half maximum of the pulse and to (t_0) is the
-% time delay. The latter ensures that when the pulse starts to be introduced
-% the envelope of the pulse has a magnitude of 10^(-8). This ensures that there
-% aren't any erroneous spectral components introduced as a result of having a
-% sharp discontinuity in time.
-function [to, hwhm] = fdtdduration(inputfile)
+function [t0, hwhm] = fdtdduration(input_file)
+    %% Calculates the parameters for the Gaussian pulse employed in the fdtd code according to:
+    %% G(t) = \exp( -\pi(\frac{t-t_0}{hwhm})^2 ).
+    %% hwhm is the half width at half maximum of the pulse.
+    %% t_0 is the time delay. This delay ensures that when the pulse starts to be introduced, the envelope of the pulse has a magnitude of 10^{-8}. In turn, this ensures that there aren't any erroneous spectral components introduced as a result of having a sharp discontinuity in time.
+    %
+    % input_file : The configuration file to read parameters from
+    % t0
 
-[fid_input,message] = fopen(inputfile,'r');
+%% Fetch the configuration information for this test
 
-%check if file was opened successfully
-if fid_input== -1
-    error(sprintf('File %s could not be opened for reading',inputfile));
+% Check that the input file can be found on the path
+if isfile(input_file)
+	% Run input file as a script to import variables into the workspace
+	run(input_file);
+else
+	% Throw error - config file cannot be found
+    error(sprintf('File %s could not be opened for reading',input_file));
 end
 
-%proceed to_l read in config information
-current_line = fgets(fid_input);
-
-while current_line ~= -1
-    eval(current_line);
-    current_line = fgets(fid_input);
+% Check required variables have been set in the config file, and loaded
+% Note that lambda will be returned once it is imported from the input file
+required_variables = {'wavelengthwidth', 'f_an', 'epsr'};
+n_required_variables = length(required_variables);
+i = 1;
+% Search through all required variables and check they exist in the workspace
+% Throw error (and break loop early) if they are not found
+while i<=n_required_variables
+	if ~exist(required_variables{i}, 'var')
+		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
+		break
+	end
+	i = i + 1;
 end
 
-[epso muo c] = import_constants;
-
-if exist('wavelengthwidth') ~= 1
-    error('wavelengthwidth is not defined - cannot determine hwhm or to');
-end
-
-if exist('f_an') ~= 1
-    error('f_an is not defined - cannot determine hwhm or to');
-end
-
+%% Define internal constants
+[~, ~, c] = import_constants;
 refractive_index = sqrt(epsr(1));
 omega_an         = 2*pi*f_an;
 lambda_an        = c/(f_an*refractive_index);
 
+%% Produce output values
 hwhm = lambda_an^2/((c/refractive_index)*wavelengthwidth)*2*sqrt(log(2)/pi);
-to   = hwhm*sqrt(log(1e8)/pi);
+t0   = hwhm*sqrt(log(1e8)/pi);
+end

--- a/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
@@ -8,7 +8,7 @@ function [t0, hwhm] = fdtdduration(input_file)
     % t0
 
 %% Fetch the configuration information for this test
-[wavelengthwidth, f_an, espr] = get_from_input_file(input_file, struct(), 'wavelengthwidth', 'f_an', 'epsr');
+[wavelengthwidth, f_an, epsr] = get_from_input_file(input_file, struct(), 'wavelengthwidth', 'f_an', 'epsr');
 
 %% Define internal constants
 [~, ~, c] = import_constants;

--- a/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtdduration.m
@@ -8,30 +8,7 @@ function [t0, hwhm] = fdtdduration(input_file)
     % t0
 
 %% Fetch the configuration information for this test
-
-% Check that the input file can be found on the path
-if isfile(input_file)
-	% Run input file as a script to import variables into the workspace
-	run(input_file);
-else
-	% Throw error - config file cannot be found
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-% Check required variables have been set in the config file, and loaded
-% Note that lambda will be returned once it is imported from the input file
-required_variables = {'wavelengthwidth', 'f_an', 'epsr'};
-n_required_variables = length(required_variables);
-i = 1;
-% Search through all required variables and check they exist in the workspace
-% Throw error (and break loop early) if they are not found
-while i<=n_required_variables
-	if ~exist(required_variables{i}, 'var')
-		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
-		break
-	end
-	i = i + 1;
-end
+[wavelengthwidth, f_an, espr] = get_from_input_file(input_file, struct(), 'wavelengthwidth', 'f_an', 'epsr');
 
 %% Define internal constants
 [~, ~, c] = import_constants;

--- a/tdms/tests/system/data/input_generation/matlab/fdtdts.m
+++ b/tdms/tests/system/data/input_generation/matlab/fdtdts.m
@@ -7,30 +7,7 @@ function [dt_upper] = fdtdts(input_file)
     % dt_upper      : Maximum allowable timestep
 
 %% Fetch the configuration information for this test
-
-% Check that the input file can be found on the path
-if isfile(input_file)
-	% Run input file as a script to import variables into the workspace
-	run(input_file);
-else
-	% Throw error - config file cannot be found
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-% Check required variables have been set in the config file, and loaded
-% Note that lambda will be returned once it is imported from the input file
-required_variables = {'delta'};
-n_required_variables = length(required_variables);
-i = 1;
-% Search through all required variables and check they exist in the workspace
-% Throw error (and break loop early) if they are not found
-while i<=n_required_variables
-	if ~exist(required_variables{i}, 'var')
-		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
-		break
-	end
-	i = i + 1;
-end
+delta = get_from_input_file(input_file, struct(), 'delta');
 
 %% Define internal constants
 [~, ~, c] = import_constants;

--- a/tdms/tests/system/data/input_generation/matlab/file_parser/is_white_space.m
+++ b/tdms/tests/system/data/input_generation/matlab/file_parser/is_white_space.m
@@ -1,14 +1,16 @@
-%function [res] = is_white_space(str)
-%
-%res is set to 1 if str is just a blank line (ie, composed of white space or just a new line).
-%res is 0 otherwise.
-function [res] = is_white_space(str)
+function [tf] = is_white_space(str)
+    %% Returns 1 (true) if the str is entirely composed of whitespace and ends in a newline character.
+    %% Usage is intended for when reading input files, and skipping over blank lines.
+    % str   : String to check
+    %
+    % tf    : True/false result
 
-res = 1;
-
-counter = 1;
-while counter < length(str)
-    res = res & strncmp(str(counter),sprintf(' '),1);
-    counter = counter + 1;
+% Logical array of indices where whitespace occurs
+whitespace = isspace(str);
+% If everything in the string except the whitespace is a single newline character at the end
+if strcmp('\n', str(~whitespace)) && strcmp('\n', str(end-1:end))
+    tf = 1;
+else
+    tf = 0;
 end
-res = res & strncmp(str(counter),sprintf('\n'),1);
+end

--- a/tdms/tests/system/data/input_generation/matlab/gauss_legendre.m
+++ b/tdms/tests/system/data/input_generation/matlab/gauss_legendre.m
@@ -1,74 +1,64 @@
-%function [xvec,wvec] = gauss_legendre(a,b,N)
-%
-%Calculate the abscissa and weights for performing numerical
-%integration within the interval (a,b), using N sample points
-%according to Gauss-Legendre quadrature
-%
-%
-%The integral of a function f(x) within (a,b) may then be evaluated
-%as:
-%
-%F = sum( f(xvec).*wvec );
-function [xvec,wvec] = gauss_legendre(a,b,N)
+function [xvec, wvec] = gauss_legendre(a,b,N)
+	%% Calculate the absciassa (sample coordinates) and weights for performing numerical integration within the interval (a,b), using N sample points via Gauss-Legendre quadrature.
+	%% From these, the integral F = \int_a^b f(x) dx can be evaluated as
+	%% F = sum( f(xvec) .* wvec ).
+	% a,b	: Interval of integration
+	% N		: Number of sample points to use
+	%
+	% xvec	: The absciassa (coordinates of the function samples)
+	% wvec	: The weights
 
-%Threshold for terminating Newton procedure
-    THRESH = eps;
+%% Define parameters and allocate storage
+% Threshold for terminating Newton procedure
+THRESH = eps;
+% There will be N roots and N weights, which are symmetric
+xvec = zeros(1,N);
+wvec = zeros(1,N);
 
-    %There will be N roots and N weights which are symmetric
-    xvec = zeros(1,N);
-    wvec = zeros(1,N);
-    for i=0:(ceil(N/2)-1)
-	%Variable determining whether convergence has been achieved
-	cont = 1;
+%% Compute xvec and wvec for the interval (0,1)
+for i=0:(ceil(N/2)-1)
+	% Variable determining whether convergence has been achieved
+	converged = false;
 
-	%use an asymptotic expansion ("Handbook of Mathematical
-	%Functions with  Formulas, Graphs, and Mathematical Tables,
-	%Milton Abramowitz and Irene A. Stegun, Dover, New York, 1964,
-	%Eq 8.10.8) to estimate the value of the root
+	% Use an asymptotic expansion ("Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical Tables, Milton Abramowitz and Irene A. Stegun, Dover, New York, 1964, Eq 8.10.8) to estimate the value of the root
 	x0 = cos( (i+3/4)*pi/(N+1/2) );
 
-	while cont
-	    %now we need to evaluate the value of the Legendre polynomial
-	    %and its derivative in order to form a Taylor series expansion
-	    %of order 1 at x0
+	while (~converged)
+		% Now we need to evaluate the value of the Legendre polynomial and its derivative in order to form a Taylor series expansion of order 1 at x0
 
-	    %Evaluate the Legendre polynomial at x0 (Abramowitz and Stegun 8.5.3)
-	    p0 = 1;
-	    p1 = x0;
-	    for j=2:N
-		p2 = ((2*j - 1)*x0*p1 - (j - 1)*p0)/j;
-		p0 = p1;
-		p1 = p2;
-	    end
-	    %p_acc = [p_acc p2];
-	    %Evaluate the derivative, again by recurrence relation
-	    %(Abramowitz and Stegun 8.5.4)
-	    p2_prime = N*(x0*p1 - p0)/(x0^2-1);
+		%Evaluate the Legendre polynomial at x0 (Abramowitz and Stegun, Eq 8.5.3)
+		p0 = 1;
+		p1 = x0;
+		for j=2:N
+			p2 = ((2*j - 1)*x0*p1 - (j - 1)*p0)/j;
+			p0 = p1;
+			p1 = p2;
+		end
+		% Evaluate the derivative (Abramowitz and Stegun, Eq 8.5.4)
+		p2_prime = N*(x0*p1 - p0)/(x0^2-1);
 
-	    xm1 = x0;
-	    x0 = x0 - p1/p2_prime;
-	    cont = abs(x0-xm1)>THRESH;
+		xm1 = x0;
+		x0 = x0 - p1/p2_prime;
+		% Determine if convergence has been achieved
+		converged = ~( abs(x0-xm1) > THRESH );
 	end
 
+	% Use symmetry and record sample coordinates
 	xvec(N-i) = x0;
 	xvec(i+1) = -x0;
-
+	% Use symmetry and record weights
 	wvec(N-i) = 2./((1.-x0*x0)*p2_prime*p2_prime);
 	wvec(i+1) = wvec(N-i);
+end
 
+%% Transform onto the interval (a,b),
+% via the transformation:
+% x = e*tau + f,
+% mapping tau = -1 to  x = a, and tau = 1 to x = b.
+% This results in e = (b-a)/2, and f = (a+b)/2.
+e = (b-a)/2;
+f = (b+a)/2;
 
-	%save(sprintf('data/fr01vars_%02d',i));
-    end
-
-    %Now transform onto domain (a,b), construct transformation:
-    %
-    %x = e*tau + f
-    %
-    %mapping tau=-1 to x=a and tau=1 to x=b
-    %
-    %this results in e = (b-a)/2 and f = (a+b)/2
-    e = (b-a)/2;
-    f = (b+a)/2;
-
-    xvec = e*xvec + f;
-    wvec = e*wvec;
+xvec = e*xvec + f;
+wvec = e*wvec;
+end

--- a/tdms/tests/system/data/input_generation/matlab/get_from_input_file.m
+++ b/tdms/tests/system/data/input_generation/matlab/get_from_input_file.m
@@ -1,0 +1,44 @@
+function [varargout] = get_from_input_file(input_file, optionals, varargin)
+    %% Pull the requested variables out of the input_file and return them in the order they were requested.
+    % input_file    : Config file to fetch values from
+    % optionals     : 1-by-1 struct. The fields of this struct should match the variable names that are considered optional retrievals from the input file, and the values of these fields should be the default value to assign if the variable is not found in the input file.
+    %
+    % varargin      : Sequence of strings/chars, the names of the variables to retrieve from the input file. They will be returned in the same order as provided to the function as inputs.
+
+%% Allocate storage and useful intermediate values
+n_variables = numel(varargin);
+varargout = cell(1, n_variables);
+
+optional_vars = fieldnames(optionals);
+n_optionals = numel(optional_vars);
+
+%% Load input file
+% Check that the input file can be found on the path
+if isfile(input_file)
+	% Run input file as a script to import variables into the workspace
+	run(input_file);
+else
+	% Throw error - config file cannot be found
+    error(sprintf('File %s could not be opened for reading',input_file));
+end
+
+%% Determine if the variables loaded in can be retrieved
+for i=1:n_variables
+    % if the variable was found, save it to the output list
+    if exist(varargin{i}, 'var')
+        varargout{i} = eval(varargin{i});
+    else
+        % variable not found, but was it optional?
+        for j=1:n_optionals
+            if strcmp(varargin{i}, optional_vars{j})
+                % this was optional, assign the default value
+                varargout{i} = optionals.(optional_vars{j});
+                % stop searching to see if this variable was optional
+                break
+            end
+        end
+        % we we got to here, the variable was not optional but wasn't found in the input file - throw error
+        error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
+    end
+end
+end

--- a/tdms/tests/system/data/input_generation/matlab/getsourcecoords.m
+++ b/tdms/tests/system/data/input_generation/matlab/getsourcecoords.m
@@ -1,317 +1,83 @@
-%function [ex_coords, ey_coords, tvec_E, fvec_E, f_an, hwhm, to_l] = getsourcecoords(input_file)
-%
-%input_file - file with input configuration information
-%
 function [ex_coords, ey_coords, tvec_E, fvec_E, f_an, hwhm, to_l] = getsourcecoords(input_file)
+	%% Computes the spatial coordinates of the source field
+	% input_file	: Config file to read parameters from
+	%
+	% ex_coords		: Spatial coordinates of the Ex component of the source field
+	% ey_coords		: Spatial coordinates of the Ey component of the source field
+	% tvec_E		: Time "coordinates" as a 1D array
+	% fvec_E		: Frequency "coordinates" as a 1D array
+	% f_an			:
+	% hwhm			:
+	% to_l			:
 
-[fid_input,~] = fopen(input_file,'r');
+%% Fetch the configuration information for this test
+% Optionals
+optional_args = struct();
+optional_args.z_launch = 0;
+optional_args.multilayer = [];
+% Fetch variables that we need
+[delta, I, J, K, Dxl, ...
+Dxu, Dyl, Dyu, Dzl, Dzu, ...
+epsr, f_an, Nt, interface, wavelengthwidth, ...
+illorigin, sourcemode, dt, z_launch, multilayer] = get_from_input_file(input_file, optional_args, ...
+'delta', 'I', 'J', 'K', 'Dxl', ...
+'Dxu', 'Dyl', 'Dyu', 'Dzl', 'Dzu', ...
+'epsr', 'f_an', 'Nt', 'interface', 'wavelengthwidth', ...
+'illorigin', 'sourcemode', 'dt', 'z_launch', 'multilayer');
 
-%%
-%check if file was opened successfully
-if fid_input==-1
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-%proceed to_l read in config information
-current_line = fgets(fid_input);
-while current_line ~= -1
-    if ~isempty(findstr('material_file',current_line))
-	if isempty(material_file) | ((~isempty(material_file)) & (findstr('material_file',current_line)>findstr('%',current_line)))
-	    eval(current_line);
-	else
-	    fprintf(1,'material_file specified as argument and in %s, using %s\n',input_file,material_file);
-	end
-    else
-	eval(current_line);
-    end
-
-    current_line = fgets(fid_input);
-end
-
-material_file = [];
-
-%now need to_l check that all of the required variables have been set
-variables = {'delta','I','J','K','n','R0','Dxl','Dxu','Dyl','Dyu','Dzl','Dzu','dt','epsr','mur','f_an','Nt','interface','material_file','efname','hfname','wavelengthwidth','z_launch','illorigin','runmode','sourcemode','exphasorsvolume','exphasorssurface','phasorsurface','phasorinc','dimension','multilayer','kappa_max','vc_vec','wp_vec','structure','f_ex_vec','exdetintegral','k_det_obs','NA_det','detsensefun','beta_det','det_trans_x','det_trans_y','illspecfun'};
-must_abort = 0; %assumes all variables have been defined
-for lvar = 1:length(variables)
-    if exist(variables{lvar}) ~= 1
-	if strncmp(variables(lvar),'z_launch',8)
-	    fprintf(1,'Failed to define %s, setting it to 0\n',variables{lvar});
-	    z_launch = 0;
-	elseif strncmp(variables(lvar),'runmode',7)
-	    fprintf(1,'Failed to define %s, setting it to ''complete''\n',variables{lvar});
-	    runmode = 'complete';
-	elseif strncmp(variables(lvar),'dimension',9)
-	    fprintf(1,'Failed to define %s, setting it to ''3''\n',variables{lvar});
-	    dimension = '3';
-	elseif strncmp(variables(lvar),'phasorinc',9)
-	    fprintf(1,'Failed to define %s, setting it to [1 1 1]\n',variables{lvar});
-	    phasorinc = [1 1 1];
-	elseif strncmp(variables(lvar),'multilayer',10)
-	    fprintf(1,'Failed to define %s, setting it to []\n',variables{lvar});
-	    multilayer = [];
-	elseif strncmp(variables(lvar),'kappa_max',9)
-	    fprintf(1,'Failed to define %s, setting it to 1\n',variables{lvar});
-	    kappa_max = 1;
-	elseif strncmp(variables{lvar},'vc_vec',6)
-	    tmp_str = num2str(zeros(1,length(epsr)));
-	    fprintf(1,'Failed to define %s, setting it to [%s]\n',variables{lvar},tmp_str);
-	    vc_vec = zeros(1,length(epsr));
-	elseif strncmp(variables{lvar},'wp_vec',6)
-	    tmp_str = num2str(zeros(1,length(epsr)));
-	    fprintf(1,'Failed to define %s, setting it to [%s]\n',variables{lvar},tmp_str);
-	    wp_vec = zeros(1,length(epsr));
-	elseif strncmp(variables{lvar},'structure',9)
-	    fprintf(1,'Failed to define %s, setting it to []\n',variables{lvar});
-	    structure = [];
-	elseif strncmp(variables{lvar},'f_ex_vec',8)
-	    fprintf(1,'Failed to define %s, setting it to f_an\n',variables{lvar});
-	    f_ex_vec = f_an;
-	elseif strncmp(variables{lvar},'exdetintegral',13)
-	    fprintf(1,'Failed to define %s, setting it to 0\n',variables{lvar});
-	    exdetintegral=0;
-	elseif strncmp(variables(lvar),'k_det_obs',9)
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort=1;
-	elseif strncmp(variables(lvar),'NA_det',6)
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort=1;
-	elseif strncmp(variables(lvar),'beta_det',8)
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort=1;
-	elseif strncmp(variables(lvar),'detsensefun',11)
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort=1;
-	elseif strncmp(variables(lvar),'det_trans_x',11)
-	    fprintf(1,'Failed to define %s, seeting to det_trans_x = 0\n',variables{lvar});
-	    det_trans_x=0;
-	elseif strncmp(variables(lvar),'det_trans_y',11)
-	    fprintf(1,'Failed to define %s, setting to det_trans_y = 0\n',variables{lvar});
-	    det_trans_y=0;
-	elseif strncmp(variables(lvar),'illspecfun',10)
-	    fprintf(1,'Failed to define %s, setting to illspecfun=''''\n',variables{lvar});
-	    illspecfun = '';
-	else
-	    fprintf(1,'Failed to define %s\n',variables{lvar});
-	    must_abort = 1;
-	end
-    end
-end
-k_obs = k_det_obs;
-NA = NA_det;
-
-%now check
-% k_obs
-% NA
-% detsensefun
-
-if exdetintegral==1
-    for lvar = 1:length(variables)
-	if exist(variables{lvar}) ~= 1
-	    if strncmp(variables(lvar),'k_obs',4)
-		fprintf(1,'Failed to define %s\n',variables{lvar});
-		must_abort=1;
-	    elseif strncmp(variables(lvar),'NA',2)
-		fprintf(1,'Failed to define %s\n',variables{lvar});
-		must_abort=1;
-	    elseif strncmp(variables(lvar),'detsensefun',11)
-		fprintf(1,'Failed to define %s\n',variables{lvar});
-		must_abort=1;
-	    end
-	end
-    end
-end
-
-if must_abort
-    error('Not all variables were defined');
-end
-
-%just check that the outputs_array is valid
-for lvar = 1:size(outputs_array,1)
-    if length(outputs_array{lvar}) < 6
-        error(sprintf('insufficient number of entries in outputs_array number %d',lvar));
-    end
-    if strcmp(outputs_array{lvar}{2},'interior') %means indexing is relative to the first non-pml cell
-						 %must check that all nodes are within the allowed range
-    node1 = outputs_array{lvar}{3};
-    node2 = outputs_array{lvar}{4};
-    if ~(node1(1)<=node2(1) & node1(2)<=node2(2) & node1(3)<=node2(3))
-	error(sprintf('outputs_array entry %d range vectors incorrect',lvar));
-    end
-
-    if strcmp('3',dimension)
-        if sum(node1<=[I J K] & node1>=[1 1 1] & node2<=[I J K] & node2>=[1 1 1])~=3
-            error(sprintf('outputs_array entry %d range vectors incorrect',lvar));
-        end
-    else
-        if sum(node1<=[I J 1] & node1>=[1 1 1] & node2<=[I J 1] & node2>=[1 1 1])~=3
-            error(sprintf('outputs_array entry %d range vectors incorrect',lvar));
-        end
-    end
-
-    %now set the values for global indexing
-    outputs_array{lvar}{3} = outputs_array{lvar}{3} + [Dxl Dyl Dzl];
-    outputs_array{lvar}{4} = outputs_array{lvar}{4} + [Dxl Dyl Dzl];
-
-    elseif strcmp(outputs_array{lvar}{2},'global') %means indexing is relative to the first cell in the grid
-        node1 = outputs_array{lvar}{3};
-        node2 = outputs_array{lvar}{4};
-        if ~(node1(1)<=node2(1) & node1(2)<=node2(2) & node1(3)<=node2(3))
-            error(sprintf('outputs_array entry %d range vectors incorrect',lvar));
-        end
-
-        if sum(node1<=[(I+Dxl+Dxu+1) (J+Dyl+Dyu+1) (K+Dyl+Dyu+1)] & node1>=[1 1 1] & node2<=[(I+Dxl+Dxu+1) (J+Dyl+Dyu+1) (K+Dyl+Dyu+1)] & node2>=[1 1 1])~=3
-            error(sprintf('outputs_array entry %d range vectors incorrect',lvar));
-        end
-    else
-        error(sprintf('Indexing for outputs_array entry number %d is incorrect, should be interior or global',lvar));
-    end
-end
-
-%just check that the outputs_array is valid - in particular the components
-for lvar = 1:length(outputs_array)
-    if length(outputs_array{lvar}{5}) > 0
-        for mvar=1:length(outputs_array{lvar}{5})
-            if isempty(findstr(outputs_array{lvar}{5}(mvar),'xyz'))
-                error(sprintf('%s is not a vector component',  outputs_array{lvar}{5}(mvar)));
-            end
-        end
-    else
-        error(sprintf('no components were specified in outputs_array element %d',lvar));
-    end
-end
-
-%just check that the outputs_array is valid - in particular that the output style is accumulate or dump
-for lvar = 1:length(outputs_array)
-    if ~( strcmp(outputs_array{lvar}{6},'accumulate') | strcmp(outputs_array{lvar}{6},'dump') )
-        error(sprintf('mode of output writing is incorrect for outputs_array entry %d',lvar));
-    end
-end
-
-%check that interface has been fully specified, if not, any
-%un-specified interface conditions will be set to 0, ie, the
-%interface condition will not be implemented
+%% Variable checks - interface
+% Check that interface has been fully specified.
+% If not, un-specified interface conditions will be set to 0 (IE no interface condition will be implemented)
 interface_field = {'I0','I1','J0','J1','K0','K1'};
-%global Isource Jsource Ksource interface source_field x y z X Y Z;
 for lvar = 1:length(interface_field)
     if ~isfield(interface,interface_field{lvar})
 	fprintf('interface.%s has not been defined, setting it to [0 0]\n', interface_field{lvar});
-	interface = setfield(interface,interface_field{lvar},[0 0]);
+	interface.(interface_field{lvar}) = [0 0];
     end
 end
 
-%now check that the entries for I0...K1 are valid
-if interface.I0(2) & interface.I1(2)
+% Check that the entries for I0...K1 are valid
+if interface.I0(2) && interface.I1(2)
     if interface.I1(1) < interface.I0(1)
-	error('Must have interface.I1>=interface.I0');
+		error('Must have interface.I1>=interface.I0');
     end
     if interface.I1(1) > I
-	error('Must have interface.I1 <= I');
+		error('Must have interface.I1 <= I');
     end
     if interface.I0(1) < 1
-	error('Must have interface.I0 >= 1');
+		error('Must have interface.I0 >= 1');
     end
 end
-
-if interface.J0(2) & interface.J1(2)
+if interface.J0(2) && interface.J1(2)
     if interface.J1(1) < interface.J0(1)
-	error('Must have interface.J1>=interface.J0');
+		error('Must have interface.J1>=interface.J0');
     end
     if interface.J1(1) > J
-	error('Must have interface.J1 <= J');
+		error('Must have interface.J1 <= J');
     end
     if interface.J0(1) < 1
-	error('Must have interface.J0 >= 1');
+		error('Must have interface.J0 >= 1');
     end
 end
-
-if interface.K0(2) & interface.K1(2)
+if interface.K0(2) && interface.K1(2)
     if interface.K1(1) < interface.K0(1)
-	error('Must have interface.K1>=interface.K0');
+		error('Must have interface.K1>=interface.K0');
     end
     if interface.K1(1) > K
-	error('Must have interface.K1 <= K');
+		error('Must have interface.K1 <= K');
     end
     if interface.K0(1) < 1
-	error('Must have interface.K0 >= 1');
+		error('Must have interface.K0 >= 1');
     end
 end
 
-%check that runmode is valid
-if ~(strncmp(runmode,'analyse',7) | strncmp(runmode,'complete',8))
-    error(sprintf('runmode ''%s'' invalid',runmode));
-end
-
-%check that sourcemode is valid
+%% Variable checks - other variables
+% sourcemode
 if ~(strncmp(sourcemode,'pulsed',6) | strncmp(sourcemode,'steadystate',11))
     error(sprintf('sourcemode ''%s'' invalid',sourcemode));
 end
 
-
-%check that phasorsurface is valid
-if exphasorssurface
-    [psm, psn] = size(phasorsurface);
-    if psm*psn ~= 6 %check for correct number of elements
-	error('phasorsurface must be a vector of 6 elements');
-    else            %now check that each entry is valid
-	if phasorsurface(1) + Dxl -2 < 1
-	    error('phasorsurface(1) out of range');
-	elseif phasorsurface(2) - Dxu > I
-	    error('phasorsurface(2) out of range');
-	elseif (phasorsurface(3) + Dyl -2 < 1) & ((J + Dyl + Dyu)>0)
-	    error('phasorsurface(3) out of range');
-	elseif (phasorsurface(4) - Dyu > J) & ((J + Dyl + Dyu)>0)
-	    error('phasorsurface(4) out of range');
-	elseif (phasorsurface(5) + Dzl -2 < 1) & ~( (K==0) & (phasorsurface(5)==0) )
-	    error('phasorsurface(5) out of range');
-	elseif phasorsurface(6) - Dzu > K
-	    error('phasorsurface(6) out of range');
-	end
-
-
-% $$$     if phasorsurface(1) < 1
-% $$$ 	error('phasorsurface(1) out of range');
-% $$$     elseif phasorsurface(2) > I
-% $$$ 	error('phasorsurface(2) out of range');
-% $$$     elseif phasorsurface(3) < 1
-% $$$ 	error('phasorsurface(3) out of range');
-% $$$     elseif phasorsurface(4) > J
-% $$$ 	error('phasorsurface(4) out of range');
-% $$$     elseif (phasorsurface(5) < 1) & ~( (K==0) & (phasorsurface(5)==0) )
-% $$$ 	error('phasorsurface(5) out of range');
-% $$$     elseif phasorsurface(6) > K
-% $$$ 	error('phasorsurface(6) out of range');
-% $$$     end
-% $$$     %now convert to global coordinates
-	phasorsurface = phasorsurface + [Dxl Dxl Dyl Dyl Dzl Dzl];
-%	fprintf(1,'Converted phasorsurface\n');
-%	phasorsurface
-	%still in the matlab convention though
-
-    end
-end
-
-%check to ensure that the phasor surface has been specified
-%correctly
-if ( mod( (phasorsurface(2) - phasorsurface(1)),phasorinc(1) ) | mod( (phasorsurface(4) - phasorsurface(3)),phasorinc(2) ) | mod( (phasorsurface(6) - phasorsurface(5)),phasorinc(3) ) )
-    mod( (phasorsurface(2) - phasorsurface(1)),phasorinc(1) )
-    mod( (phasorsurface(4) - phasorsurface(3)),phasorinc(2) )
-    mod( (phasorsurface(6) - phasorsurface(5)),phasorinc(3) )
-    error('incorrect specification of phasorinc');
-end
-
-
-%this is really just for completeness
-x_max = I*delta.x;
-y_max = J*delta.y;
-z_max = K*delta.z;
-
-%now check that dimension is correct
-if ~(strcmp('3',dimension) | strcmp('TE',dimension) | strcmp('TM',dimension))
-    error('Dimension must take the value ''3'', ''TM'' or ''TE''');
-end
-
-%check that multilayer and epsr have the correct dimension
+% multilayer and epsr
 if isempty(multilayer)
     if numel(epsr)~=1
 	error('epsr should have only a single element in the case of a single layer');
@@ -322,180 +88,59 @@ else
     end
 end
 
-I_tot = I + Dxl + Dxu;  %Extent of the grid - including the PML
+% Extent of the grid - including the PML
+I_tot = I + Dxl + Dxu;
 J_tot = J + Dyl + Dyu;
 K_tot = K + Dzl + Dzu;
-
-%error checking for structure
-if isempty(multilayer)
-    if ~isempty(structure)
-	error('structure is not empty yet multlayer is');
-    end
-else
-    if  ~isempty(structure)
-	structure(1,:) = structure(1,:) + Dxl;
-	old_structure = structure;
-	if old_structure(1,1)>1
-	    structure = zeros(2,size(structure,2)+1);
-	    structure(:,2:end) = old_structure;
-	    structure(1,1) = 1;
-	    structure(2,1) = old_structure(2,1);
-	end
-
-	old_structure = structure;
-	if old_structure(1,end)<I_tot
-	    structure = zeros(2,size(structure,2)+1);
-	    structure(:,1:(end-1)) = old_structure;
-	    structure(1,end) = I_tot+1;
-	    structure(2,end) = old_structure(2,end);
-	end
-
-
-	tmp_pro = cumprod(double(diff(structure(1,:))>0));
-	if  ~tmp_pro(end);
-	    error('structure should have first row monotonically increasing');
-	end
-
-	if structure(1,1)<1
-	    error('structure should have first row entries all greater than 1');
-	end
-
-	if structure(1,end)>(I_tot+1)
-	    error('structure should have first row entries all less than I+1');
-	end
-
-	[ml_mat,pl_mat] = ndgrid(multilayer,structure(2,:));
-	if ~isempty(find( (ml_mat+pl_mat)<2 ))
-	    error('trench is breaking PML boundary, reduce magnitude of structure displacement');
-	end
-
-	if ~isempty(find( (ml_mat+pl_mat)>(K-1) ))
-	    error('trench is breaking PML boundary, reduce magnitude of structure displacement');
-	end
-	%%
-	i_int = 1:(I_tot+1);
-	p_int = int32(round(interp1(structure(1,:),structure(2,:),i_int,'linear')));
-	i_int = int32(i_int);
-
-	structure = [i_int;p_int];
-	%%
-    end
-end
-%error checking for structure
-
-%check that kappa_max has the correct dimension
-if numel(kappa_max)~=1
-    if numel(kappa_max)~=numel(epsr)
-	error('should have numel(kappa_ax)=numel(epsr)');
-    end
-end
-
-%check that vc_vec and wp_vec have the correct dimension
-if numel(vc_vec) ~= numel(wp_vec)
-    error('vc_vec and wp_vec should have the same number of elements');
-end
-
-if numel(multilayer)~=(numel(vc_vec)-1)
-    error('vc_vec and wp_vec should have one more member than multilayer');
-end
-
-%check correctness of multilayer
-if ~isempty(multilayer)
-    if min(multilayer) <1
-	error('multilayer must have elements greater than 0');
-    end
-    if max(multilayer)>K
-	error('multilayer must have elements less than or equal to  K');
-    end
-    if sum(sort(multilayer)==multilayer)~=numel(multilayer)
-	error('multilayer must be monotonically increasing');
-    end
-end
-
-%check the correctness of f_ex_vec
-if numel(f_ex_vec)>1
-    if ~(size(f_ex_vec,1)==1 | size(f_ex_vec,2)==1)
-	error('f_ex_vec should be a vector (ie, a matrix with one singleton dimension)');
-    end
-end
-
-
 
 fprintf('Allocating grid...');
 fdtdgrid = initialisesplitgrid(I,J,K,Dxl,Dxu,Dyl,Dyu,Dzl,Dzu);
 fprintf('Done\n');
 
-%[epso , muo , c] = import_constants;
+%% Impliment incident planewave
+% We now implement an incident planewave using a total/scattered field formulation.
+% For k<K1 we have scattered and for k>=K1 we have total. The field is coupled into system by means of update equations to maintain consistency.
 
-%We now implement an incident planewave using a total/scattered field
-%formulation. For k<K1 we have scattered and for k>=K1 we have total.
-%The field is coupled into system by means of update equations to_l maintain
-%consistency.
-
-%correct:
-%refractive_index = sqrt(real(epsr(1)));
-
-%omega_an = 2*pi*f_an;
-%lambda_an = c/(f_an*refractive_index);
-%wave_num_an = 2*pi/lambda_an;%wave number in m^-1
-
-%fprintf('Initialising source field...');
-
-%Isource(:,1,1) = [Ey Ez Hy Hz Ey Ez Hy Hz]
-%Jsource(:,1,1) = [Ex Ez Hx Hz Ex Ez Hx Hz]
-%Ksource(:,1,1) = [Ex Ey Hx Hy Ex Ey Hx Hy]
-
-%now need to adjust interface to be in global coordinates
-interface.I0(1) = interface.I0(1) + Dxl;
-interface.I1(1) = interface.I1(1) + Dxl;
-interface.J0(1) = interface.J0(1) + Dyl;
-interface.J1(1) = interface.J1(1) + Dyl;
-interface.K0(1) = interface.K0(1) + Dzl;
-interface.K1(1) = interface.K1(1) + Dzl;
-
-illorigin = illorigin + [Dxl Dyl Dzl];
-
-%however, if the sourcemode is pulsed then we must reset these
-%values to:
-
-
-if strncmp(sourcemode,'pulsed',6)
-    interface.I0(1) = 1;
+if strcmp(sourcemode, 'pulsed')
+	interface.I0(1) = 1;
     interface.J0(1) = 1;
     interface.I1(1) = I_tot+1;
     interface.J1(1) = J_tot+1;
-
     interface.I0(2) = 0;
     interface.I1(2) = 0;
     interface.J0(2) = 0;
     interface.J1(2) = 0;
     interface.K1(2) = 0;
-
     if (interface.K0(2)==0) & K~=0
-	error('Running in pulsed mode with k0[0]=0, there is no point running');
+		error('Running in pulsed mode with k0[0]=0, there is no point running');
     end
+else
+	% Adjust interface to use global coordinates
+	interface.I0(1) = interface.I0(1) + Dxl;
+	interface.I1(1) = interface.I1(1) + Dxl;
+	interface.J0(1) = interface.J0(1) + Dyl;
+	interface.J1(1) = interface.J1(1) + Dyl;
+	interface.K0(1) = interface.K0(1) + Dzl;
+	interface.K1(1) = interface.K1(1) + Dzl;
 end
+% Specify origin of the source
+illorigin = illorigin + [Dxl Dyl Dzl];
 
-%Set up the Ksource field. This has to be defined on a 2d array
-%over the range (I0,I1)x(J0,J1). We calculate the field values
-%assuming an origin for the illumination
+% Set up the Ksource field.
+% This has to be defined on a 2d array over the range (I0,I1)x(J0,J1). We calculate the field values assuming an origin for the illumination
 i_source = (interface.I0(1):interface.I1(1)) - illorigin(1);
 j_source = (interface.J0(1):interface.J1(1)) - illorigin(2);
 k_source = interface.K0(1) - illorigin(3);
 
-
-
 if interface.K0(2)
-
     %Ex, K0
-    [x,y,z] = yeeposition(i_source,j_source,k_source,delta,'Ex');
+    [x,y,z] = yeeposition(i_source, j_source, k_source, delta, 'Ex');
     z = z + z_launch;
     ex_coords.x = x;
     ex_coords.y = y;
     ex_coords.z = z;
-
     %Ey, K0
-    [x,y,z] = yeeposition(i_source,j_source,k_source,delta,'Ey');
+    [x,y,z] = yeeposition(i_source, j_source, k_source, delta, 'Ey');
     z = z + z_launch;
     ey_coords.x = x;
     ey_coords.y = y;
@@ -513,8 +158,9 @@ ind0 = find(fvec_E==0);
 fvec_E(1:(ind0-1)) = fvec_E(1:(ind0-1)) -fvec_E(ind0-1) - fvec_E(ind0+1);
 fvec_E = ifftshift(fvec_E);
 
-[epso , muo , c] = import_constants;
+[~, ~, c] = import_constants;
 refractive_index = sqrt(real(epsr(1)));
 lambda_an = c/(f_an*refractive_index);
 hwhm = lambda_an^2/((c/refractive_index)*wavelengthwidth)*2*sqrt(log(2)/pi);
 to_l = hwhm*sqrt(log(1e8)/pi);
+end

--- a/tdms/tests/system/data/input_generation/matlab/hfield_focused_equiv.m
+++ b/tdms/tests/system/data/input_generation/matlab/hfield_focused_equiv.m
@@ -1,24 +1,12 @@
-%function [E] = efield(X,Y,Z);
-%
-%This function is called by iteratefdtd_matrix to set the electric
-%field source terms
-%
-function [E] = hfield_focused_equiv(X,Y,Z)
+function [H] = hfield_focused_equiv(X,Y,Z)
+	%% Set the magnetic field source terms to be 0, over the computational grid X, Y, Z provided.
+	%% This function is called by iteratefdtd_matrix to set the magnetic field source terms.
+	% X, Y, Z	: Grid coordinates
+	%
+	% H			: Magnetic field over the grid
 
-
-    [m,n] = size(X);
-
-    for i=1:m
-	for j=1:n
-	    %[Etmp,d] = RichardsWolfZernike(pi/2,1,0,inf,0,0,1,10,0,0,X(i,j)*1e6,X(i,j)*1e6,Y(i,j)*1e6,Y(i,j)*1e6,Z*1e6,Z*1e6,1,1,1,10);
-	    %the following -1* terms are there to account for the
-            %fact that the fdtd code employs the exp(+jwt) convention
-	    %E{1}(i,j) = exp(sqrt(-1)*k*Z);
-	    %E{2}(i,j) = 0;
-	    %[Etmp,Htmp,d] = NLayerIllumination(alpha,k,nvec,dbs,gbs,hvec,X(i,j),X(i,j),Y(i,j),Y(i,j),Z,Z,Nx,Ny,Nz,nint);
-
-	    E{1}(i,j) = 0;%zeros(size(Htmp{1}));
-	    E{2}(i,j) = 0;%zeros(size(Htmp{2}));
-	    E{3}(i,j) = 0;%zeros(size(Htmp{3}));
+	H = cell(1, 3);
+	for component = 1:3
+		H{component} = zeros(size(X));
 	end
-    end
+end

--- a/tdms/tests/system/data/input_generation/matlab/import_constants.m
+++ b/tdms/tests/system/data/input_generation/matlab/import_constants.m
@@ -1,8 +1,11 @@
-%function [epso muo c] = import_constants
-%
-%This is where all physical constants are defined
-function [epso , muo , c] = import_constants
+function [epso , muo , c] = import_constants()
+    %% Returns the values of physical constants relevant to light propagation.
+    %
+    % eps0  : Permitivity of free space
+    % mu0   : Permeability of free space
+    % c     : Speed of light in vacuum
 
 epso = 8.854187817e-12;
 muo = 4.0 * pi * 1.0e-7;
 c = 1.0 / sqrt(muo*epso);
+end

--- a/tdms/tests/system/data/input_generation/matlab/initialisesplitgrid.m
+++ b/tdms/tests/system/data/input_generation/matlab/initialisesplitgrid.m
@@ -6,7 +6,7 @@ function [fdtdgrid] = initialisesplitgrid(I,J,K,Dxl,Dxu,Dyl,Dyu,Dzl,Dzu)
     % I, J, K       : Number of non- PML Yee cells x, y, z direction
     % Dx, Dy, Dz    : Number of cells in x, y, z direction in a single PML layer
     %
-    % fdtdgrid : Struct with 13 elements:
+    % fdtdgrid : 1-by-1 struct with 13 elements:
     % Exy, Exz, Eyx, Eyz, Ezx, Ezy, Hxy, Hxz, Hyx, Hyz, Hzx, Hzy : The split-field components
     % material                                                   : Flags whether the cell is PML or not
     %
@@ -14,21 +14,16 @@ function [fdtdgrid] = initialisesplitgrid(I,J,K,Dxl,Dxu,Dyl,Dyu,Dzl,Dzu)
     % A material type of 0 means that the material is either free space or a pml cell, and the cell index may be used to index into the appropriate vector for the update parameter.
     % If the material type is greater than zero, the update paramter is found by indexing into the material matrix.
 
+%% Compute total number of cells
 I_tot = I + Dxl + Dxu;
 J_tot = J + Dyl + Dyu;
 K_tot = K + Dzl + Dzu;
 
-fdtdgrid.Exy = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Exz = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Eyx = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Eyz = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Ezx = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Ezy = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hxy = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hxz = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hyx = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hyz = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hzx = zeros(I_tot+1,J_tot+1,K_tot+1);
-%fdtdgrid.Hzy = zeros(I_tot+1,J_tot+1,K_tot+1);
+%% Create structure array
+split_field_components = {'Exy', 'Exz', 'Eyx', 'Eyz', 'Ezx', 'Ezy', 'Hxy', 'Hxz', 'Hyx', 'Hyz', 'Hzx', 'Hzy'};
+fdtdgrid = struct();
+for i=1:numel(split_field_components)
+    fdtdgrid.(split_field_components{i}) = zeros(I_tot+1,J_tot+1,K_tot+1);
+end
 fdtdgrid.materials = uint8(zeros(I_tot+1,J_tot+1,K_tot+1));
 end

--- a/tdms/tests/system/data/input_generation/matlab/initialisesplitgrid.m
+++ b/tdms/tests/system/data/input_generation/matlab/initialisesplitgrid.m
@@ -1,65 +1,34 @@
-%function [fdtdgrid] = initialisesplitgrid(I,J,K,Dx,Dy,Dz)
-%
-%initialises a new FDTD grid for the split formulation with a PML.
-%EXCLUDING the PML there are I Yee cells
-%in the x-direction, J Yee cells in the y-direction
-%and K Yee cells in the z direction. When the PML is taken
-%into account there are:
-%
-%I+2*Dx cells in x direction
-%J+2*Dy cells in y direction
-%K+2*Dz cells in z direction
-%
-%Inputs -
-%
-%I - the number of Yee cells (excluding PML) in the x direction
-%J - the number of Yee cells (excluding PML) in the y direction
-%K - the number of Yee cells (excluding PML) in the z direction
-% Dx - Number of cells in x direction in a single PML layer
-% Dy - Number of cells in y direction in a single PML layer
-% Dz - Number of cells in z direction in a single PML layer
-%
-%Returns -
-%
-% fdtdgrid - a struct with 13 elements:
-%               fdtdgrid.Exy
-%               fdtdgrid.Exz
-%               fdtdgrid.Eyx
-%               fdtdgrid.Eyz
-%               fdtdgrid.Ezx
-%               fdtdgrid.Ezy
-%               fdtdgrid.Hxy
-%               fdtdgrid.Hxz
-%               fdtdgrid.Hyx
-%               fdtdgrid.Hyz
-%               fdtdgrid.Hzx
-%               fdtdgrid.Hzy
-%               fdtdgrid.material
-%
-%These are arrays of diemension (I+2*Dx+1)x(J+2*Dy+1)x(K+2*Dz+1)
-%and are intialised to 0. The first 12 are actual field quantities
-%whilst the final is a descriptor for a material type. A material
-%type of 0 means that the material is either free space or a pml
-%and the cell index may be used to index into the appropriate
-%vector for the update parameter. If it is greater than zero, the
-%update paramter is found by indexing into the material matrix.
-%
 function [fdtdgrid] = initialisesplitgrid(I,J,K,Dxl,Dxu,Dyl,Dyu,Dzl,Dzu)
+    %% Initialise a new FDTD grid for the split formulation with a PML.
+    %% EXCLUDING the PML there are (I,J,K) Yee cells in the (x,y,z)-directions. When the PML is taken into account there are
+    %% (I,J,K)+2*(Dx,Dy,Dz)
+    %% cells in the (x,y,z) direction.
+    % I, J, K       : Number of non- PML Yee cells x, y, z direction
+    % Dx, Dy, Dz    : Number of cells in x, y, z direction in a single PML layer
+    %
+    % fdtdgrid : Struct with 13 elements:
+    % Exy, Exz, Eyx, Eyz, Ezx, Ezy, Hxy, Hxz, Hyx, Hyz, Hzx, Hzy : The split-field components
+    % material                                                   : Flags whether the cell is PML or not
+    %
+    % These are arrays of diemension (I+2*Dx+1,J+2*Dy+1,K+2*Dz+1), and are intialised to 0.
+    % A material type of 0 means that the material is either free space or a pml cell, and the cell index may be used to index into the appropriate vector for the update parameter.
+    % If the material type is greater than zero, the update paramter is found by indexing into the material matrix.
 
-I = I + Dxl + Dxu;
-J = J + Dyl + Dyu;
-K = K + Dzl + Dzu;
+I_tot = I + Dxl + Dxu;
+J_tot = J + Dyl + Dyu;
+K_tot = K + Dzl + Dzu;
 
-fdtdgrid.Exy = zeros(I+1,J+1,K+1);
-%fdtdgrid.Exz = zeros(I+1,J+1,K+1);
-%fdtdgrid.Eyx = zeros(I+1,J+1,K+1);
-%fdtdgrid.Eyz = zeros(I+1,J+1,K+1);
-%fdtdgrid.Ezx = zeros(I+1,J+1,K+1);
-%fdtdgrid.Ezy = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hxy = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hxz = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hyx = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hyz = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hzx = zeros(I+1,J+1,K+1);
-%fdtdgrid.Hzy = zeros(I+1,J+1,K+1);
-fdtdgrid.materials = uint8(zeros(I+1,J+1,K+1));
+fdtdgrid.Exy = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Exz = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Eyx = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Eyz = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Ezx = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Ezy = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hxy = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hxz = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hyx = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hyz = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hzx = zeros(I_tot+1,J_tot+1,K_tot+1);
+%fdtdgrid.Hzy = zeros(I_tot+1,J_tot+1,K_tot+1);
+fdtdgrid.materials = uint8(zeros(I_tot+1,J_tot+1,K_tot+1));
+end

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
@@ -12,8 +12,8 @@ function [n] = minsteps_fdtd(input_file)
 
 %% Load / compute parameters required
 [~, ~, c] = import_constants;
-[t0, hwhm] = fdtdduration(inputfile);
-dt_upper = fdtdts(inputfile);
+[t0, hwhm] = fdtdduration(input_file);
+dt_upper = fdtdts(input_file);
 
 % Adjust so that we have the pulse close to 0 at the interface
 t = 2*t0;

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
@@ -7,30 +7,8 @@ function [n] = minsteps_fdtd(input_file)
     % n             : Minimum number of timesteps that will need to be performed in a fdtd simulation
 
 %% Fetch the configuration information for this test
-
-% Check that the input file can be found on the path
-if isfile(input_file)
-	% Run input file as a script to import variables into the workspace
-	run(input_file);
-else
-	% Throw error - config file cannot be found
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-% Check required variables have been set in the config file, and loaded
-% Note that lambda will be returned once it is imported from the input file
-required_variables = {'delta','K','interface','f_an','epsr'};
-n_required_variables = length(required_variables);
-i = 1;
-% Search through all required variables and check they exist in the workspace
-% Throw error (and break loop early) if they are not found
-while i<=n_required_variables
-	if ~exist(required_variables{i}, 'var')
-		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
-		break
-	end
-	i = i + 1;
-end
+[delta, K, interface, epsr] = get_from_input_file(input_file, struct(), ...
+												'delta','K','interface','epsr');
 
 %% Load / compute parameters required
 [~, ~, c] = import_constants;

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_fdtd.m
@@ -1,54 +1,49 @@
-%function [n] = fdtdminsteps(inputfile)
-%
-%estimates the minmum number of steps required in a fdtd simulation
-%assuming the time step used is 0.95xmaximum time step and that the
-%trailing edge of the guassian pulse travels at the speed of
-%light. (dispersion free). Calculates the edge of the pulse travelling from
-%interface to end wall and back.
-function [n] = minsteps_fdtd(inputfile)
+function [n] = minsteps_fdtd(input_file)
+    %% Estimates the minmum number of steps required in a fdtd simulation.
+    %% Assumes the time step used is 0.95 * maximum time step, and that the trailing edge of the guassian pulse travels at the speed of light (dispersion free).
+    %% Calculates the edge of the pulse travelling from the interface to the end wall and back.
+    % input_file    : Config file to read values from
+    %
+    % n             : Minimum number of timesteps that will need to be performed in a fdtd simulation
 
-[fid_input,message] = fopen(inputfile,'r');
+%% Fetch the configuration information for this test
 
-%check if file was opened successfully
-if fid_input== -1
+% Check that the input file can be found on the path
+if isfile(input_file)
+	% Run input file as a script to import variables into the workspace
+	run(input_file);
+else
+	% Throw error - config file cannot be found
     error(sprintf('File %s could not be opened for reading',input_file));
 end
 
-%proceed to_l read in config information
-current_line = fgets(fid_input);
-
-while current_line ~= -1
-    eval(current_line);
-    current_line = fgets(fid_input);
+% Check required variables have been set in the config file, and loaded
+% Note that lambda will be returned once it is imported from the input file
+required_variables = {'delta','K','interface','f_an','epsr'};
+n_required_variables = length(required_variables);
+i = 1;
+% Search through all required variables and check they exist in the workspace
+% Throw error (and break loop early) if they are not found
+while i<=n_required_variables
+	if ~exist(required_variables{i}, 'var')
+		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
+		break
+	end
+	i = i + 1;
 end
 
-[epso muo c] = import_constants;
+%% Load / compute parameters required
+[~, ~, c] = import_constants;
+[t0, hwhm] = fdtdduration(inputfile);
+dt_upper = fdtdts(inputfile);
 
-if exist('K') ~= 1
-    error('K is not defined - cannot determine n');
-end
+% Adjust so that we have the pulse close to 0 at the interface
+t = 2*t0;
 
-if exist('delta') ~= 1
-    error('delta is not defined - cannot determine n');
-end
-
-if exist('interface') ~= 1
-    error('interface is not defined - cannot determine n');
-end
-
-if exist('f_an') ~= 1
-    error('f_an is not defined - cannot determine n');
-end
-
-
-[to hwhm] = fdtdduration(inputfile);
-[dt_upper] = fdtdts(inputfile);
-
-%have to have pulse reaching close to 0 at the interface
-t = 2*to;
-
-%now this has to propagate from the interface to the other edge of
-%the grid and then out again
+%% Compute timestep estimate
+% This pulse has to propagate from the interface, to the other edge of the grid, and then out again
+% This is the time that will be ellapsed
 t = t + (K-interface.K0(1))*delta.z/(c/sqrt(max(epsr))) + K*delta.z/(c/sqrt(max(epsr)));
-
+% Hence from the ellapsed time, we can compute the number of timesteps we need for the pulse to travel back & forth
 n = ceil(t/(0.95*dt_upper));
+end

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
@@ -12,7 +12,7 @@ function [n] = minsteps_pstd(input_file)
 
 %% Load / compute parameters required
 [~, ~, c] = import_constants;
-[t0, hwhm] = fdtdduration(inputfile);
+[t0, hwhm] = fdtdduration(input_file);
 
 % Adjust so that we have the pulse close to 0 at the interface
 t = 2*t0;

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
@@ -1,56 +1,48 @@
-%function [n] = fdtdminsteps(inputfile)
-%
-%estimates the minmum number of steps required in a fdtd simulation
-%assuming the time step used is 0.95xmaximum time step and that the
-%trailing edge of the guassian pulse travels at the speed of
-%light. (dispersion free). Calculates the edge of the pulse travelling from
-%interface to end wall and back.
-function [n] = minsteps_pstd(inputfile)
+function [n] = minsteps_pstd(input_file)
+    %% Estimates the minmum number of steps required in a pstd simulation.
+    %% Assumes the time step used is 0.95 * maximum time step, and that the trailing edge of the guassian pulse travels at the speed of light (dispersion free).
+    %% Calculates the edge of the pulse travelling from the interface to the end wall and back.
+    % input_file    : Config file to read values from
+    %
+    % n             : Minimum number of timesteps that will need to be performed in a fdtd simulation
 
-[fid_input,message] = fopen(inputfile,'r');
+%% Fetch the configuration information for this test
 
-%check if file was opened successfully
-if fid_input== -1
+% Check that the input file can be found on the path
+if isfile(input_file)
+	% Run input file as a script to import variables into the workspace
+	run(input_file);
+else
+	% Throw error - config file cannot be found
     error(sprintf('File %s could not be opened for reading',input_file));
 end
 
-%proceed to_l read in config information
-current_line = fgets(fid_input);
-
-while current_line ~= -1
-    eval(current_line);
-    current_line = fgets(fid_input);
+% Check required variables have been set in the config file, and loaded
+% Note that lambda will be returned once it is imported from the input file
+required_variables = {'delta','K','interface','f_an','dt','epsr'};
+n_required_variables = length(required_variables);
+i = 1;
+% Search through all required variables and check they exist in the workspace
+% Throw error (and break loop early) if they are not found
+while i<=n_required_variables
+	if ~exist(required_variables{i}, 'var')
+		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
+		break
+	end
+	i = i + 1;
 end
 
-[epso muo c] = import_constants;
+%% Load / compute parameters required
+[~, ~, c] = import_constants;
+[t0, hwhm] = fdtdduration(inputfile);
 
-if exist('K') ~= 1
-    error('K is not defined - cannot determine n');
-end
+% Adjust so that we have the pulse close to 0 at the interface
+t = 2*t0;
 
-if exist('delta') ~= 1
-    error('delta is not defined - cannot determine n');
-end
-
-if exist('interface') ~= 1
-    error('interface is not defined - cannot determine n');
-end
-
-if exist('f_an') ~= 1
-    error('f_an is not defined - cannot determine n');
-end
-
-if exist('dt') ~= 1
-    error('dt is not defined - cannot determine n');
-end
-
-[to hwhm] = fdtdduration(inputfile);
-
-%have to have pulse reaching close to 0 at the interface
-t = 2*to;
-
-%now this has to propagate from the interface to the other edge of
-%the grid and then out again
+%% Compute timestep estimate
+% This pulse has to propagate from the interface, to the other edge of the grid, and then out again
+% This is the time that will be ellapsed
 t = t + (K-interface.K1(1))*delta.z/(c/sqrt(epsr(1))) + K*delta.z/(c/sqrt(epsr(1)));
-
+% Hence from the ellapsed time, we can compute the number of timesteps we need for the pulse to travel back & forth
 n = ceil(t/(0.95*dt));
+end

--- a/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
+++ b/tdms/tests/system/data/input_generation/matlab/minsteps_pstd.m
@@ -7,30 +7,8 @@ function [n] = minsteps_pstd(input_file)
     % n             : Minimum number of timesteps that will need to be performed in a fdtd simulation
 
 %% Fetch the configuration information for this test
-
-% Check that the input file can be found on the path
-if isfile(input_file)
-	% Run input file as a script to import variables into the workspace
-	run(input_file);
-else
-	% Throw error - config file cannot be found
-    error(sprintf('File %s could not be opened for reading',input_file));
-end
-
-% Check required variables have been set in the config file, and loaded
-% Note that lambda will be returned once it is imported from the input file
-required_variables = {'delta','K','interface','f_an','dt','epsr'};
-n_required_variables = length(required_variables);
-i = 1;
-% Search through all required variables and check they exist in the workspace
-% Throw error (and break loop early) if they are not found
-while i<=n_required_variables
-	if ~exist(required_variables{i}, 'var')
-		error(sprintf('Required variable %s not present in %s', required_variables{i}, input_file));
-		break
-	end
-	i = i + 1;
-end
+[delta,K,interface,dt,epsr] = get_from_input_file(input_file, struct(), ...
+														'delta','K','interface','dt','epsr');
 
 %% Load / compute parameters required
 [~, ~, c] = import_constants;

--- a/tdms/tests/system/data/input_generation/matlab/multi_layer.m
+++ b/tdms/tests/system/data/input_generation/matlab/multi_layer.m
@@ -1,34 +1,20 @@
-%[S] = multi_layer( zvec, nvec, lambda0, theta0, sp)
-%
-%Caculate the characteristic matrix of a multlayer structure
-%specified as per the following:
-%
-% zvec =    [z1    z2   ... zN]
-% nvec = [n0    n1    n2  ...  nN]
-% lambda0: wavelength in air
-% theta0: angle of incidence of plane wave in radians
-% sp: 'TE' or 'TM'. 'TE' is taken to mean that the electric vector
-%                        in perpendicular to the plane in which the
-%                        wave propagates and 'TM' is the case when
-%                        the electric field vector is in, or
-%                        parallel to, the plane in which the wave
-%                        propagates
+function [S] = multi_layer(zvec, nvec, lambda0, theta0, sp)
+    %% Compute the characteristic matrix of a multilayer structure.
+    % zvec      : [    z1, z2, ..., zN].
+    % nvec      : [n0, n1, n2, ..., nN].
+    % lambda0   : Wavelength of light in air.
+    % theta0    : Angle of incidence of the plane wave, in radians.
+    % sp        : Either 'TE' or 'TM'. 'TE' is taken to mean that the electric vector is perpendicular to the plane in which the wave propagates. 'TM' is when the electric field vector is in, or parallel to, the plane in which the wave propagates.
+    %
+    % S         : Characteristic matrix of the multilayer structure.
 
-function [S] = multi_layer( zvec, nvec, lambda0, theta0, sp)
+%% Check dimensionality of inputs
+if numel(nvec)-numel(zvec) ~= 1
+    error('nvec should have one more element that zvec');
+end
 
-
-%sp='TE';%TM %s in the TE case (perpendicular) and p the TM case (parallel), see Azzam and
-        %Bashara page 271. Essentially, s is perpendicular to the
-        %plane that the plane propagates in the p is parallel.
-
-%function [S] = multi_layer( zvec, nvec, lambda0, theta0, sp)
-    %perform some basic checks
-	if numel(nvec)-numel(zvec) ~= 1
-	    error('nvec should have one more element that zvec');
-	end
-
+%% Compute constant values
 theta_vec=asin(nvec(1)*sin(theta0)./nvec);
-
 st=sin(theta_vec);
 ct=cos(theta_vec);
 
@@ -37,32 +23,19 @@ if numel(nvec)>2
     beta=ct(2:(end-1)).*nvec(2:(end-1)).*d*2*pi/lambda0;
 end
 
-if strcmp(sp,'TE')%the 's' case
+if strcmp(sp,'TE')
     t_fresnel = 2*nvec(1:(end-1)).*ct(1:(end-1))./(nvec(1:(end-1)).*ct(1:(end-1))+nvec(2:end).*ct(2:end));
     r_fresnel = (nvec(1:(end-1)).*ct(1:(end-1))-nvec(2:end).*ct(2:end))./(nvec(1:(end-1)).*ct(1:(end-1))+nvec(2:end).*ct(2:end));
-else%the 'p' case
+else
     t_fresnel = 2*nvec(1:(end-1)).*ct(1:(end-1))./(nvec(2:end).*ct(1:(end-1))+nvec(1:(end-1)).*ct(2:end));
     r_fresnel = (nvec(2:end).*ct(1:(end-1))-nvec(1:(end-1)).*ct(2:end))./(nvec(2:end).*ct(1:(end-1))+nvec(1:(end-1)).*ct(2:end));
 end
 
-%trans_s
-%2.*n1*ct1/(n1*ct1 + n2*ct2);
-%ref_s
-%(n1*ct1 - n2*ct2)/(n1*ct1 + n2*ct2);
-
-%trans_p
-%2.*n1*ct1/(n2*ct1 + n1*ct2);
-%ref_p
-%(n2*ct1 - n1*ct2)/(n2*ct1 + n1*ct2);
-
+%% Setup scattering matrix
 S = 1/t_fresnel(1)*[1 r_fresnel(1);r_fresnel(1) 1];
 for il=2:numel(zvec)
-    %dP=exp(sqrt(-1)*beta(il-1));
     P = [exp(-sqrt(-1)*beta(il-1)) 0;0 exp(sqrt(-1)*beta(il-1))];
     L = 1/t_fresnel(il)*[1 r_fresnel(il);r_fresnel(il) 1];
     S=S*P*L;
 end
-%S1=S;
-%[S] = multi_layer_03( zvec, nvec, lambda0);
-%abs(S1-S)
-%save ml_vars;
+end

--- a/tdms/tests/system/data/input_generation/matlab/yeeposition.m
+++ b/tdms/tests/system/data/input_generation/matlab/yeeposition.m
@@ -1,34 +1,32 @@
-%function [x y z] = yeeposition(i,j,k,delta,component)
-%
-%Calculate the position in a cartesian grid of the field
-%component specified by the yee cell index (i,j,k). delta
-%is a struct with members:
-%delta.x, delta.y and delta.z which are the yee cell
-%dimension and component is the component of interest
 function [x, y, z] = yeeposition(i,j,k,delta,component)
+	%% Calculate the position in cartesian space of the field component associated to the Yee cell with index (i,j,k).
+	%% E-field components are offset by 0.5 * the Yee cell extent in their dimension.
+	%% H-field components are offset by 0.5 * the Yee cell extent in the OTHER two dimensions.
+	% i, j, k	: Indicies of the Yee cell.
+	% delta		: Struct with members x, y, z, which are the Yee cell extent in the corresponding axial direction.
+	% component	: String, the field component whose position we wish to know.
+	%
+	% x, y, z	: The cartesian coordinates of the field component.
 
-    if strcmp(component,'Ex')
-	x = (i+0.5)*delta.x;
-	y = j*delta.y;
-	z = k*delta.z;
-    elseif strcmp(component,'Ey')
-	x = i*delta.x;
-	y = (j+0.5)*delta.y;
-	z = k*delta.z;
-    elseif strcmp(component,'Ez')
-	x = i*delta.x;
-	y = j*delta.y;
-	z = (k+0.5)*delta.z;
-    elseif strcmp(component,'Hx')
-	x = i*delta.x;
-	y = (j+0.5)*delta.y;
-	z = (k+0.5)*delta.z;
-    elseif strcmp(component,'Hy')
-	x = (i+0.5)*delta.x;
-	y = j*delta.y;
-	z = (k+0.5)*delta.z;
-    elseif strcmp(component,'Hz')
-	x = (i+0.5)*delta.x;
-	y = (j+0.5)*delta.y;
-	z = k*delta.z;
-    end
+%% Field component coordinate alligns with Yee cell centre for all other components
+x = i * delta.x;
+y = j * delta.y;
+z = k * delta.z;
+%% Add offsets based on which component we are examining
+if strcmp(component,'Ex')
+	x = x + 0.5*delta.x;
+elseif strcmp(component,'Ey')
+	y = y + 0.5*delta.y;
+elseif strcmp(component,'Ez')
+	z = z + 0.5*delta.z;
+elseif strcmp(component,'Hx')
+	y = y + 0.5*delta.y;
+	z = z + 0.5*delta.z;
+elseif strcmp(component,'Hy')
+	x = x + 0.5*delta.x;
+	z = z + 0.5*delta.z;
+elseif strcmp(component,'Hz')
+	x = x + 0.5*delta.x;
+	y = y + 0.5*delta.y;
+end
+end


### PR DESCRIPTION
Continues #236 | Related to #266 in that it adds a lot of docstrings and simplifies a lot of the codebase.

Now that the input data generation scripts are tracked by the repository, we can focus on tidying up the supporting `MATLAB` functions in the `matlab` folder to reduce code duplication, bloat, etc.

There are a _lot_ of docstring fixes, which the commit history logs pretty well. 

### Significant functionality re-writes are:
- `get_from_input_file` allows us to recycle the code chunk that appeared in almost all of the longer functions into one place. It also fetches the values in a safer manner than before (running `eval` over each line of a script sequentially), and it also means the linter doesn't complain when you open a file that has had a variable implicitly defined by an `eval` statement and not actually defined _properly_.
- `getsourcecoords` has been compressed to only import variables it actually needs.
- `fdtd_bounds` runs a bit faster because we can remove some superfluous code chunks.

`test_regen.py` still successfully completes under these changes, so functionality is being preserved.

### Not Touching `iteratefdtd_matrix.m`
Deliberately _not_ touching `iteratefdtd_matrix` because #208 will be overwriting those changes anyway, and we can work from the new version of the file.