### PR TITLE
Detach the `EHVec` class from `Matrix`

### DIFF
--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -524,14 +524,6 @@ public:
 class CCoefficientMatrix : public Matrix<double> {};
 
 /**
- * Temporary storage 'vector'
- */
-class EHVec : public Matrix<fftw_complex> {
-public:
-  ~EHVec();
-};
-
-/**
  * Container for storing snapshots of the full-field
  */
 class FullFieldSnapshot {

--- a/tdms/include/arrays/eh_vec.h
+++ b/tdms/include/arrays/eh_vec.h
@@ -11,37 +11,14 @@ protected:
 
   fftw_complex **data_ = nullptr;
 
-  void free_memory() {
-    spdlog::info("Freeing memory");
-    if (is_allocated()) {
-      for (int i = 0; i < n_rows_; i++) { std::free(data_[i]); }
-    }
-    std::free(data_);
-    data_ = nullptr;
-    spdlog::info("Free'd");
-  }
+  void free_memory();
 
 public:
   EHVec() = default;
 
   fftw_complex *operator[](int col_index) { return data_[col_index]; }
 
-  void allocate(int n_rows, int n_cols) {
-    // If already allocated we need to clean up old memory before resizing!
-    if (is_allocated()) {
-      spdlog::warn("EHVec is already assigned - freeing old memory before "
-                   "reallocating!");
-      free_memory();
-    }
-
-    n_rows_ = n_rows;
-    n_cols_ = n_cols;
-
-    data_ = (fftw_complex **) malloc(n_rows_ * sizeof(fftw_complex *));
-    for (int i = 0; i < n_cols_; i++) {
-      data_[i] = (fftw_complex *) malloc(n_cols_ * sizeof(fftw_complex));
-    }
-  }
+  void allocate(int n_rows, int n_cols);
 
   bool is_allocated() const { return data_ != nullptr; }
 

--- a/tdms/include/arrays/eh_vec.h
+++ b/tdms/include/arrays/eh_vec.h
@@ -1,9 +1,19 @@
+/**
+ * @file eh_vec.h
+ * @author William Graham (william.graham@ucl.ac.uk)
+ * @brief Declaration for the storage class used when performing Fourier
+ * transforms via fftw
+ */
 #pragma once
 
 #include <fftw3.h>
-#include <spdlog/spdlog.h>
 
-// EHVec[n_cols][n_rows]
+/**
+ * @brief Storage class for Fourier transform values, obtained when performing
+ * the pseudo-spectral timestep.
+ * @details Storage is organised as a 2D buffer of fftw_complex types, of size
+ * n_rows_ by n_cols. Elements can be accessed via the [] operator.
+ */
 class EHVec {
 protected:
   int n_rows_ = 0;
@@ -11,6 +21,7 @@ protected:
 
   fftw_complex **data_ = nullptr;
 
+  /** @brief Free the memory assigned to this instance */
   void free_memory();
 
 public:
@@ -18,8 +29,18 @@ public:
 
   fftw_complex *operator[](int col_index) { return data_[col_index]; }
 
+  /**
+   * @brief Allocate storage for this instance. Existing storage will be lost
+   * (if present).
+   * @details Reallocation of an already-allocated EHVec frees the current
+   * buffer before reassigning the new buffer. Any values stored in the old
+   * buffer are lost, EVEN IF THE NEW BUFFER IS OF GREATER SIZE THAN THE OLD
+   * BUFFER.
+   * @param n_rows,n_cols Shape of storage to allocate.
+   */
   void allocate(int n_rows, int n_cols);
 
+  /** @brief Determine whether the instance has memory allocated. */
   bool is_allocated() const { return data_ != nullptr; }
 
   ~EHVec() { free_memory(); }

--- a/tdms/include/arrays/eh_vec.h
+++ b/tdms/include/arrays/eh_vec.h
@@ -11,13 +11,14 @@ protected:
 
   fftw_complex **data_ = nullptr;
 
-  bool is_allocated() const { return data_ != nullptr; }
-
   void free_memory() {
+    spdlog::info("Freeing memory");
     if (is_allocated()) {
       for (int i = 0; i < n_rows_; i++) { std::free(data_[i]); }
     }
     std::free(data_);
+    data_ = nullptr;
+    spdlog::info("Free'd");
   }
 
 public:
@@ -41,6 +42,8 @@ public:
       data_[i] = (fftw_complex *) malloc(n_cols_ * sizeof(fftw_complex));
     }
   }
+
+  bool is_allocated() const { return data_ != nullptr; }
 
   ~EHVec() { free_memory(); }
 };

