### PR TITLE
Add coverage build and upload unit-test coverage to codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
         # also test 'Release'.
         build_testing: [ON, OFF]
         exclude:
-          # Currently our tests don't compile in Windows so skip this.
+          # Currently our tests don't compile, and nor do we have a coverage
+          # build in Windows so skip this.
           - os: windows-latest
             build_testing: ON
 
@@ -60,7 +61,7 @@ jobs:
         if: ${{ contains(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get update
-          sudo apt-get install libfftw3-dev libgomp1 python3
+          sudo apt-get install libfftw3-dev libgomp1 python3 lcov
 
       # -------------------------------------------------------------------------------
       # Windows
@@ -82,7 +83,7 @@ jobs:
       # MacOS
       - name: Install dependencies for MacOS
         if: ${{ contains(matrix.os, 'macos') }}
-        run: brew install fftw
+        run: brew install fftw lcov
 
       - name: Fix omp headers not linked on MacOS
         if: ${{ contains(matrix.os, 'macos') }}
@@ -108,6 +109,7 @@ jobs:
           cmake ${GITHUB_WORKSPACE}/tdms -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
            -DBUILD_TESTING=${{ matrix.build_testing }} \
+           -DCODE_COVERAGE=${{ matrix.build_testing }} \
            ${DOMP_ROOT_MAC}
         # This 👆 env variable only exists on MacOS builds to fix the OMP
         # homebrew/PATH problem.
@@ -125,6 +127,23 @@ jobs:
         run: |
           export OMP_NUM_THREADS=1
           ctest -C ${{ matrix.build_type }} --output-on-failure --extra-verbose
+
+      - name: Run coverage analysis with lcov
+        if: matrix.build_testing == 'ON'
+        shell: bash
+        # Create the coverage summary, filter out dependencies' coverage then
+        # print human-readable summary in the build logs.
+        run: |
+          lcov --capture --directory ${{ runner.workspace }}/build/CMakeFiles/tdms_tests.dir/src --output-file coverage.info
+          lcov --remove coverage.info '/usr/*' --output-file coverage.info
+          lcov --remove coverage.info '*/_deps/*' --output-file coverage.info
+          lcov --remove coverage.info '/Library/*' --output-file coverage.info
+          lcov --remove coverage.info '/Applications/*' --output-file coverage.info
+          lcov --list coverage.info
+
+      - name: Upload coverage reports to Codecov
+        if: matrix.build_testing == 'ON'
+        uses: codecov/codecov-action@v3
 
       - name: Tar the build result to maintain permissions
         # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # build output
+build/
 **build/
 **cmake-build**
 **.o
@@ -18,6 +19,7 @@ tdms/tests/system/data
 # text editor files
 .idea/
 .vscode/
+.cache/
 
 # MacOS
 **.DS_store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 and title at the top of README.md when building the project page (the title
 would be duplicated) everything else in README.md is also the project homepage. -->
 
-# TDMS · [![latest release](https://badgen.net/github/release/UCL/TDMS)](https://github.com/UCL/TDMS/releases)  [![license](https://badgen.net/github/license/UCL/TDMS)](https://github.com/UCL/TDMS/blob/main/LICENSE) [![Build and test](https://github.com/UCL/TDMS/actions/workflows/ci.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/ci.yml) [![MATLAB tests](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml) [![codecov](https://codecov.io/gh/UCL/TDMS/branch/main/graph/badge.svg?token=FIXME)](https://codecov.io/gh/UCL/TDMS)
+# TDMS · [![latest release](https://badgen.net/github/release/UCL/TDMS)](https://github.com/UCL/TDMS/releases)  [![license](https://badgen.net/github/license/UCL/TDMS)](https://github.com/UCL/TDMS/blob/main/LICENSE) [![Build and test](https://github.com/UCL/TDMS/actions/workflows/ci.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/ci.yml) [![MATLAB tests](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml) [![codecov](https://codecov.io/gh/UCL/TDMS/branch/master/graph/badge.svg?token=3kqP14kslL)](https://codecov.io/gh/UCL/TDMS)
 
 > **Warning**
 > This repository is a _work in progress_. The API will change without notice

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 and title at the top of README.md when building the project page (the title
 would be duplicated) everything else in README.md is also the project homepage. -->
 
-# TDMS · [![latest release](https://badgen.net/github/release/UCL/TDMS)](https://github.com/UCL/TDMS/releases)  [![license](https://badgen.net/github/license/UCL/TDMS)](https://github.com/UCL/TDMS/blob/main/LICENSE) [![Build and test](https://github.com/UCL/TDMS/actions/workflows/ci.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/ci.yml) [![MATLAB tests](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml)
+# TDMS · [![latest release](https://badgen.net/github/release/UCL/TDMS)](https://github.com/UCL/TDMS/releases)  [![license](https://badgen.net/github/license/UCL/TDMS)](https://github.com/UCL/TDMS/blob/main/LICENSE) [![Build and test](https://github.com/UCL/TDMS/actions/workflows/ci.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/ci.yml) [![MATLAB tests](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml/badge.svg)](https://github.com/UCL/TDMS/actions/workflows/matlab_tests.yml) [![codecov](https://codecov.io/gh/UCL/TDMS/branch/main/graph/badge.svg?token=FIXME)](https://codecov.io/gh/UCL/TDMS)
 
 > **Warning**
 > This repository is a _work in progress_. The API will change without notice

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -83,12 +83,15 @@ cmake ../tdms \
 # -DFFTW_ROOT=/usr/local/fftw3/ \
 # -DCMAKE_INSTALL_PREFIX=$HOME/.local/ \
 # -DBUILD_TESTING=ON \
+# -DCODE_COVERAGE=ON \
 # -DCMAKE_BUILD_TYPE=Debug
 make install
 ```
 You may need to help CMake find MATLAB/fftw etc.
 
 - By default, build testing is turned off. You can turn it on with `-DBUILD_TESTING=ON`.
+- By default, code coverage is disabled. You can enable it with `-DCODE_COVERAGE=ON`.
+   - [Then follow some extra steps](#coverage).
 - Also by default, debug printout is off. Turn on with `-DCMAKE_BUILD_TYPE=Debug` or manually at some specific place in the code with:
 ```{.cpp}
 #include <spdlog/spdlog.h>
@@ -223,6 +226,38 @@ The doxygen-style comments will be included in this developer documentation.
 To run the unit tests, [compile](#compiling) with `-DBUILD_TESTING=ON`. Then run `ctest` from the build directory or execute the test executable `./tdms_tests`.
 
 It's good practice, and reassuring for your pull-request reviewers, if new C++ functionality is at covered by unit tests.
+
+### Test coverage {#coverage}
+
+If you want to check the coverage of the unit tests, then build with `-DCODE_COVERAGE=ON`.
+Then when you run `ctest` or the `tdms_tests` executable, [GCDA coverage files](https://gcc.gnu.org/onlinedocs/gcc/Gcov-Data-Files.html) are generated.
+They are not really for humans to parse but can be summarised with other tools.
+In our build system we use [`lcov`](https://github.com/linux-test-project/lcov), a frontend for `gcov` reports.
+If you don't have `lcov`, you can install it with aptitude or homebrew (`sudo apt install lcov` or `brew install lcov`).
+
+To get a coverage report in the terminal: execute the unit tests and then confirm you generated .gcda files...
+```{.sh}
+./tdms_tests
+find . --name "*.gcda"
+```
+they're probably somewhere like `build/CMakeFiles/tdms.dir/src`.
+
+Then generate the coverage report with
+```{.sh}
+lcov --capture --directory ./CMakeFiles/tdms_tests.dir/src --output-file coverage.info
+lcov --list coverage.info
+```
+You'll notice it also counts the dependencies.
+You can filter these (`lcov --remove`) if you don't want them to appear in the statistics:
+```{.sh}
+lcov --remove coverage.info '/usr/*' --output-file coverage.info
+lcov --remove coverage.info '*/_deps/*' --output-file coverage.info
+```
+
+But you don't need to worry about this too much.
+When you open a pull-request, codecov will report.
+And you can browse the [codecov TDMS pages online](https://codecov.io/gh/UCL/TDMS).
+
 
 ### System {#system-tests}
 

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -81,6 +81,7 @@ else()
     add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
 endif()
 
+
 # TDMS target -----------------------------------------------------------------
 
 # wildcard to find all *.cpp files in the src directory except for main.cpp
@@ -113,6 +114,27 @@ endif()
 # Install ---------------------------------------------------------------------
 install(TARGETS tdms)
 
+
+# Code Coverage ---------------------------------------------------------------
+add_library(coverage_config INTERFACE)
+
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  message("Setting up code coverage.")
+  # Add required flags (GCC & LLVM/Clang)
+  target_compile_options(coverage_config INTERFACE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # sets all required flags
+  )
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(coverage_config INTERFACE --coverage)
+  else()
+    target_link_libraries(coverage_config INTERFACE --coverage)
+  endif()
+endif(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+
+
 # Testing ---------------------------------------------------------------------
 if (BUILD_TESTING)
     enable_testing()
@@ -128,6 +150,7 @@ if (BUILD_TESTING)
     target_link_libraries(tdms_tests PRIVATE
             Catch2::Catch2WithMain
             tdms_lib
+            coverage_config
             )
 
     add_test(test_all tdms_tests)


### PR DESCRIPTION
# Context/Description 

Adds a coverage build to CMakeLists and additions to the GitHub action to upload it all to codecov.io.

* Fixes  #120 

## More details

* Adds a coverage build to CMakeLists. Currently, this is only for the `tdms_tests` executable. Could also add it to `tdms` itself if we wanted to check the system tests' coverage.
* In our CI GitHub action, I install `lcov` (for nice summaries of the coverage stats for humans, and for upload to [codecov.io](https://codecov.io/gh/UCL/TDMS)).
* Add a badge 🎉 (but we need to get a token before it will be meaningful).

## Testing
Tested over on my fork.

* An example of the [build output](https://github.com/samcunliffe/TDMS/actions/runs/4796581423) (I temporarily disabled a whole bunch of irrelevant stuff in the build matrix).
* [What it looks like on codecov](https://app.codecov.io/gh/samcunliffe/TDMS/tree/coverage-build).

## Documentation 

* Added to developers' documentation with a section under "unit testing".
