### PR TITLE
Turn off coverage reporting in MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           lcov --list coverage.info
 
       - name: Upload coverage reports to Codecov
-        if: matrix.build_testing == 'ON' && ${{ contains(matrix.os, 'ubuntu') }}
+        if: matrix.build_testing == 'ON' && contains(matrix.os, 'ubuntu')
         uses: codecov/codecov-action@v3
 
       - name: Tar the build result to maintain permissions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           lcov --list coverage.info
 
       - name: Upload coverage reports to Codecov
-        if: matrix.build_testing == 'ON'
+        if: matrix.build_testing == 'ON' && ${{ contains(matrix.os, 'ubuntu') }}
         uses: codecov/codecov-action@v3
 
       - name: Tar the build result to maintain permissions


### PR DESCRIPTION
Something is strange about the coverage reported by MacOS builds. Perhaps `llvm-cov`? Turning off whilst we investigate.

Relates to #279 and "solves" it by ignoring the problem.

Should improve the developers' quality of life. And will stop giving @codecovbot inconsistent reports.