### PR TITLE
Minor tidy up, and skip the tests if no file is found.

### DIFF
--- a/tdms/cmake/targets.cmake
+++ b/tdms/cmake/targets.cmake
@@ -27,7 +27,7 @@ function(test_target)
     FetchContent_Declare(
             Catch2
             GIT_REPOSITORY ${GITHUB_PREFIX}catchorg/Catch2.git
-            GIT_TAG        v3.0.1
+            GIT_TAG        v3.3.2
     )
 
     FetchContent_MakeAvailable(Catch2)

--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -4,21 +4,32 @@
  */
 #pragma once
 
+// std
 #include <complex>
 #include <filesystem>
 #include <random>
 #include <string>
 
+// external
+#include <catch2/catch_test_macros.hpp>
+
+// tdms
 #include "globals.h"
 
 using tdms_math_constants::DCPI;
 
 namespace tdms_unit_test_data {
 
-inline std::string cant_find_test_data_message =
-        "Can't find the test data .hdf5/.mat, probably it wasn't generated "
-        "before running the unit-test suite. So skipping this test.";
-// TODO: add explaination 👆 of how to run the test data generation?
+inline std::string cant_find_test_data_message("foo");
+
+inline void skip_if_missing(const std::string &expected_data_file) {
+  if (!std::filesystem::exists(expected_data_file)) {
+    // TODO: add explaination of how to run the test data generation?
+    SKIP("Can't find the test data .hdf5/.mat, probably it wasn't generated "
+         "before running the unit-test suite. So skipping this test.");
+  }
+}
+
 
 #ifdef CMAKE_SOURCE_DIR
 inline std::string tdms_object_data(std::string(CMAKE_SOURCE_DIR) +

--- a/tdms/tests/include/unit_test_utils.h
+++ b/tdms/tests/include/unit_test_utils.h
@@ -15,6 +15,11 @@ using tdms_math_constants::DCPI;
 
 namespace tdms_unit_test_data {
 
+inline std::string cant_find_test_data_message =
+        "Can't find the test data .hdf5/.mat, probably it wasn't generated "
+        "before running the unit-test suite. So skipping this test.";
+// TODO: add explaination 👆 of how to run the test data generation?
+
 #ifdef CMAKE_SOURCE_DIR
 inline std::string tdms_object_data(std::string(CMAKE_SOURCE_DIR) +
                                     "/tests/unit/benchmark_scripts/"

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -52,11 +52,12 @@ void DTildeTest::test_incorrect_number_of_fields() {
     create_struct_array(2, dimensions_2d, 3, too_mny_names);
     REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
-  // SECTION("Struct with too few fields") {
-  // const char *too_few_names[1] = {"field1"};
-  // create_struct_array(2, dimensions_2d, 3, too_few_names);
-  // REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
-  // }
+  SECTION("Struct with too few fields") {
+    SKIP("Causes segmentation violation.");
+    const char *too_few_names[1] = {"field1"};
+    create_struct_array(2, dimensions_2d, 3, too_few_names);
+    REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
+  }
 }
 
 void DTildeTest::test_initialise_method() {

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -52,12 +52,11 @@ void DTildeTest::test_incorrect_number_of_fields() {
     create_struct_array(2, dimensions_2d, 3, too_mny_names);
     REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
-  SECTION("Struct with too few fields") {
-    SKIP("Causes segmentation violation.");
-    const char *too_few_names[1] = {"field1"};
-    create_struct_array(2, dimensions_2d, 3, too_few_names);
-    REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
-  }
+  // SECTION("Struct with too few fields") {
+  // const char *too_few_names[1] = {"field1"};
+  // create_struct_array(2, dimensions_2d, 3, too_few_names);
+  // REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
+  // }
 }
 
 void DTildeTest::test_initialise_method() {

--- a/tdms/tests/unit/array_tests/test_DTilde.cpp
+++ b/tdms/tests/unit/array_tests/test_DTilde.cpp
@@ -53,6 +53,7 @@ void DTildeTest::test_incorrect_number_of_fields() {
     REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);
   }
   SECTION("Struct with too few fields") {
+    SKIP("Causes segmentation violation.");
     const char *too_few_names[1] = {"field1"};
     create_struct_array(2, dimensions_2d, 3, too_few_names);
     REQUIRE_THROWS_AS(dt.initialise(matlab_input, 0, 0), runtime_error);

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
@@ -9,7 +9,8 @@
 
 #include "unit_test_utils.h"
 
-using tdms_unit_test_data::tdms_object_data,
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::tdms_object_data,
         tdms_unit_test_data::tdms_bad_object_data;
 
 /**
@@ -22,6 +23,8 @@ TEST_CASE("HDF5: Read Cuboid") {
   Cuboid cube;
 
   SECTION("Read into existing object") {
+    if (!std::filesystem::exists(tdms_object_data))
+      SKIP(cant_find_test_data_message);
     HDF5Reader MATFile(tdms_object_data);
     MATFile.read(&cube);
     // Check expected values, noting the -1 offset that is applied because of
@@ -33,6 +36,8 @@ TEST_CASE("HDF5: Read Cuboid") {
   }
 
   SECTION("Throw error if too many elements provided") {
+    if (!std::filesystem::exists(tdms_bad_object_data))
+      SKIP(cant_find_test_data_message);
     HDF5Reader MATFile(tdms_bad_object_data);
     // Error should be thrown due to incorrect dimensions
     REQUIRE_THROWS_AS(MATFile.read(&cube), std::runtime_error);

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
@@ -9,8 +9,7 @@
 
 #include "unit_test_utils.h"
 
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::tdms_object_data,
+using tdms_unit_test_data::tdms_object_data,
         tdms_unit_test_data::tdms_bad_object_data;
 
 /**
@@ -23,8 +22,7 @@ TEST_CASE("HDF5: Read Cuboid") {
   Cuboid cube;
 
   SECTION("Read into existing object") {
-    if (!std::filesystem::exists(tdms_object_data))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(tdms_object_data);
     HDF5Reader MATFile(tdms_object_data);
     MATFile.read(&cube);
     // Check expected values, noting the -1 offset that is applied because of
@@ -36,8 +34,7 @@ TEST_CASE("HDF5: Read Cuboid") {
   }
 
   SECTION("Throw error if too many elements provided") {
-    if (!std::filesystem::exists(tdms_bad_object_data))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(tdms_bad_object_data);
     HDF5Reader MATFile(tdms_bad_object_data);
     // Error should be thrown due to incorrect dimensions
     REQUIRE_THROWS_AS(MATFile.read(&cube), std::runtime_error);

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
@@ -9,9 +9,12 @@
 
 using Catch::Approx;
 using namespace std;
-using tdms_unit_test_data::tdms_object_data;
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::tdms_object_data;
 
 TEST_CASE("HDF5: Read DispersiveMultiLayer") {
+  if (!std::filesystem::exists(tdms_object_data))
+    SKIP(cant_find_test_data_message);
   HDF5Reader MATFile(tdms_object_data);
   // read from dispersive_aux group
   DispersiveMultiLayer dml;

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
@@ -9,12 +9,10 @@
 
 using Catch::Approx;
 using namespace std;
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::tdms_object_data;
+using tdms_unit_test_data::tdms_object_data;
 
 TEST_CASE("HDF5: Read DispersiveMultiLayer") {
-  if (!std::filesystem::exists(tdms_object_data))
-    SKIP(cant_find_test_data_message);
+  tdms_unit_test_data::skip_if_missing(tdms_object_data);
   HDF5Reader MATFile(tdms_object_data);
   // read from dispersive_aux group
   DispersiveMultiLayer dml;

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
@@ -11,8 +11,7 @@
 #include "unit_test_utils.h"
 
 using Catch::Approx;
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::tdms_object_data,
+using tdms_unit_test_data::tdms_object_data,
         tdms_unit_test_data::tdms_bad_object_data;
 
 inline int EXPECTED_VEC_SIZE = 4;
@@ -35,8 +34,7 @@ TEST_CASE("HDF5: Read FrequencyVector") {
   FrequencyVectors f_vec;
 
   SECTION("Correct data") {
-    if (!std::filesystem::exists(tdms_object_data))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(tdms_object_data);
     HDF5Reader MATFile(tdms_object_data);
 
     SECTION("Read into existing FrequencyVectors object") {
@@ -62,8 +60,7 @@ TEST_CASE("HDF5: Read FrequencyVector") {
 
   // Bad object data provides a 2D array for fx_vec component
   SECTION("Incorrect sizes") {
-    if (!std::filesystem::exists(tdms_bad_object_data))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(tdms_bad_object_data);
     HDF5Reader MATFile(tdms_bad_object_data);
     REQUIRE_THROWS_AS(MATFile.read(&f_vec), std::runtime_error);
   }

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
@@ -11,7 +11,8 @@
 #include "unit_test_utils.h"
 
 using Catch::Approx;
-using tdms_unit_test_data::tdms_object_data,
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::tdms_object_data,
         tdms_unit_test_data::tdms_bad_object_data;
 
 inline int EXPECTED_VEC_SIZE = 4;
@@ -34,6 +35,8 @@ TEST_CASE("HDF5: Read FrequencyVector") {
   FrequencyVectors f_vec;
 
   SECTION("Correct data") {
+    if (!std::filesystem::exists(tdms_object_data))
+      SKIP(cant_find_test_data_message);
     HDF5Reader MATFile(tdms_object_data);
 
     SECTION("Read into existing FrequencyVectors object") {
@@ -59,6 +62,8 @@ TEST_CASE("HDF5: Read FrequencyVector") {
 
   // Bad object data provides a 2D array for fx_vec component
   SECTION("Incorrect sizes") {
+    if (!std::filesystem::exists(tdms_bad_object_data))
+      SKIP(cant_find_test_data_message);
     HDF5Reader MATFile(tdms_bad_object_data);
     REQUIRE_THROWS_AS(MATFile.read(&f_vec), std::runtime_error);
   }

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
@@ -13,8 +13,7 @@
 #include "unit_test_utils.h"
 
 using namespace std;
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::tdms_object_data;
+using tdms_unit_test_data::tdms_object_data;
 
 /**
  * @brief Check that HDF5 can read an InterfaceComponent from a HDF5 file.
@@ -38,8 +37,7 @@ using tdms_unit_test_data::cant_find_test_data_message,
  * _match_ those we expect from the data file.
  */
 TEST_CASE("HDF5: Read InterfaceComponent") {
-  if (!std::filesystem::exists(tdms_object_data))
-    SKIP(cant_find_test_data_message);
+  tdms_unit_test_data::skip_if_missing(tdms_object_data);
   HDF5Reader MATFile(tdms_object_data);
 
   SECTION("Read into existing InterfaceComponent") {

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
@@ -13,7 +13,8 @@
 #include "unit_test_utils.h"
 
 using namespace std;
-using tdms_unit_test_data::tdms_object_data;
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::tdms_object_data;
 
 /**
  * @brief Check that HDF5 can read an InterfaceComponent from a HDF5 file.
@@ -37,6 +38,8 @@ using tdms_unit_test_data::tdms_object_data;
  * _match_ those we expect from the data file.
  */
 TEST_CASE("HDF5: Read InterfaceComponent") {
+  if (!std::filesystem::exists(tdms_object_data))
+    SKIP(cant_find_test_data_message);
   HDF5Reader MATFile(tdms_object_data);
 
   SECTION("Read into existing InterfaceComponent") {

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
@@ -13,12 +13,10 @@
 #include "unit_test_utils.h"
 
 using namespace std;
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::struct_testdata;
+using tdms_unit_test_data::struct_testdata;
 
 TEST_CASE("Fetch dimensions correctly") {
-  if (!std::filesystem::exists(struct_testdata))
-    SKIP(cant_find_test_data_message);
+  tdms_unit_test_data::skip_if_missing(struct_testdata);
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("2D array") {

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
@@ -13,9 +13,12 @@
 #include "unit_test_utils.h"
 
 using namespace std;
-using tdms_unit_test_data::struct_testdata;
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::struct_testdata;
 
 TEST_CASE("Fetch dimensions correctly") {
+  if (!std::filesystem::exists(struct_testdata))
+    SKIP(cant_find_test_data_message);
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("2D array") {

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_io.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_io.cpp
@@ -19,7 +19,8 @@
 
 using namespace std;
 using tdms_tests::create_tmp_dir;
-using tdms_unit_test_data::struct_testdata,
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::struct_testdata,
         tdms_unit_test_data::tdms_object_data;
 
 TEST_CASE("Test file I/O construction/destruction.") {
@@ -151,15 +152,22 @@ TEST_CASE("Test read/write wrt standard datatypes") {
   filesystem::remove_all(tmp);
 }
 
-TEST_CASE("Test group can be found") {
+TEST_CASE("Test groups and datasets can be found") {
   SECTION("Groups") {
+    if (!std::filesystem::exists(struct_testdata))
+      SKIP(cant_find_test_data_message);
+    // TODO: make this a bit nicer and include instructions for how to create
+    // the testdata files (run this python script etc)
     HDF5Reader reader(struct_testdata);
     REQUIRE(!reader.contains("group_doesnt_exist"));
     REQUIRE(reader.contains("example_struct"));
   }
   SECTION("DataSets") {
+    if (!std::filesystem::exists(tdms_object_data))
+      SKIP(cant_find_test_data_message);
+    //"Test data file not created before running these unit tests.");
     HDF5Reader reader(tdms_object_data);
+    REQUIRE(!reader.contains("dataset_doesnt_exist"));
     REQUIRE(reader.contains("phasorsurface"));
-    REQUIRE(!reader.contains("flibble"));
   }
 }

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_io.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_io.cpp
@@ -154,18 +154,13 @@ TEST_CASE("Test read/write wrt standard datatypes") {
 
 TEST_CASE("Test groups and datasets can be found") {
   SECTION("Groups") {
-    if (!std::filesystem::exists(struct_testdata))
-      SKIP(cant_find_test_data_message);
-    // TODO: make this a bit nicer and include instructions for how to create
-    // the testdata files (run this python script etc)
+    tdms_unit_test_data::skip_if_missing(struct_testdata);
     HDF5Reader reader(struct_testdata);
     REQUIRE(!reader.contains("group_doesnt_exist"));
     REQUIRE(reader.contains("example_struct"));
   }
   SECTION("DataSets") {
-    if (!std::filesystem::exists(tdms_object_data))
-      SKIP(cant_find_test_data_message);
-    //"Test data file not created before running these unit tests.");
+    tdms_unit_test_data::skip_if_missing(tdms_object_data);
     HDF5Reader reader(tdms_object_data);
     REQUIRE(!reader.contains("dataset_doesnt_exist"));
     REQUIRE(reader.contains("phasorsurface"));

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
@@ -19,9 +19,13 @@
 
 using namespace std;
 using tdms_tests::uint16s_to_string;
-using tdms_unit_test_data::struct_testdata, tdms_unit_test_data::hdf5_test_file;
+using tdms_unit_test_data::cant_find_test_data_message,
+        tdms_unit_test_data::struct_testdata,
+        tdms_unit_test_data::hdf5_test_file;
 
 TEST_CASE("HDF5: Read from a MATLAB struct") {
+  if (!std::filesystem::exists(struct_testdata))
+    SKIP(cant_find_test_data_message);
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("Read numeric scalars") {
@@ -84,6 +88,8 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
   bool entries_read_correctly = true;
 
   SECTION(".mat files") {
+    if (!std::filesystem::exists(struct_testdata))
+      SKIP(cant_find_test_data_message);
     HDF5Reader Hfile(struct_testdata);
 
     SECTION("Vector [int32]") {
@@ -106,6 +112,8 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
   }
 
   SECTION(".hdf5 files") {
+    if (!std::filesystem::exists(hdf5_test_file))
+      SKIP(cant_find_test_data_message);
     HDF5Reader Hfile(hdf5_test_file);
 
     // h5py saves int dtype at 64-bit integers

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
@@ -19,13 +19,10 @@
 
 using namespace std;
 using tdms_tests::uint16s_to_string;
-using tdms_unit_test_data::cant_find_test_data_message,
-        tdms_unit_test_data::struct_testdata,
-        tdms_unit_test_data::hdf5_test_file;
+using tdms_unit_test_data::struct_testdata, tdms_unit_test_data::hdf5_test_file;
 
 TEST_CASE("HDF5: Read from a MATLAB struct") {
-  if (!std::filesystem::exists(struct_testdata))
-    SKIP(cant_find_test_data_message);
+  tdms_unit_test_data::skip_if_missing(struct_testdata);
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("Read numeric scalars") {
@@ -88,8 +85,7 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
   bool entries_read_correctly = true;
 
   SECTION(".mat files") {
-    if (!std::filesystem::exists(struct_testdata))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(struct_testdata);
     HDF5Reader Hfile(struct_testdata);
 
     SECTION("Vector [int32]") {
@@ -112,8 +108,7 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
   }
 
   SECTION(".hdf5 files") {
-    if (!std::filesystem::exists(hdf5_test_file))
-      SKIP(cant_find_test_data_message);
+    tdms_unit_test_data::skip_if_missing(hdf5_test_file);
     HDF5Reader Hfile(hdf5_test_file);
 
     // h5py saves int dtype at 64-bit integers

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_writer.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_writer.cpp
@@ -20,7 +20,6 @@
 using Catch::Approx;
 using namespace std;
 using tdms_tests::create_tmp_dir;
-using tdms_unit_test_data::struct_testdata, tdms_unit_test_data::hdf5_test_file;
 
 TEST_CASE("HDF5Writer: Write doubles to a group.") {
 
@@ -35,27 +34,21 @@ TEST_CASE("HDF5Writer: Write doubles to a group.") {
 
   {
     HDF5Writer writer(file_name);
-
     {
       vector<double> write_me_out = {.0, .1, .2, .3, .4, .5, .6, .7, .8, .9};
-
       writer.write_dataset_to_group(group_name, double_dataset, write_me_out);
     }
     {
       vector<int> write_me_out = {0, 1, 2, 3, 4, 5};
-
       writer.write_dataset_to_group(group_name, int_dataset, write_me_out);
     }
-
     REQUIRE(writer.contains(group_name));
   }
 
   // Read data back to confirm entries are as expected
   {
     HDF5Reader reader(file_name);
-
     REQUIRE(reader.contains(group_name));
-
     {
       vector<double> read_back_in;
       reader.read_dataset_in_group(group_name, double_dataset, read_back_in);


### PR DESCRIPTION
# Context/Description

Possibly overkill but in the interest of small PRs (cough cough). Here is a tweak to your small data sample unit tests which skips them if the data not found. This is a PR against our draft branch from Friday (so you know what I'm proposing).

Still TODO: decide whether to provide instructions to generate them here in the logging. What do you think?

* Relates to #181 
* Targets #294
    * Not `main`:
      🐢
      🐢
      🐢

## Testing

Checked locally with

```
➤ mv ../tdms/tests/unit/benchmark_scripts/unit_test_data ../tdms/tests/unit/benchmark_scripts/_unit_test_data
➤ ./tdms_tests

< ... blah blah ...>

===============================================================================
test cases:  51 |  43 passed | 8 skipped
assertions: 904 | 904 passed

➤ mv ../tdms/tests/unit/benchmark_scripts/_unit_test_data ../tdms/tests/unit/benchmark_scripts/unit_test_data
➤ ./tdms_tests

< ... blah blah ...>

===============================================================================
All tests passed (944 assertions in 51 test cases)
```