--- a/tdms/include/arrays/eh_vec.h
+++ b/tdms/include/arrays/eh_vec.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <fftw3.h>
+#include <spdlog/spdlog.h>
+
+// EHVec[n_cols][n_rows]
+class EHVec {
+protected:
+  int n_rows_ = 0;
+  int n_cols_ = 0;
+
+  fftw_complex **data_ = nullptr;
+
+  bool is_allocated() const { return data_ != nullptr; }
+
+  void free_memory() {
+    if (is_allocated()) {
+      for (int i = 0; i < n_rows_; i++) { std::free(data_[i]); }
+    }
+    std::free(data_);
+  }
+
+public:
+  EHVec() = default;
+
+  fftw_complex *operator[](int col_index) { return data_[col_index]; }
+
+  void allocate(int n_rows, int n_cols) {
+    // If already allocated we need to clean up old memory before resizing!
+    if (is_allocated()) {
+      spdlog::warn("EHVec is already assigned - freeing old memory before "
+                   "reallocating!");
+      free_memory();
+    }
+
+    n_rows_ = n_rows;
+    n_cols_ = n_cols;
+
+    data_ = (fftw_complex **) malloc(n_rows_ * sizeof(fftw_complex *));
+    for (int i = 0; i < n_cols_; i++) {
+      data_[i] = (fftw_complex *) malloc(n_cols_ * sizeof(fftw_complex));
+    }
+  }
+
+  ~EHVec() { free_memory(); }
+};

--- a/tdms/include/field.h
+++ b/tdms/include/field.h
@@ -7,6 +7,7 @@
 #include <complex>
 
 #include "arrays.h"
+#include "arrays/eh_vec.h"
 #include "cell_coordinate.h"
 #include "dimensions.h"
 #include "input_flags.h"

--- a/tdms/include/simulation_manager/simulation_manager.h
+++ b/tdms/include/simulation_manager/simulation_manager.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "arrays.h"
+#include "arrays/eh_vec.h"
 #include "cell_coordinate.h"
 #include "globals.h"
 #include "input_flags.h"

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -376,11 +376,3 @@ DetectorSensitivityArrays::~DetectorSensitivityArrays() {
   fftw_free(v);
   fftw_destroy_plan(plan);
 }
-
-EHVec::~EHVec() {
-  if (has_elements()) {
-    for (int i = 0; i < n_rows; i++) fftw_free(matrix[i]);
-    free(matrix);
-  }
-  matrix = nullptr;
-}

--- a/tdms/src/arrays/eh_vec.cpp
+++ b/tdms/src/arrays/eh_vec.cpp
@@ -1,0 +1,28 @@
+#include "arrays/eh_vec.h"
+
+#include <spdlog/spdlog.h>
+
+void EHVec::free_memory() {
+  if (is_allocated()) {
+    for (int i = 0; i < n_rows_; i++) { fftw_free(data_[i]); }
+    free(data_);
+  }
+  data_ = nullptr;
+}
+
+void EHVec::allocate(int n_rows, int n_cols) {
+  // If already allocated we need to clean up old memory before resizing!
+  if (is_allocated()) {
+    spdlog::warn("EHVec is already assigned - freeing old memory before "
+                 "reallocating!");
+    free_memory();
+  }
+
+  n_rows_ = n_rows;
+  n_cols_ = n_cols;
+
+  data_ = (fftw_complex **) malloc(n_rows_ * sizeof(fftw_complex *));
+  for (int i = 0; i < n_rows_; i++) {
+    data_[i] = (fftw_complex *) malloc(n_cols_ * sizeof(fftw_complex));
+  }
+}

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -199,18 +199,6 @@ public:
   std::string get_class_name() override { return "Pupil"; }
 };
 
