### PR TITLE
Add docstrings to variables

### DIFF
--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -432,17 +432,29 @@ public:
   }
 };
 
+/**
+ * @brief Stores the fibre modes in the Fourier plane of the objective lens.
+ *
+ * The "Tilde" indicates that these quantities are in a Fourier plane relative
+ * to where the optical fibre is actually located, meaning that is has a Fourier
+ * relationship relative to the physical fibre mode(s).
+ */
 class DTilde {
 protected:
-  int n_det_modes = 0;
+  int n_det_modes = 0;//< Number of modes specified
   static void set_component(Tensor3D<std::complex<double>> &tensor,
                             const mxArray *ptr, const std::string &name,
                             int n_rows, int n_cols);
 
 public:
+  /** @brief Fetch the number of modes */
   inline int num_det_modes() const { return n_det_modes; };
 
+  /*! 3-dimensional vector of fibre modes indexed by (j, i, i_m).
+   * i and j index over the x and y plane respectively.
+   * i_m indexes the different modes specified in the input file.*/
   Tensor3D<std::complex<double>> x;
+  /*! @copydoc x */
   Tensor3D<std::complex<double>> y;
 
   void initialise(const mxArray *ptr, int n_rows, int n_cols);

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -330,7 +330,18 @@ public:
   void initialise(const mxArray *ptr);
 };
 
-// TODO: docstring
+/**
+ * @brief Defines the numerical aperture of the objective, assuming that the
+ * lens is centred on the origin of the PSTD simulation.
+ *
+ * In particular, since the fibre modes are imaged onto a Fourier plane of both
+ * the physical fibre and the sample, the field scattered by the sample and
+ * collected by the objective lens can have only a finite spatial support in the
+ * aperature of the objective lens.
+ *
+ * Pupil[j][i] thus takes the value 1 for those (i,j) indices (note the order
+ * swapping) within the aperture of the lens.
+ */
 class Pupil : public Matrix<double> {
 public:
   Pupil() = default;

--- a/tdms/include/output_matrices/id_variables.h
+++ b/tdms/include/output_matrices/id_variables.h
@@ -11,15 +11,31 @@
 /**
  * @brief Class that handles the variables associated with the ID output.
  *
+ * The x and y members store the optical frequency (wavelength) dependent
+ * detector signals that have been acquired in the Fourier plane of the
+ * objective lens, corresponding to the respective components of the field.
+ * These quantities are evaluated when exdetintegral is set to 1, and are
+ * indexed by the wavenumbers and modes specified in the input file.
+ *
+ * The paper Peter R. T. Munro, "Exploiting data redundancy in computational
+ * optical imaging," Opt. Express 23, 30603-30617 (2015), explains the
+ * underlying theory and. In particular, how the coupling coefficient of a field
+ * coupled into an optical fiber can be evaluated at different planes within the
+ * optical system.
+ *
+ * Whilst a single mode optical fiber has just one mode which the field must
+ * match in order to be coupled into the fibre, this functionality allows the
+ * user to specify a multi-mode fibre, or a single-mode fiber that can be
+ * translated to different positions.
+ *
  * The ID output is a MATLAB struct that we create during runtime, so we need to
  * free the memory we reserve upon destruction, as well as link pointers to the
  * MATLAB structs to our native C++ arrays.
  */
 class IDVariables {
 private:
-  int n_frequencies = 0;//< Number of frequencies that we're extracting at. ( =
-                        // to f_ex_vec.size() )
-  int n_det_modes = 0;  //< D_tilde.num_det_modes()
+  int n_frequencies = 0;//< Number of frequencies that we're extracting at
+  int n_det_modes = 0;  //< The number of fibre modes
 
   bool memory_assigned = false;//< Flags whether MATLAB memory has been assigned
                                // and needs to be free'd
@@ -29,6 +45,10 @@ public:
   mxArray *y_ptr =
           nullptr;//< Holds the arrays in the Idy field of OutputMatrices["Id"]
 
+  /*! Indexed by (i_wavenum, i_m).
+  i_wavenum indexes the wavenumbers specified in the input file using the
+  k_vec.i_m indices in the main loop. i_m indexes the different modes specified
+  by the input detmodevec. */
   std::complex<double> **x = nullptr, **y = nullptr;
 
   // pointers to the real (re) and imaginary (im) parts of the data in the Id
@@ -51,7 +71,7 @@ public:
    * @param id_pointer Pointer to the ID output structure array
    * @param _n_frequencies The number of frequencies we are considering in this
    * simulation
-   * @param n_det_modes TODO:: DTilde.n_det_modes()
+   * @param n_det_modes Number of fibre modes specified
    */
   void link_to_pointer(mxArray *&id_pointer, int _n_frequencies,
                        int n_det_modes);


### PR DESCRIPTION
# Context/Description 
Adds docstrings to variables and classes that were currently lacking them, using the information @prmunro provided in #219.

* Fixes #219

## Testing

Only changes are docstrings, and a quick Doxygen build locally confirms the docstrings are found.
