### PR TITLE
Fix example script path

### DIFF
--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -3,7 +3,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %start by defining the coordinates of the computational grid
-addpath('../../tdms/matlab');
+addpath('../../tdms/tests/system/data/input_generation/matlab');
 [x,y,z,lambda] = fdtd_bounds('pstd_input_file.m');
 
 %15 micron radius cylinder
@@ -55,4 +55,9 @@ title('Focussed beam in free space');
 subplot(2,1,2);
 imagesc(dat_fs.z_i,dat_fs.x_i,abs(squeeze(dat_cyl.Ex_i)));
 title('Focussed beam with scattering cylinder');
+axis equal;
+
+%%
+figure;
+imagesc(dat_cyl.z_i, dat_cyl.x_i, abs(squeeze(dat_cyl.Hz_out)));
 axis equal;

--- a/examples/arc_01/run_pstd_bscan.m
+++ b/examples/arc_01/run_pstd_bscan.m
@@ -61,3 +61,4 @@ axis equal;
 figure;
 imagesc(dat_cyl.z_i, dat_cyl.x_i, abs(squeeze(dat_cyl.Hz_out)));
 axis equal;
+title('Normalised Hz component of the scattered field from a cylinder');


### PR DESCRIPTION
# Context/Description

* Fixes #271 

## More details

Updates the additional path added to the `MATLABPATH` when running the example script, so that MATLAB can find the required files.

## Testing

`examples/arc_01` can now be run using the instructions in the README.md and does not error.
