### PR TITLE
Add CI, MATLAB tests, and doxygen build to the `merge_group`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/matlab_tests.yml
+++ b/.github/workflows/matlab_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: "main"
   pull_request:
+  merge_group:
   release:
   workflow_dispatch:
 


### PR DESCRIPTION
# Context/Description

Adding `merge_group:` to the CI checks we will want to build for a [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

* First part of #287.