-/** @brief Unit tests for EHVec */
-class EHVecTest : public AbstractArrayTest {
-private:
-  const int n_rows = 4, n_cols = 8;
-
-  // allocate() needs testing
-  void test_other_methods() override;
-
-public:
-  std::string get_class_name() override { return "EHVec"; }
-};
-
 /** @brief Unit tests for Tensor3D */
 class Tensor3DTest : public AbstractArrayTest {
 private:

--- a/tdms/tests/unit/array_tests/test_EHVec.cpp
+++ b/tdms/tests/unit/array_tests/test_EHVec.cpp
@@ -1,0 +1,34 @@
+#include <catch2/catch_test_macros.hpp>
+#include <spdlog/spdlog.h>
+
+#include "arrays/eh_vec.h"
+#include "unit_test_utils.h"
+
+using tdms_tests::is_close;
+
+TEST_CASE("EHVec") {
+  const int REAL = 0, IMAG = 1;
+  const int n_rows = 4, n_cols = 8;
+  EHVec eh;
+
+  // allocate memory
+  REQUIRE(!eh.is_allocated());
+  eh.allocate(n_rows, n_cols);
+  REQUIRE(eh.is_allocated());
+  spdlog::info("Completed assignment");
+
+  // check that we an assign fftw_complexes to the elements
+  eh[0][0][REAL] = 1.;
+  eh[0][0][IMAG] = 0.;
+  eh[0][1][REAL] = 0.;
+  eh[0][1][IMAG] = 1.;
+  fftw_complex fftw_unit{1., 0.};
+  fftw_complex fftw_imag_unit{0., 1.};
+
+  bool elements_set_correctly =
+          is_close(eh[0][0][REAL], fftw_unit[REAL]) &&
+          is_close(eh[0][0][IMAG], fftw_unit[IMAG]) &&
+          is_close(eh[0][1][REAL], fftw_imag_unit[REAL]) &&
+          is_close(eh[0][1][IMAG], fftw_imag_unit[IMAG]);
+  REQUIRE(elements_set_correctly);
+}

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -9,6 +9,7 @@
 
 #include "array_test_class.h"
 #include "arrays.h"
+#include "arrays/eh_vec.h"
 #include "unit_test_utils.h"
 
 using tdms_tests::is_close;
@@ -167,8 +168,9 @@ void EHVecTest::test_other_methods() {
   EHVec eh;
 
   // allocate memory
+  REQUIRE(!eh.is_allocated());
   eh.allocate(n_rows, n_cols);
-  REQUIRE(eh.has_elements());
+  REQUIRE(eh.is_allocated());
 
   // check that we an assign fftw_complexes to the elements
   eh[0][0][REAL] = 1.;

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -2,17 +2,13 @@
  * @file test_Matrix.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
  * @brief Tests for the Matrix class and its subclasses (Vertices,
- * GratingStructure, Pupil, EHVec)
+ * GratingStructure, Pupil)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
 #include "array_test_class.h"
 #include "arrays.h"
-#include "arrays/eh_vec.h"
-#include "unit_test_utils.h"
-
-using tdms_tests::is_close;
 
 void MatrixTest::test_correct_construction() {
   // create a Matrix via the default constructor
@@ -163,31 +159,6 @@ void PupilTest::test_correct_construction() {
   }
 }
 
-void EHVecTest::test_other_methods() {
-  const int REAL = 0, IMAG = 1;
-  EHVec eh;
-
-  // allocate memory
-  REQUIRE(!eh.is_allocated());
-  eh.allocate(n_rows, n_cols);
-  REQUIRE(eh.is_allocated());
-
-  // check that we an assign fftw_complexes to the elements
-  eh[0][0][REAL] = 1.;
-  eh[0][0][IMAG] = 0.;
-  eh[0][1][REAL] = 0.;
-  eh[0][1][IMAG] = 1.;
-  fftw_complex fftw_unit{1., 0.};
-  fftw_complex fftw_imag_unit{0., 1.};
-
-  bool elements_set_correctly =
-          is_close(eh[0][0][REAL], fftw_unit[REAL]) &&
-          is_close(eh[0][0][IMAG], fftw_unit[IMAG]) &&
-          is_close(eh[0][1][REAL], fftw_imag_unit[REAL]) &&
-          is_close(eh[0][1][IMAG], fftw_imag_unit[IMAG]);
-  REQUIRE(elements_set_correctly);
-}
-
 TEST_CASE("Matrix") { MatrixTest().run_all_class_tests(); }
 
 TEST_CASE("Vertices") { VerticesTest().run_all_class_tests(); }
@@ -195,5 +166,3 @@ TEST_CASE("Vertices") { VerticesTest().run_all_class_tests(); }
 TEST_CASE("GratingStructure") { GratingStructureTest().run_all_class_tests(); }
 
 TEST_CASE("Pupil") { PupilTest().run_all_class_tests(); }
-
-TEST_CASE("EHVec") { EHVecTest().run_all_class_tests(); }


### PR DESCRIPTION
# Description 

The `EHVec` class is currently a public `Matrix<fftw_complex>`. It is desirable to convert `Matrix<>` to used strided vector storage and remove any MATLAB dependencies.

The former doesn't work for `EHVec` since the `fftw_complex` type is a double[2], which throws an error when used in templated `std::vector<T>` functions. Additionally, `EHVec` is used in such a way that `fftw` needs a continuous buffer to perform the forward/backward transform, which a strided vector does not guarantee.

As such, it is necessary to provide `EHVec` with it's own (MATLAB-free) class. This enables `Matrix` and its other derivatives to be freed of MATLAB influence.

* Concerns #285, resolves the `EHVec` task.
* Depends on #324, targets the expected state of `main`.

## Testing

- Existing unit tests for `EHVec` continue to pass after the refactor. 
- Removed the `EHVecTest` class since it is no longer a member of the `arrays.h` file, and it only had a single unit test in the first place (so a class was overkill).
