### PR TITLE
Fix typo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ For example:
 3. Plot the resulting...
 4. See error by checking...
 
-**Expected behavior**
+**Expected behaviour**
 What you expected to happen (if it's not already obvious from the context).
 
 **Plots**


### PR DESCRIPTION
# Context/Description 

* Fixes #272 

## More details

Changes `US` English `behavior` spelling in the issue template to `behaviour` (`UK`).