### PR TITLE
`isort` to make `black`-compatible changes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"


### PR DESCRIPTION
`isort` uses a default linting style for long includes [that is incompatible with `black`s default](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#isort). We have both in our pre-commit and do not resolve this conflict.

This PR adds a `pyproject.toml` to the repo to implement the recommended fix.

(This conflict has only just come to light because it only occurs when an `import` line is too long and needs to be wrapped. Working on #241 has bought this to light)