### PR TITLE
"Fix" M2 Mac `TDFieldExporter2D` problem.

### DIFF
--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -522,7 +522,7 @@ private:
 public:
   mxArray *matlab_array = nullptr;
   double **array = nullptr;
-  const char *folder_name = nullptr;
+  std::string folder_name = "";
 
   /**
    * Allocate the arrays to hold the field

--- a/tdms/src/fields/td_field_exporter_2d.cpp
+++ b/tdms/src/fields/td_field_exporter_2d.cpp
@@ -1,8 +1,10 @@
 #include "field.h"
 
 #include <stdexcept>
+#include <string>
 
 #include "matlabio.h"
+using std::string;
 
 void TDFieldExporter2D::allocate(int _nI, int _nK) {
 
@@ -37,11 +39,10 @@ void TDFieldExporter2D::export_field(SplitField &F, int stride,
     i += stride;
   }
 
-  char toutputfilename[512];
-  snprintf(toutputfilename, 512, "%s/ex_%06d.mat", folder_name, iteration);
-  fprintf(stderr, "time domain output: %s\n", toutputfilename);
-
-  auto toutfile = matOpen(toutputfilename, "w");
-  matPutVariable(toutfile, "ex_tdf", (mxArray *) matlab_array);
-  matClose(toutfile);
+  // set up and write to MATLAB file
+  string file_name = folder_name + "ex_" + std::to_string(iteration) + ".mat";
+  spdlog::debug("Writing time-domain output to: {}", file_name);
+  auto output_file = matOpen(file_name.c_str(), "w");
+  matPutVariable(output_file, "ex_tdf", (mxArray *) matlab_array);
+  matClose(output_file);
 }

--- a/tdms/src/fields/td_field_exporter_2d.cpp
+++ b/tdms/src/fields/td_field_exporter_2d.cpp
@@ -3,6 +3,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <spdlog/spdlog.h>
+
 #include "matlabio.h"
 using std::string;
 

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -97,27 +97,31 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
     params.z_obs = input_grid_labels.z[params.k_det_obs];
   }
 
-  // Get tdfdir - check what's going on here in a second
+  // Get 'tdfdir' - this is the directory name to write the time-domain fields
+  // into. If it's an empty string, then don't write out the TD fields at all.
+  // Only write out every `skip_tdf` fields.
   ex_td_field_exporter = TDFieldExporter2D();
   if (mxIsChar(matrices_from_input_file["tdfdir"])) {
     std::string dir = string_in(matrices_from_input_file["tdfdir"], "tdfdir");
-    ex_td_field_exporter.folder_name = dir.c_str();
 
-    int Ni_tdf = 0, Nk_tdf = 0;
-    for (int k = 0; k < IJK_tot.k; k++)
-      if ((k % skip_tdf) == 0) Nk_tdf++;
+    if (dir == "") {
+      spdlog::debug("Will not write out the time-domain fields.");
 
-    for (int i = 0; i < IJK_tot.i; i++)
-      if ((i % skip_tdf) == 0) Ni_tdf++;
-    spdlog::info("Ni_tdf = {0:d}, Nk_tdf = {1:d}", Ni_tdf, Nk_tdf);
-
-    if (!are_equal(ex_td_field_exporter.folder_name, "")) {
-      spdlog::debug("Will write the TD fields to '{}'.",
+    } else {
+      ex_td_field_exporter.folder_name = dir.c_str();
+      spdlog::debug("Will write the time-domain fields to '{}'.",
                     ex_td_field_exporter.folder_name);
+
+      int Ni_tdf = 0, Nk_tdf = 0;
+      for (int k = 0; k < IJK_tot.k; k++)
+        if ((k % skip_tdf) == 0) Nk_tdf++;
+
+      for (int i = 0; i < IJK_tot.i; i++)
+        if ((i % skip_tdf) == 0) Ni_tdf++;
+      spdlog::debug("Ni_tdf = {0:d}, Nk_tdf = {1:d}", Ni_tdf, Nk_tdf);
+
       params.has_tdfdir = true;
       ex_td_field_exporter.allocate(Ni_tdf, Nk_tdf);
-    } else {
-      spdlog::debug("Will not write out the TD fields.");
     }
   }
 

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -108,7 +108,7 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
       spdlog::debug("Will not write out the time-domain fields.");
 
     } else {
-      ex_td_field_exporter.folder_name = dir.c_str();
+      ex_td_field_exporter.folder_name = dir;
       spdlog::debug("Will write the time-domain fields to '{}'.",
                     ex_td_field_exporter.folder_name);
 

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -100,8 +100,8 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   // Get tdfdir - check what's going on here in a second
   ex_td_field_exporter = TDFieldExporter2D();
   if (mxIsChar(matrices_from_input_file["tdfdir"])) {
-    ex_td_field_exporter.folder_name =
-            string_in(matrices_from_input_file["tdfdir"], "tdfdir").c_str();
+    std::string dir = string_in(matrices_from_input_file["tdfdir"], "tdfdir");
+    ex_td_field_exporter.folder_name = dir.c_str();
 
     int Ni_tdf = 0, Nk_tdf = 0;
     for (int k = 0; k < IJK_tot.k; k++)
@@ -112,8 +112,12 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
     spdlog::info("Ni_tdf = {0:d}, Nk_tdf = {1:d}", Ni_tdf, Nk_tdf);
 
     if (!are_equal(ex_td_field_exporter.folder_name, "")) {
+      spdlog::debug("Will write the TD fields to '{}'.",
+                    ex_td_field_exporter.folder_name);
       params.has_tdfdir = true;
       ex_td_field_exporter.allocate(Ni_tdf, Nk_tdf);
+    } else {
+      spdlog::debug("Will not write out the TD fields.");
     }
   }
 


### PR DESCRIPTION
3b0fcb3d6cbdf92425d46012bdfde3f6114d6dd7 fixes the problem with exporting the fields to a non-existent directory. And since I've got the context in my head, I replaced `char* folder_name` in the `TDFieldExporter2D` to an `std::string` and did some sanity refactoring in 9fbe3e70fd8c596c9584d7f0d4cc18d52f04567f.

Probably related to #211. Superficially fixes #255 (I retrospectively created a bug report) and fixes #129 (I forgot that we'd seen this before and it disappeared).