### PR TITLE
Convert `Matrix` to a strided vector

### DIFF
--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -327,27 +327,6 @@ struct FrequencyVectors {
 };
 
 /**
- * @brief Defines the numerical aperture of the objective, assuming that the
- * lens is centred on the origin of the PSTD simulation.
- *
- * In particular, since the fibre modes are imaged onto a Fourier plane of both
- * the physical fibre and the sample, the field scattered by the sample and
- * collected by the objective lens can have only a finite spatial support in the
- * aperature of the objective lens.
- *
- * Pupil[j][i] thus takes the value 1 for those (i,j) indices (note the order
- * swapping) within the aperture of the lens.
- */
-class Pupil : public Matrix<double> {
-public:
-  Pupil() = default;
-
-  void initialise(const mxArray *ptr, int n_rows, int n_cols);
-
-  ~Pupil();
-};
-
-/**
  * List of field components as integers
  */
 class FieldComponentsVector : public Vector<int> {

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -230,67 +230,6 @@ public:
 };
 
 template<typename T>
-class Matrix {
-protected:
-  int n_rows = 0;
-  int n_cols = 0;
-  T **matrix = nullptr;
-
-public:
-  /**
-   * @brief Construct a new Matrix object, without assigned elements
-   *
-   */
-  Matrix() = default;
-  /**
-   * @brief Construct a new Matrix object, providing the dimensions
-   *
-   * @param n_rows,n_cols Number of rows and columns in the matrix
-   * @param initial_value The initial value of the elements, defaults to 0 to
-   * avoid initalised but unassigned values
-   */
-  Matrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
-
-  inline T *operator[](int value) const { return matrix[value]; }
-  /**
-   * @brief Check whether this matrix has elements assigned
-   *
-   * @return true If this matrix has assigned elements
-   * @return false This matrix is currently unassigned
-   */
-  bool has_elements() { return matrix != nullptr; };
-
-  /**
-   * Allocate the memory for this matrix
-   *
-   * @param n_rows Number of rows
-   * @param n_cols Number of columns
-   */
-  void allocate(int n_rows, int n_cols, T initial_value = 0) {
-    this->n_rows = n_rows;
-    this->n_cols = n_cols;
-
-    matrix = (T **) malloc(sizeof(T *) * n_rows);
-    for (int i = 0; i < n_rows; i++) {
-      matrix[i] = (T *) malloc(sizeof(T) * n_cols);
-    }
-  };
-
-  int get_n_cols() const { return n_cols; }
-  int get_n_rows() const { return n_rows; }
-
-  /**
-   * Destructor. Must be defined in the header
-   */
-  ~Matrix() {
-    if (has_elements()) {
-      for (int i = 0; i < n_rows; i++) { free(matrix[i]); }
-      free(matrix);
-    }
-  };
-};
-
-template<typename T>
 class Vector {
 protected:
   int n = 0;          // Number of elements

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -290,14 +290,6 @@ public:
   };
 };
 
-class GratingStructure : public Matrix<int> {
-
-public:
-  GratingStructure(const mxArray *ptr, int I_tot);
-
-  ~GratingStructure();
-};
-
 template<typename T>
 class Vector {
 protected:

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -399,11 +399,6 @@ public:
 };
 
 /**
- * Matrix of c coefficients. See the pdf documentation for their definition
- */
-class CCoefficientMatrix : public Matrix<double> {};
-
-/**
  * Container for storing snapshots of the full-field
  */
 class FullFieldSnapshot {

--- a/tdms/include/arrays.h
+++ b/tdms/include/arrays.h
@@ -344,20 +344,6 @@ public:
   int index(int value);
 };
 
-class Vertices : public Matrix<int> {
-public:
-  Vertices() = default;
-
-  void initialise(const mxArray *ptr);
-
-  int n_vertices() { return n_rows; }
-
-  ~Vertices() {
-    if (has_elements()) { free_cast_matlab_2D_array(matrix); }
-    matrix = nullptr;
-  };
-};
-
 class DetectorSensitivityArrays {
 public:
   fftw_complex *v = nullptr;          // Flat fftw vector

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -32,6 +32,7 @@ public:
 
   void initialise(T **buffer, int n_rows, int n_cols,
                   bool buffer_leads_n_cols = false) {
+    allocate(n_rows, n_cols);
     if (buffer_leads_n_cols) {
       for (int i = 0; i < n_rows; i++) {
         for (int j = 0; j < n_cols; j++) { operator()(i, j) = buffer[j][i]; }
@@ -48,9 +49,9 @@ public:
 
 class CCoefficientMatrix : public TDMSMatrix<double> {};
 
-// class GratingStructure : public Matrix<int> {
-//   GratingStructure(const mxArray *ptr, int I_tot);
-// };
+struct GratingStructure : public TDMSMatrix<int> {
+  GratingStructure(const mxArray *ptr, int I_tot);
+};
 
 // class Pupil : public Matrix<double> {
 // public:

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -13,8 +13,8 @@
  *
  * this->(i, j) = data_[i * n_cols_ + j].
  *
- * This is consistent with the way hdf5 files store array-like data, see
- * https://support.hdfgroup.org/HDF5/doc1.6/UG/12_Dataspaces.html.
+ * @seealso This is consistent with the way hdf5 files store array-like data, see
+ *          https://support.hdfgroup.org/HDF5/doc1.6/UG/12_Dataspaces.html.
  * @tparam T Numerical datatype
  */
 template<typename T>
@@ -91,11 +91,11 @@ typedef Matrix<double> CCoefficientMatrix;
 
 /**
  * @brief Defines the numerical aperture of the objective, assuming that the
- * lens is centred on the origin of the PSTD simulation.
+ *        lens is centred on the origin of the PSTD simulation.
  * @details In particular, since the fibre modes are imaged onto a Fourier plane
- * of both the physical fibre and the sample, the field scattered by the sample
- * and collected by the objective lens can have only a finite spatial support in
- * the aperture of the objective lens.
+ *         of both the physical fibre and the sample, the field scattered by the sample
+ *         and collected by the objective lens can have only a finite spatial support in
+ *         the aperture of the objective lens.
  *
  * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
  * aperture of the lens.

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "cell_coordinate.h"
 #include "matlabio.h"
 #include "matrix.h"
 
@@ -19,9 +20,8 @@ public:
   TDMSMatrix() = default;
   TDMSMatrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
 
-  T &operator()(int row, int col) {
-    return data_[row * n_cols_ + col];
-  }// TODO: convert old syntax :(
+  T &operator()(int row, int col) { return data_[row * n_cols_ + col]; }
+  T operator()(int row, int col) const { return data_[row * n_cols_ + col]; }
 
   void allocate(int n_rows, int n_cols) {
     n_rows_ = n_rows;
@@ -69,16 +69,11 @@ struct Pupil : public TDMSMatrix<double> {
   void initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols);
 };
 
-// class Vertices : public Matrix<int> {
-// public:
-//   Vertices() = default;
+struct Vertices : public TDMSMatrix<int> {
+  Vertices() = default;
 
-//   void initialise(const mxArray *ptr);
+  void initialise_from_matlab(const mxArray *ptr);
 
-//   int n_vertices() { return n_rows_; }
-
-//   ~Vertices() {
-//     if (has_elements()) { free_cast_matlab_2D_array(matrix); }
-//     matrix = nullptr;
-//   };
-// };
+  int n_vertices() { return n_rows_; }
+  ijk index_in_row(int row) const;
+};

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -6,30 +6,61 @@
 #include "matlabio.h"
 #include "matrix.h"
 
+/**
+ * @brief Template class for storing two dimensional data as a strided vector.
+ * @details Two dimensional data is stored as a strided vector, in row-major (C)
+ * format. The column dimension has the fastest-varying index, so
+ *
+ * this->(i, j) = data_[i * n_cols_ + j].
+ *
+ * This is consistent with the way hdf5 files store array-like data, see
+ * https://support.hdfgroup.org/HDF5/doc1.6/UG/12_Dataspaces.html.
+ * @tparam T Numerical datatype
+ */
 template<typename T>
 class TDMSMatrix {
 protected:
   int n_rows_ = 0;
   int n_cols_ = 0;
 
+  /*! Strided vector that will store the array data */
   std::vector<T> data_;
 
+  /*! The total number of elements, according to the dimension values currently
+   * set. */
   int n_elements() const { return n_rows_ * n_cols_; }
 
 public:
   TDMSMatrix() = default;
   TDMSMatrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
 
+  /** @brief Subscript operator for the Matrix, retrieving the (i,j)-th element
+   */
   T &operator()(int row, int col) { return data_[row * n_cols_ + col]; }
+  /** @copydoc operator() */
   T operator()(int row, int col) const { return data_[row * n_cols_ + col]; }
 
+  /**
+   * @brief Allocate memory for this Matrix given the dimensions passed.
+   *
+   * @param n_rows,n_cols Number of rows and columns to assign.
+   */
   void allocate(int n_rows, int n_cols) {
     n_rows_ = n_rows;
     n_cols_ = n_cols;
-
     data_.resize(n_elements());
   }
 
+  /**
+   * @brief Initialise this Matrix from a 2D-buffer of matching size.
+   * @details Data values are copied so that membership over this->data_ is
+   * preserved.
+   * @param buffer 2D buffer to read from
+   * @param n_rows,n_cols "Shape" of the read buffer to assign to this Matrix
+   * @param buffer_leads_n_cols If true, the buffer to read from is assumed to
+   * have dimensions [n_cols][n_rows]. If false, it is assumed to have
+   * dimensions [n_rows][n_cols].
+   */
   void initialise(T **buffer, int n_rows, int n_cols,
                   bool buffer_leads_n_cols = false) {
     allocate(n_rows, n_cols);
@@ -44,11 +75,15 @@ public:
     }
   }
 
+  /** @brief Whether this Matrix contains any elements */
   bool has_elements() const { return n_elements() != 0; }
 };
 
+/** @brief Matrix of C-coefficients. See the pdf documentation for their
+ * definition. */
 class CCoefficientMatrix : public TDMSMatrix<double> {};
 
+/** TODO: Docstring */
 struct GratingStructure : public TDMSMatrix<int> {
   GratingStructure(const mxArray *ptr, int I_tot);
 };
@@ -56,11 +91,10 @@ struct GratingStructure : public TDMSMatrix<int> {
 /**
  * @brief Defines the numerical aperture of the objective, assuming that the
  * lens is centred on the origin of the PSTD simulation.
- *
- * In particular, since the fibre modes are imaged onto a Fourier plane of both
- * the physical fibre and the sample, the field scattered by the sample and
- * collected by the objective lens can have only a finite spatial support in the
- * aperture of the objective lens.
+ * @details In particular, since the fibre modes are imaged onto a Fourier plane
+ * of both the physical fibre and the sample, the field scattered by the sample
+ * and collected by the objective lens can have only a finite spatial support in
+ * the aperture of the objective lens.
  *
  * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
  * aperture of the lens.
@@ -69,11 +103,19 @@ struct Pupil : public TDMSMatrix<double> {
   void initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols);
 };
 
+/**
+ * @brief n_vertices-by-3 storage used for holding Yee cell indices.
+ * @details Each row of a Vertices instance consists of three integers (i, j, k)
+ * that form the index of a particular Yee cell in the simulation space.
+ */
 struct Vertices : public TDMSMatrix<int> {
   Vertices() = default;
 
   void initialise_from_matlab(const mxArray *ptr);
 
   int n_vertices() { return n_rows_; }
+
+  /** @brief Convert the (i,j,k) index stored across the columns of row to an
+   * ijk struct. */
   ijk index_in_row(int row) const;
 };

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -53,14 +53,21 @@ struct GratingStructure : public TDMSMatrix<int> {
   GratingStructure(const mxArray *ptr, int I_tot);
 };
 
-// class Pupil : public Matrix<double> {
-// public:
-//   Pupil() = default;
-
-//   void initialise(const mxArray *ptr, int n_rows, int n_cols);
-
-//   ~Pupil();
-// };
+/**
+ * @brief Defines the numerical aperture of the objective, assuming that the
+ * lens is centred on the origin of the PSTD simulation.
+ *
+ * In particular, since the fibre modes are imaged onto a Fourier plane of both
+ * the physical fibre and the sample, the field scattered by the sample and
+ * collected by the objective lens can have only a finite spatial support in the
+ * aperture of the objective lens.
+ *
+ * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
+ * aperture of the lens.
+ */
+struct Pupil : public TDMSMatrix<double> {
+  void initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols);
+};
 
 // class Vertices : public Matrix<int> {
 // public:

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -18,7 +18,7 @@
  * @tparam T Numerical datatype
  */
 template<typename T>
-class TDMSMatrix {
+class Matrix {
 protected:
   int n_rows_ = 0;
   int n_cols_ = 0;
@@ -31,8 +31,11 @@ protected:
   int n_elements() const { return n_rows_ * n_cols_; }
 
 public:
-  TDMSMatrix() = default;
-  TDMSMatrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
+  Matrix() = default;
+  Matrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
+
+  int get_n_rows() const { return n_rows_; }
+  int get_n_cols() const { return n_cols_; }
 
   /** @brief Subscript operator for the Matrix, retrieving the (i,j)-th element
    */
@@ -81,10 +84,10 @@ public:
 
 /** @brief Matrix of C-coefficients. See the pdf documentation for their
  * definition. */
-class CCoefficientMatrix : public TDMSMatrix<double> {};
+typedef Matrix<double> CCoefficientMatrix;
 
 /** TODO: Docstring */
-struct GratingStructure : public TDMSMatrix<int> {
+struct GratingStructure : public Matrix<int> {
   GratingStructure(const mxArray *ptr, int I_tot);
 };
 
@@ -99,7 +102,7 @@ struct GratingStructure : public TDMSMatrix<int> {
  * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
  * aperture of the lens.
  */
-struct Pupil : public TDMSMatrix<double> {
+struct Pupil : public Matrix<double> {
   void initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols);
 };
 
@@ -108,7 +111,7 @@ struct Pupil : public TDMSMatrix<double> {
  * @details Each row of a Vertices instance consists of three integers (i, j, k)
  * that form the index of a particular Yee cell in the simulation space.
  */
-struct Vertices : public TDMSMatrix<int> {
+struct Vertices : public Matrix<int> {
   Vertices() = default;
 
   void initialise_from_matlab(const mxArray *ptr);

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <vector>
+
+#include "matlabio.h"
+#include "matrix.h"
+
+template<typename T>
+class TDMSMatrix {
+protected:
+  int n_rows_ = 0;
+  int n_cols_ = 0;
+
+  std::vector<T> data_;
+
+  int n_elements() const { return n_rows_ * n_cols_; }
+
+public:
+  TDMSMatrix() = default;
+  TDMSMatrix(int n_rows, int n_cols) { allocate(n_rows, n_cols); }
+
+  T &operator()(int row, int col) {
+    return data_[row * n_cols_ + col];
+  }// TODO: convert old syntax :(
+
+  void allocate(int n_rows, int n_cols) {
+    n_rows_ = n_rows;
+    n_cols_ = n_cols;
+
+    data_.resize(n_elements());
+  }
+
+  void initialise(T **buffer, int n_rows, int n_cols,
+                  bool buffer_leads_n_cols = false) {
+    if (buffer_leads_n_cols) {
+      for (int i = 0; i < n_rows; i++) {
+        for (int j = 0; j < n_cols; j++) { operator()(i, j) = buffer[j][i]; }
+      }
+    } else {
+      for (int i = 0; i < n_rows; i++) {
+        for (int j = 0; j < n_cols; j++) { operator()(i, j) = buffer[i][j]; }
+      }
+    }
+  }
+
+  bool has_elements() const { return n_elements() != 0; }
+};
+
+class CCoefficientMatrix : public TDMSMatrix<double> {};
+
+// class GratingStructure : public Matrix<int> {
+//   GratingStructure(const mxArray *ptr, int I_tot);
+// };
+
+// class Pupil : public Matrix<double> {
+// public:
+//   Pupil() = default;
+
+//   void initialise(const mxArray *ptr, int n_rows, int n_cols);
+
+//   ~Pupil();
+// };
+
+// class Vertices : public Matrix<int> {
+// public:
+//   Vertices() = default;
+
+//   void initialise(const mxArray *ptr);
+
+//   int n_vertices() { return n_rows_; }
+
+//   ~Vertices() {
+//     if (has_elements()) { free_cast_matlab_2D_array(matrix); }
+//     matrix = nullptr;
+//   };
+// };

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -19,6 +19,9 @@
  */
 template<typename T>
 class Matrix {
+  friend class HDF5Reader;
+  friend class HDF5Writer;
+
 protected:
   int n_rows_ = 0;
   int n_cols_ = 0;

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -89,11 +89,6 @@ public:
  * definition. */
 typedef Matrix<double> CCoefficientMatrix;
 
-/** TODO: Docstring */
-struct GratingStructure : public Matrix<int> {
-  GratingStructure(const mxArray *ptr, int I_tot);
-};
-
 /**
  * @brief Defines the numerical aperture of the objective, assuming that the
  * lens is centred on the origin of the PSTD simulation.
@@ -105,8 +100,11 @@ struct GratingStructure : public Matrix<int> {
  * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
  * aperture of the lens.
  */
-struct Pupil : public Matrix<double> {
-  void initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols);
+typedef Matrix<double> Pupil;
+
+/** TODO: Docstring */
+struct GratingStructure : public Matrix<int> {
+  GratingStructure(const mxArray *ptr, int I_tot);
 };
 
 /**

--- a/tdms/include/arrays/tdms_matrix.h
+++ b/tdms/include/arrays/tdms_matrix.h
@@ -13,8 +13,8 @@
  *
  * this->(i, j) = data_[i * n_cols_ + j].
  *
- * @seealso This is consistent with the way hdf5 files store array-like data, see
- *          https://support.hdfgroup.org/HDF5/doc1.6/UG/12_Dataspaces.html.
+ * @seealso This is consistent with the way hdf5 files store array-like data,
+ * see https://support.hdfgroup.org/HDF5/doc1.6/UG/12_Dataspaces.html.
  * @tparam T Numerical datatype
  */
 template<typename T>
@@ -93,9 +93,9 @@ typedef Matrix<double> CCoefficientMatrix;
  * @brief Defines the numerical aperture of the objective, assuming that the
  *        lens is centred on the origin of the PSTD simulation.
  * @details In particular, since the fibre modes are imaged onto a Fourier plane
- *         of both the physical fibre and the sample, the field scattered by the sample
- *         and collected by the objective lens can have only a finite spatial support in
- *         the aperture of the objective lens.
+ *         of both the physical fibre and the sample, the field scattered by the
+ * sample and collected by the objective lens can have only a finite spatial
+ * support in the aperture of the objective lens.
  *
  * Pupil(i, j) thus takes the value 1 for those (i,j) indices within the
  * aperture of the lens.

--- a/tdms/include/hdf5_io/hdf5_reader.h
+++ b/tdms/include/hdf5_io/hdf5_reader.h
@@ -14,7 +14,6 @@
  *          **double, but can be anything in general).
  */
 class HDF5Reader : public HDF5Base {
-
 public:
   /**
    * @brief Construct a new HDF5Reader for a named file.
@@ -82,19 +81,9 @@ public:
               "Cannot read " + dataset_name + " into a 2D matrix, it has " +
               std::to_string(dimensions.size()) + " dimensions");
     }
-    int n_rows = dimensions[0];
-    int n_cols = dimensions[1];
 
-    SPDLOG_DEBUG("n_rows = {}; n_cols = {}", n_rows, n_cols);
-    T *buff = (T *) malloc(n_rows * n_cols * sizeof(T));
-    read(dataset_name, buff);
-
-    data_location.allocate(n_rows, n_cols);
-    for (unsigned int i = 0; i < n_rows; i++) {
-      for (unsigned int j = 0; j < n_cols; j++) {
-        data_location(i, j) = buff[i * n_cols + j];
-      }
-    }
+    data_location.allocate(dimensions[0], dimensions[1]);
+    read(dataset_name, data_location.data_.data());
     return;
   }
 

--- a/tdms/include/hdf5_io/hdf5_reader.h
+++ b/tdms/include/hdf5_io/hdf5_reader.h
@@ -5,6 +5,7 @@
 
 #include "arrays.h"
 #include "arrays/cuboid.h"
+#include "arrays/tdms_matrix.h"
 #include "interface.h"
 
 /**
@@ -91,7 +92,7 @@ public:
     data_location.allocate(n_rows, n_cols);
     for (unsigned int i = 0; i < n_rows; i++) {
       for (unsigned int j = 0; j < n_cols; j++) {
-        data_location[i][j] = buff[i * n_cols + j];
+        data_location(i, j) = buff[i * n_cols + j];
       }
     }
     return;

--- a/tdms/include/hdf5_io/hdf5_writer.h
+++ b/tdms/include/hdf5_io/hdf5_writer.h
@@ -22,7 +22,7 @@ public:
    * @param size The size of the data array.
    * @param dimensions The number of dimensions of the array.
    */
-  void write(const std::string &dataname, double *data, int size,
+  void write(const std::string &dataname, const double *data, int size,
              hsize_t *dimensions);
 
   /**
@@ -35,16 +35,9 @@ public:
    */
   template<typename T>
   void write(const std::string &dataname, const Matrix<T> &data) {
-    int n_cols = data.get_n_cols();
-    int n_rows = data.get_n_rows();
-    hsize_t dimension[2] = {static_cast<hsize_t>(n_rows),
-                            static_cast<hsize_t>(n_cols)};
-    T *buff = (T *) malloc(n_rows * n_cols * sizeof(T));
-    for (unsigned int i = 0; i < n_rows; i++) {
-      for (unsigned int j = 0; j < n_cols; j++) {
-        buff[i * n_cols + j] = data(i, j);
-      }
-    }
-    write(dataname, buff, 2, dimension);
+    hsize_t dimensions[2];
+    dimensions[0] = data.get_n_rows();
+    dimensions[1] = data.get_n_cols();
+    write(dataname, data.data_.data(), 2, dimensions);
   }
 };

--- a/tdms/include/hdf5_io/hdf5_writer.h
+++ b/tdms/include/hdf5_io/hdf5_writer.h
@@ -2,7 +2,7 @@
 
 #include "hdf5_io/hdf5_base.h"
 
-#include "arrays.h"
+#include "arrays/tdms_matrix.h"
 
 class HDF5Writer : public HDF5Base {
 
@@ -42,7 +42,7 @@ public:
     T *buff = (T *) malloc(n_rows * n_cols * sizeof(T));
     for (unsigned int i = 0; i < n_rows; i++) {
       for (unsigned int j = 0; j < n_cols; j++) {
-        buff[i * n_cols + j] = data[i][j];
+        buff[i * n_cols + j] = data(i, j);
       }
     }
     write(dataname, buff, 2, dimension);

--- a/tdms/include/simulation_manager/objects_from_infile.h
+++ b/tdms/include/simulation_manager/objects_from_infile.h
@@ -13,6 +13,7 @@
 #include "arrays/cuboid.h"
 #include "arrays/dtilde.h"
 #include "arrays/incident_field.h"
+#include "arrays/tdms_matrix.h"
 #include "cell_coordinate.h"
 #include "field.h"
 #include "fieldsample.h"
@@ -90,7 +91,7 @@ public:
  * inputs from this file.
  *
  * The Sources, GratingStructure, and FrequencyExtractVector can only be
- * initalised after the other arrays in the input file have been parsed.
+ * initialised after the other arrays in the input file have been parsed.
  *
  * As such, this object inherits the setup of IndependentObjectsFromInfile, and
  * then constructs the aforementioned arrays using a combination of information

--- a/tdms/include/simulation_manager/objects_from_infile.h
+++ b/tdms/include/simulation_manager/objects_from_infile.h
@@ -65,12 +65,12 @@ public:
 
   IncidentField Ei;//< time-domain field
 
-  FrequencyVectors f_vec;//<! Frequency vector
-  Pupil pupil;           //<! Numerical aperture of the objective lens
-  DTilde D_tilde;        //< TODO
-  TDFieldExporter2D ex_td_field_exporter;//< two-dimensional field exporter
+  FrequencyVectors f_vec;//!< Frequency vector
+  Pupil pupil;           //!< Numerical aperture of the objective lens
+  DTilde D_tilde;        //!< TODO
+  TDFieldExporter2D ex_td_field_exporter;//!< two-dimensional field exporter
 
-  GridLabels input_grid_labels;//< cartesian labels of the Yee cells
+  GridLabels input_grid_labels;//!< cartesian labels of the Yee cells
 
   /* DERIVED VARIABLES FROM INDEPENDENT INPUTS */
 

--- a/tdms/include/simulation_manager/objects_from_infile.h
+++ b/tdms/include/simulation_manager/objects_from_infile.h
@@ -65,9 +65,9 @@ public:
 
   IncidentField Ei;//< time-domain field
 
-  FrequencyVectors f_vec;                //< frequency vector
-  Pupil pupil;                           //< TODO
-  DTilde D_tilde;                        //< TODO
+  FrequencyVectors f_vec;//<! Frequency vector
+  Pupil pupil;           //<! Numerical aperture of the objective lens
+  DTilde D_tilde;        //< TODO
   TDFieldExporter2D ex_td_field_exporter;//< two-dimensional field exporter
 
   GridLabels input_grid_labels;//< cartesian labels of the Yee cells

--- a/tdms/include/simulation_manager/pstd_variables.h
+++ b/tdms/include/simulation_manager/pstd_variables.h
@@ -7,7 +7,7 @@
 
 #include <fftw3.h>
 
-#include "arrays.h"
+#include "arrays/tdms_matrix.h"
 #include "cell_coordinate.h"
 
 /**

--- a/tdms/include/vertex_phasors.h
+++ b/tdms/include/vertex_phasors.h
@@ -7,7 +7,7 @@
 
 #include <complex>
 
-#include "arrays.h"
+#include "arrays/tdms_matrix.h"
 #include "field.h"
 #include "grid_labels.h"
 

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -172,25 +172,6 @@ bool DispersiveMultiLayer::is_dispersive(double near_zero_tolerance) const {
   return false;
 }
 
-GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
-
-  if (mxIsEmpty(ptr)) { return; }
-
-  auto dims = mxGetDimensions(ptr);
-  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != 2 ||
-      dims[1] != (I_tot + 1)) {
-    throw runtime_error("structure should have dimension 2 x (I_tot+1) ");
-  }
-
-  matrix = cast_matlab_2D_array((int *) mxGetPr(ptr), 2, I_tot + 1);
-}
-
-GratingStructure::~GratingStructure() {
-  free_cast_matlab_2D_array(matrix);
-  // prevent double free when calling ~Matrix, superclass destructor
-  matrix = nullptr;
-}
-
 FrequencyExtractVector::FrequencyExtractVector(const mxArray *ptr,
                                                double omega_an) {
 

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -219,26 +219,6 @@ int FieldComponentsVector::index(int value) {
   return -1;
 }
 
-void Vertices::initialise(const mxArray *ptr) {
-
-  auto element = ptr_to_matrix_in(ptr, "vertices", "campssample");
-  if (mxIsEmpty(element)) { return; }
-
-  auto dims = mxGetDimensions(element);
-  int n_vertices = n_rows = dims[0];
-  n_cols = dims[1];
-
-  if (n_cols != 3) {
-    throw runtime_error("Second dimension in campssample.vertices must be 3");
-  }
-
-  spdlog::info("Found vertices ({0:d} x 3)", n_vertices);
-  matrix = cast_matlab_2D_array((int *) mxGetPr(element), n_vertices, n_cols);
-
-  for (int j = 0; j < n_vertices; j++)// decrement index for MATLAB->C indexing
-    for (int k = 0; k < n_cols; k++) { matrix[k][j] -= 1; }
-}
-
 void DetectorSensitivityArrays::initialise(int n_rows, int n_cols) {
 
   v = (fftw_complex *) fftw_malloc(n_rows * n_cols * sizeof(fftw_complex));

--- a/tdms/src/arrays.cpp
+++ b/tdms/src/arrays.cpp
@@ -200,29 +200,6 @@ double FrequencyExtractVector::max() {
   return tmp;
 }
 
-void Pupil::initialise(const mxArray *ptr, int n_rows, int n_cols) {
-
-  if (mxIsEmpty(ptr)) { return; }
-
-  auto dims = (int *) mxGetDimensions(ptr);
-
-  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != n_rows ||
-      dims[1] != n_cols) {
-    throw runtime_error("Pupil has dimension " + to_string(dims[0]) + "x" +
-                        to_string(dims[1]) + " but it needed to be " +
-                        to_string(n_rows) + "x" + to_string(n_cols));
-  }
-
-  matrix = cast_matlab_2D_array(mxGetPr(ptr), n_rows, n_cols);
-  this->n_cols = n_cols;
-  this->n_rows = n_rows;
-}
-
-Pupil::~Pupil() {
-  free_cast_matlab_2D_array(matrix);
-  matrix = nullptr;
-}
-
 void FieldComponentsVector::initialise(const mxArray *ptr) {
 
   auto element = ptr_to_matrix_in(ptr, "components", "campssample");

--- a/tdms/src/arrays/tdms_matrix.cpp
+++ b/tdms/src/arrays/tdms_matrix.cpp
@@ -1,0 +1,21 @@
+#include "arrays/tdms_matrix.h"
+
+#include <stdexcept>
+
+using std::runtime_error;
+
+GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
+
+  if (mxIsEmpty(ptr)) { return; }
+
+  auto dims = mxGetDimensions(ptr);
+  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != 2 ||
+      dims[1] != (I_tot + 1)) {
+    throw runtime_error("structure should have dimension 2 x (I_tot+1) ");
+  }
+
+  int **matlab_buffer =
+          cast_matlab_2D_array((int *) mxGetPr(ptr), 2, I_tot + 1);
+  initialise(matlab_buffer, 2, I_tot + 1, true);
+  free_cast_matlab_2D_array(matlab_buffer);
+}

--- a/tdms/src/arrays/tdms_matrix.cpp
+++ b/tdms/src/arrays/tdms_matrix.cpp
@@ -25,24 +25,6 @@ GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
   free_cast_matlab_2D_array(matlab_buffer);
 }
 
-void Pupil::initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols) {
-
-  if (mxIsEmpty(ptr)) { return; }
-
-  auto dims = (int *) mxGetDimensions(ptr);
-
-  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != n_rows ||
-      dims[1] != n_cols) {
-    throw runtime_error("Pupil has dimension " + to_string(dims[0]) + "x" +
-                        to_string(dims[1]) + " but it needed to be " +
-                        to_string(n_rows) + "x" + to_string(n_cols));
-  }
-
-  double **matlab_buffer = cast_matlab_2D_array(mxGetPr(ptr), n_rows, n_cols);
-  initialise(matlab_buffer, n_rows, n_cols, true);
-  free_cast_matlab_2D_array(matlab_buffer);
-}
-
 void Vertices::initialise_from_matlab(const mxArray *ptr) {
 
   auto element = ptr_to_matrix_in(ptr, "vertices", "campssample");

--- a/tdms/src/arrays/tdms_matrix.cpp
+++ b/tdms/src/arrays/tdms_matrix.cpp
@@ -15,7 +15,8 @@ GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
   auto dims = mxGetDimensions(ptr);
   if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != 2 ||
       dims[1] != (I_tot + 1)) {
-    throw runtime_error("structure should have dimension 2 x (I_tot+1) ");
+    throw runtime_error("structure should have dimension 2 x " +
+                        to_string(I_tot + 1));
   }
 
   int **matlab_buffer =

--- a/tdms/src/arrays/tdms_matrix.cpp
+++ b/tdms/src/arrays/tdms_matrix.cpp
@@ -1,8 +1,10 @@
 #include "arrays/tdms_matrix.h"
 
 #include <stdexcept>
+#include <string>
 
 using std::runtime_error;
+using std::to_string;
 
 GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
 
@@ -17,5 +19,23 @@ GratingStructure::GratingStructure(const mxArray *ptr, int I_tot) {
   int **matlab_buffer =
           cast_matlab_2D_array((int *) mxGetPr(ptr), 2, I_tot + 1);
   initialise(matlab_buffer, 2, I_tot + 1, true);
+  free_cast_matlab_2D_array(matlab_buffer);
+}
+
+void Pupil::initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols) {
+
+  if (mxIsEmpty(ptr)) { return; }
+
+  auto dims = (int *) mxGetDimensions(ptr);
+
+  if (mxGetNumberOfDimensions(ptr) != 2 || dims[0] != n_rows ||
+      dims[1] != n_cols) {
+    throw runtime_error("Pupil has dimension " + to_string(dims[0]) + "x" +
+                        to_string(dims[1]) + " but it needed to be " +
+                        to_string(n_rows) + "x" + to_string(n_cols));
+  }
+
+  double **matlab_buffer = cast_matlab_2D_array(mxGetPr(ptr), n_rows, n_cols);
+  initialise(matlab_buffer, n_rows, n_cols, true);
   free_cast_matlab_2D_array(matlab_buffer);
 }

--- a/tdms/src/arrays/tdms_matrix.cpp
+++ b/tdms/src/arrays/tdms_matrix.cpp
@@ -3,6 +3,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <spdlog/spdlog.h>
+
 using std::runtime_error;
 using std::to_string;
 
@@ -38,4 +40,30 @@ void Pupil::initialise_from_matlab(const mxArray *ptr, int n_rows, int n_cols) {
   double **matlab_buffer = cast_matlab_2D_array(mxGetPr(ptr), n_rows, n_cols);
   initialise(matlab_buffer, n_rows, n_cols, true);
   free_cast_matlab_2D_array(matlab_buffer);
+}
+
+void Vertices::initialise_from_matlab(const mxArray *ptr) {
+
+  auto element = ptr_to_matrix_in(ptr, "vertices", "campssample");
+  if (mxIsEmpty(element)) { return; }
+
+  auto dims = mxGetDimensions(element);
+
+  if (dims[1] != 3) {
+    throw runtime_error("Second dimension in campssample.vertices must be 3");
+  } else {
+    spdlog::info("Found vertices ({0:d} x 3)", dims[0]);
+  }
+
+  int **matlab_buffer =
+          cast_matlab_2D_array((int *) mxGetPr(element), dims[0], dims[1]);
+  initialise(matlab_buffer, dims[0], 3, true);
+  free_cast_matlab_2D_array(matlab_buffer);
+
+  // Decrement stored index values, because of MATLAB->C indexing
+  std::for_each(data_.begin(), data_.end(), [](int &n) { n--; });
+}
+
+ijk Vertices::index_in_row(int row) const {
+  return {operator()(row, 0), operator()(row, 1), operator()(row, 2)};
 }

--- a/tdms/src/hdf5_io/hdf5_writer.cpp
+++ b/tdms/src/hdf5_io/hdf5_writer.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-void HDF5Writer::write(const string &dataset_name, double *data, int size,
+void HDF5Writer::write(const string &dataset_name, const double *data, int size,
                        hsize_t *dimensions) {
   spdlog::debug("Writing {} to file: {}", dataset_name, filename_);
 

--- a/tdms/src/simulation_manager/execute_detector_subfunctions.cpp
+++ b/tdms/src/simulation_manager/execute_detector_subfunctions.cpp
@@ -71,8 +71,8 @@ void SimulationManager::compute_detector_functions(unsigned int tind,
          j++)
       for (int i = 0;
            i < (I_tot - inputs.params.pml.Dxu - inputs.params.pml.Dxl); i++) {
-        lv.Ex_t.cm[j][i] *= inputs.pupil[j][i] * inputs.D_tilde.x(im, i, j);
-        lv.Ey_t.cm[j][i] *= inputs.pupil[j][i] * inputs.D_tilde.y(im, i, j);
+        lv.Ex_t.cm[j][i] *= inputs.pupil(i, j) * inputs.D_tilde.x(im, i, j);
+        lv.Ey_t.cm[j][i] *= inputs.pupil(i, j) * inputs.D_tilde.y(im, i, j);
       }
 
       /* Now iterate over each frequency we are extracting phasors at.

--- a/tdms/src/simulation_manager/execute_simulation.cpp
+++ b/tdms/src/simulation_manager/execute_simulation.cpp
@@ -152,12 +152,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -310,12 +310,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -490,12 +490,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -642,12 +642,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -819,12 +819,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -969,12 +969,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1141,12 +1141,12 @@ void SimulationManager::execute() {
                 if (k > inputs.params.pml.Dzl &&
                     k < (inputs.params.pml.Dzl +
                          loop_variables.n_non_pml_cells_in_K)) {
-                  if ((k - inputs.structure[i][1]) <
+                  if ((k - inputs.structure(1, i)) <
                               (loop_variables.n_non_pml_cells_in_K +
                                inputs.params.pml.Dzl) &&
-                      (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                    k_loc = k - inputs.structure[i][1];
-                  else if ((k - inputs.structure[i][1]) >=
+                      (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                    k_loc = k - inputs.structure(1, i);
+                  else if ((k - inputs.structure(1, i)) >=
                            (loop_variables.n_non_pml_cells_in_K +
                             inputs.params.pml.Dzl))
                     k_loc = inputs.params.pml.Dzl +
@@ -1249,12 +1249,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1402,12 +1402,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1577,12 +1577,12 @@ void SimulationManager::execute() {
                 if (k > inputs.params.pml.Dzl &&
                     k < (inputs.params.pml.Dzl +
                          loop_variables.n_non_pml_cells_in_K)) {
-                  if ((k - inputs.structure[i][1]) <
+                  if ((k - inputs.structure(1, i)) <
                               (loop_variables.n_non_pml_cells_in_K +
                                inputs.params.pml.Dzl) &&
-                      (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                    k_loc = k - inputs.structure[i][1];
-                  else if ((k - inputs.structure[i][1]) >=
+                      (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                    k_loc = k - inputs.structure(1, i);
+                  else if ((k - inputs.structure(1, i)) >=
                            (loop_variables.n_non_pml_cells_in_K +
                             inputs.params.pml.Dzl))
                     k_loc = inputs.params.pml.Dzl +
@@ -1737,12 +1737,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1780,12 +1780,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1843,12 +1843,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1889,12 +1889,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1952,12 +1952,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -1999,12 +1999,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2062,12 +2062,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2107,12 +2107,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2174,12 +2174,12 @@ void SimulationManager::execute() {
                 if (k > inputs.params.pml.Dzl &&
                     k < (inputs.params.pml.Dzl +
                          loop_variables.n_non_pml_cells_in_K)) {
-                  if ((k - inputs.structure[i][1]) <
+                  if ((k - inputs.structure(1, i)) <
                               (loop_variables.n_non_pml_cells_in_K +
                                inputs.params.pml.Dzl) &&
-                      (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                    k_loc = k - inputs.structure[i][1];
-                  else if ((k - inputs.structure[i][1]) >=
+                      (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                    k_loc = k - inputs.structure(1, i);
+                  else if ((k - inputs.structure(1, i)) >=
                            (loop_variables.n_non_pml_cells_in_K +
                             inputs.params.pml.Dzl))
                     k_loc = inputs.params.pml.Dzl +
@@ -2218,12 +2218,12 @@ void SimulationManager::execute() {
                 if (k > inputs.params.pml.Dzl &&
                     k < (inputs.params.pml.Dzl +
                          loop_variables.n_non_pml_cells_in_K)) {
-                  if ((k - inputs.structure[i][1]) <
+                  if ((k - inputs.structure(1, i)) <
                               (loop_variables.n_non_pml_cells_in_K +
                                inputs.params.pml.Dzl) &&
-                      (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                    k_loc = k - inputs.structure[i][1];
-                  else if ((k - inputs.structure[i][1]) >=
+                      (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                    k_loc = k - inputs.structure(1, i);
+                  else if ((k - inputs.structure(1, i)) >=
                            (loop_variables.n_non_pml_cells_in_K +
                             inputs.params.pml.Dzl))
                     k_loc = inputs.params.pml.Dzl +
@@ -2276,12 +2276,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2322,12 +2322,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2386,12 +2386,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +
@@ -2432,12 +2432,12 @@ void SimulationManager::execute() {
                   if (k > inputs.params.pml.Dzl &&
                       k < (inputs.params.pml.Dzl +
                            loop_variables.n_non_pml_cells_in_K)) {
-                    if ((k - inputs.structure[i][1]) <
+                    if ((k - inputs.structure(1, i)) <
                                 (loop_variables.n_non_pml_cells_in_K +
                                  inputs.params.pml.Dzl) &&
-                        (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-                      k_loc = k - inputs.structure[i][1];
-                    else if ((k - inputs.structure[i][1]) >=
+                        (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+                      k_loc = k - inputs.structure(1, i);
+                    else if ((k - inputs.structure(1, i)) >=
                              (loop_variables.n_non_pml_cells_in_K +
                               inputs.params.pml.Dzl))
                       k_loc = inputs.params.pml.Dzl +

--- a/tdms/src/simulation_manager/execute_simulation.cpp
+++ b/tdms/src/simulation_manager/execute_simulation.cpp
@@ -455,8 +455,8 @@ void SimulationManager::execute() {
                 eh_vec[n][i][0] =
                         inputs.H_s.zx(i, j, k) + inputs.H_s.zy(i, j, k);
                 eh_vec[n][i][1] = 0.;
-                PSTD.ca[n][i - 1] = Ca;
-                PSTD.cb[n][i - 1] = Cb;
+                PSTD.ca(n, i - 1) = Ca;
+                PSTD.cb(n, i - 1) = Cb;
               }
               i = 0;
               eh_vec[n][i][0] = inputs.H_s.zx(i, j, k) + inputs.H_s.zy(i, j, k);
@@ -468,8 +468,8 @@ void SimulationManager::execute() {
 
               for (i = 1; i < I_tot; i++) {
                 inputs.E_s.yx(i, j, k) =
-                        PSTD.ca[n][i - 1] * inputs.E_s.yx(i, j, k) -
-                        PSTD.cb[n][i - 1] * eh_vec[n][i][0] /
+                        PSTD.ca(n, i - 1) * inputs.E_s.yx(i, j, k) -
+                        PSTD.cb(n, i - 1) * eh_vec[n][i][0] /
                                 ((double) PSTD.N_ex);
                 // E_s.yx(i,j,k) = Enp1;
               }
@@ -781,8 +781,8 @@ void SimulationManager::execute() {
                 eh_vec[n][k][0] =
                         inputs.H_s.xy(i, j, k) + inputs.H_s.xz(i, j, k);
                 eh_vec[n][k][1] = 0.;
-                PSTD.ca[n][k - 1] = Ca;
-                PSTD.cb[n][k - 1] = Cb;
+                PSTD.ca(n, k - 1) = Ca;
+                PSTD.cb(n, k - 1) = Cb;
               }
               k = 0;
               eh_vec[n][k][0] = inputs.H_s.xy(i, j, k) + inputs.H_s.xz(i, j, k);
@@ -794,8 +794,8 @@ void SimulationManager::execute() {
 
               for (k = 1; k < K_tot; k++) {
                 inputs.E_s.yz(i, j, k) =
-                        PSTD.ca[n][k - 1] * inputs.E_s.yz(i, j, k) +
-                        PSTD.cb[n][k - 1] * eh_vec[n][k][0] /
+                        PSTD.ca(n, k - 1) * inputs.E_s.yz(i, j, k) +
+                        PSTD.cb(n, k - 1) * eh_vec[n][k][0] /
                                 ((double) PSTD.N_ez);
                 // E_s.yz(i,j,k) = Enp1;
               }
@@ -1106,8 +1106,8 @@ void SimulationManager::execute() {
                 eh_vec[n][i][0] =
                         inputs.H_s.yx(i, j, k) + inputs.H_s.yz(i, j, k);
                 eh_vec[n][i][1] = 0.;
-                PSTD.ca[n][i - 1] = Ca;
-                PSTD.cb[n][i - 1] = Cb;
+                PSTD.ca(n, i - 1) = Ca;
+                PSTD.cb(n, i - 1) = Cb;
               }
               i = 0;
               eh_vec[n][i][0] = inputs.H_s.yx(i, j, k) + inputs.H_s.yz(i, j, k);
@@ -1119,8 +1119,8 @@ void SimulationManager::execute() {
 
               for (i = 1; i < I_tot; i++) {
                 inputs.E_s.zx(i, j, k) =
-                        PSTD.ca[n][i - 1] * inputs.E_s.zx(i, j, k) +
-                        PSTD.cb[n][i - 1] * eh_vec[n][i][0] /
+                        PSTD.ca(n, i - 1) * inputs.E_s.zx(i, j, k) +
+                        PSTD.cb(n, i - 1) * eh_vec[n][i][0] /
                                 ((double) PSTD.N_ex);
                 // E_s.zx(i,j,k) = Enp1;
               }
@@ -1542,8 +1542,8 @@ void SimulationManager::execute() {
                 eh_vec[n][j][0] =
                         inputs.H_s.xy(i, j, k) + inputs.H_s.xz(i, j, k);
                 eh_vec[n][j][1] = 0.;
-                PSTD.ca[n][j - 1] = Ca;
-                PSTD.cb[n][j - 1] = Cb;
+                PSTD.ca(n, j - 1) = Ca;
+                PSTD.cb(n, j - 1) = Cb;
               }
               if (J_tot > 1) {
                 j = 0;
@@ -1556,8 +1556,8 @@ void SimulationManager::execute() {
               }
               for (j = 1; j < J_tot; j++) {
                 inputs.E_s.zy(i, j, k) =
-                        PSTD.ca[n][j - 1] * inputs.E_s.zy(i, j, k) -
-                        PSTD.cb[n][j - 1] * eh_vec[n][j][0] /
+                        PSTD.ca(n, j - 1) * inputs.E_s.zy(i, j, k) -
+                        PSTD.cb(n, j - 1) * eh_vec[n][j][0] /
                                 ((double) PSTD.N_ey);
                 // E_s.zy(i,j,k) = Enp1;
               }
@@ -1795,16 +1795,12 @@ void SimulationManager::execute() {
                   }
 
                 if (!inputs.materials[k][j][i]) {
-                  PSTD.ca[n][k] = inputs.D.a.z[k_loc];
-                  PSTD.cb[n][k] = inputs.D.b.z[k_loc];
-                  // H_s.xz(i, j, k) =
-                  // D.a.z[k_loc]*H_s.xz(i, j,
-                  // k)+D.b.z[k_loc]*(E_s.yx[k+1][j][i]
-                  // + E_s.yz[k+1][j][i] - E_s.yx(i,j,k) - E_s.yz(i,j,k));
+                  PSTD.ca(n, k) = inputs.D.a.z[k_loc];
+                  PSTD.cb(n, k) = inputs.D.b.z[k_loc];
                 } else {
-                  PSTD.ca[n][k] =
+                  PSTD.ca(n, k) =
                           inputs.Dmaterial.a.z[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][k] =
+                  PSTD.cb(n, k) =
                           inputs.Dmaterial.b.z[inputs.materials[k][j][i] - 1];
                   // H_s.xz(i, j, k) =
                   // Dmaterial.Da.z[materials[k][j][i]-1]*H_s.xz(i, j,
@@ -1826,8 +1822,8 @@ void SimulationManager::execute() {
 
               for (k = 0; k < K_tot; k++) {
                 inputs.H_s.xz(i, j, k) =
-                        PSTD.ca[n][k] * inputs.H_s.xz(i, j, k) +
-                        PSTD.cb[n][k] * eh_vec[n][k][0] / ((double) PSTD.N_hz);
+                        PSTD.ca(n, k) * inputs.H_s.xz(i, j, k) +
+                        PSTD.cb(n, k) * eh_vec[n][k][0] / ((double) PSTD.N_hz);
               }
             }
 
@@ -1910,15 +1906,12 @@ void SimulationManager::execute() {
                 else
                   array_ind = (J_tot + 1) * k_loc + j;
                 if (!inputs.materials[k][j][i]) {
-                  PSTD.ca[n][j] = inputs.D.a.y[array_ind];
-                  PSTD.cb[n][j] = inputs.D.b.y[array_ind];
-                  //		H_s.xy(i,j,k) =
-                  // D.a.y[array_ind]*H_s.xy(i,j,k)+D.b.y[array_ind]*(E_s.zy(i,j,k)
-                  // + E_s.zx(i,j,k) - E_s.zy[k][j+1][i] - E_s.zx[k][j+1][i]);
+                  PSTD.ca(n, j) = inputs.D.a.y[array_ind];
+                  PSTD.cb(n, j) = inputs.D.b.y[array_ind];
                 } else {
-                  PSTD.ca[n][j] =
+                  PSTD.ca(n, j) =
                           inputs.Dmaterial.a.y[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][j] =
+                  PSTD.cb(n, j) =
                           inputs.Dmaterial.b.y[inputs.materials[k][j][i] - 1];
                   //		H_s.xy(i,j,k) =
                   // Dmaterial.Da.y[materials[k][j][i]-1]*H_s.xy(i,j,k)+Dmaterial.Db.y[materials[k][j][i]-1]*(E_s.zy(i,j,k)
@@ -1939,8 +1932,8 @@ void SimulationManager::execute() {
 
               for (j = 0; j < J_tot; j++) {
                 inputs.H_s.xy(i, j, k) =
-                        PSTD.ca[n][j] * inputs.H_s.xy(i, j, k) -
-                        PSTD.cb[n][j] * eh_vec[n][j][0] / ((double) PSTD.N_hy);
+                        PSTD.ca(n, j) * inputs.H_s.xy(i, j, k) -
+                        PSTD.cb(n, j) * eh_vec[n][j][0] / ((double) PSTD.N_hy);
               }
             }
           // PSTD, H_s.xy
@@ -2023,16 +2016,12 @@ void SimulationManager::execute() {
                 else
                   array_ind = (I_tot + 1) * k_loc + i;
                 if (!inputs.materials[k][j][i]) {
-                  PSTD.ca[n][i] = inputs.D.a.x[array_ind];
-                  PSTD.cb[n][i] = inputs.D.b.x[array_ind];
-                  //		H_s.yx(i, j, k) =
-                  // D.a.x[array_ind]*H_s.yx(i, j,
-                  // k)+D.b.x[array_ind]*(E_s.zx[k][j][i+1]
-                  // + E_s.zy[k][j][i+1] - E_s.zx(i,j,k) - E_s.zy(i,j,k));
+                  PSTD.ca(n, i) = inputs.D.a.x[array_ind];
+                  PSTD.cb(n, i) = inputs.D.b.x[array_ind];
                 } else {
-                  PSTD.ca[n][i] =
+                  PSTD.ca(n, i) =
                           inputs.Dmaterial.a.x[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][i] =
+                  PSTD.cb(n, i) =
                           inputs.Dmaterial.b.x[inputs.materials[k][j][i] - 1];
                   //	H_s.yx(i, j, k) =
                   // Dmaterial.Da.x[materials[k][j][i]-1]*H_s.yx(i, j,
@@ -2054,8 +2043,8 @@ void SimulationManager::execute() {
 
               for (i = 0; i < I_tot; i++) {
                 inputs.H_s.yx(i, j, k) =
-                        PSTD.ca[n][i] * inputs.H_s.yx(i, j, k) +
-                        PSTD.cb[n][i] * eh_vec[n][i][0] / ((double) PSTD.N_hx);
+                        PSTD.ca(n, i) * inputs.H_s.yx(i, j, k) +
+                        PSTD.cb(n, i) * eh_vec[n][i][0] / ((double) PSTD.N_hx);
               }
             }
           // PSTD, H_s.yx
@@ -2132,15 +2121,12 @@ void SimulationManager::execute() {
                       k_loc = inputs.params.pml.Dzl + 1;
                   }
                 if (!inputs.materials[k][j][i]) {
-                  PSTD.ca[n][k] = inputs.D.a.z[k_loc];
-                  PSTD.cb[n][k] = inputs.D.b.z[k_loc];
-                  // H_s.yz(i,j,k) =
-                  // D.a.z[k_loc]*H_s.yz(i,j,k)+D.b.z[k_loc]*(E_s.xy(i,j,k)
-                  // + E_s.xz(i, j, k) - E_s.xy[k+1][j][i] - E_s.xz[k+1][j][i]);
+                  PSTD.ca(n, k) = inputs.D.a.z[k_loc];
+                  PSTD.cb(n, k) = inputs.D.b.z[k_loc];
                 } else {
-                  PSTD.ca[n][k] =
+                  PSTD.ca(n, k) =
                           inputs.Dmaterial.a.z[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][k] =
+                  PSTD.cb(n, k) =
                           inputs.Dmaterial.b.z[inputs.materials[k][j][i] - 1];
                   // H_s.yz(i,j,k) =
                   // Dmaterial.Da.z[materials[k][j][i]-1]*H_s.yz(i,j,k)+Dmaterial.Db.z[materials[k][j][i]-1]*(E_s.xy(i,j,k)
@@ -2160,8 +2146,8 @@ void SimulationManager::execute() {
 
               for (k = 0; k < K_tot; k++) {
                 inputs.H_s.yz(i, j, k) =
-                        PSTD.ca[n][k] * inputs.H_s.yz(i, j, k) -
-                        PSTD.cb[n][k] * eh_vec[n][k][0] / ((double) PSTD.N_hz);
+                        PSTD.ca(n, k) * inputs.H_s.yz(i, j, k) -
+                        PSTD.cb(n, k) * eh_vec[n][k][0] / ((double) PSTD.N_hz);
               }
             }
           // PSTD, H_s.yz
@@ -2353,15 +2339,12 @@ void SimulationManager::execute() {
                 else
                   array_ind = (J_tot + 1) * k_loc + j;
                 if (!inputs.materials[k][j][i]) {
-                  PSTD.ca[n][j] = inputs.D.a.y[array_ind];
-                  PSTD.cb[n][j] = inputs.D.b.y[array_ind];
-                  //	      H_s.zy(i,j,k) =
-                  // D.a.y[array_ind]*H_s.zy(i,j,k)+D.b.y[array_ind]*(E_s.xy[k][j+1][i]
-                  // + E_s.xz[k][j+1][i] - E_s.xy(i,j,k) - E_s.xz(i, j, k));
+                  PSTD.ca(n, j) = inputs.D.a.y[array_ind];
+                  PSTD.cb(n, j) = inputs.D.b.y[array_ind];
                 } else {
-                  PSTD.ca[n][j] =
+                  PSTD.ca(n, j) =
                           inputs.Dmaterial.a.y[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][j] =
+                  PSTD.cb(n, j) =
                           inputs.Dmaterial.b.y[inputs.materials[k][j][i] - 1];
                   //	      H_s.zy(i,j,k) =
                   // Dmaterial.Da.y[materials[k][j][i]-1]*H_s.zy(i,j,k)+Dmaterial.Db.y[materials[k][j][i]-1]*(E_s.xy[k][j+1][i]
@@ -2382,8 +2365,8 @@ void SimulationManager::execute() {
 
               for (j = 0; j < J_tot; j++) {
                 inputs.H_s.zy(i, j, k) =
-                        PSTD.ca[n][j] * inputs.H_s.zy(i, j, k) +
-                        PSTD.cb[n][j] * eh_vec[n][j][0] / ((double) PSTD.N_hy);
+                        PSTD.ca(n, j) * inputs.H_s.zy(i, j, k) +
+                        PSTD.cb(n, j) * eh_vec[n][j][0] / ((double) PSTD.N_hy);
               }
             }
           // PSTD, H_s.zy
@@ -2466,18 +2449,12 @@ void SimulationManager::execute() {
                 else
                   array_ind = (I_tot + 1) * k_loc + i;
                 if (!inputs.materials[k][j][i]) {
-                  //		H_s.zx(i,j,k) =
-                  // D.a.x[array_ind]*H_s.zx(i,j,k)+D.b.x[array_ind]*(E_s.yx(i,j,k)
-                  // + E_s.yz(i,j,k) - E_s.yx[k][j][i+1] - E_s.yz[k][j][i+1]);
-                  PSTD.ca[n][i] = inputs.D.a.x[array_ind];
-                  PSTD.cb[n][i] = inputs.D.b.x[array_ind];
+                  PSTD.ca(n, i) = inputs.D.a.x[array_ind];
+                  PSTD.cb(n, i) = inputs.D.b.x[array_ind];
                 } else {
-                  //		H_s.zx(i,j,k) =
-                  // Dmaterial.Da.x[materials[k][j][i]-1]*H_s.zx(i,j,k)+Dmaterial.Db.x[materials[k][j][i]-1]*(E_s.yx(i,j,k)
-                  //+ E_s.yz(i,j,k) - E_s.yx[k][j][i+1] - E_s.yz[k][j][i+1]);
-                  PSTD.ca[n][i] =
+                  PSTD.ca(n, i) =
                           inputs.Dmaterial.a.x[inputs.materials[k][j][i] - 1];
-                  PSTD.cb[n][i] =
+                  PSTD.cb(n, i) =
                           inputs.Dmaterial.b.x[inputs.materials[k][j][i] - 1];
                 }
 
@@ -2496,8 +2473,8 @@ void SimulationManager::execute() {
 
               for (i = 0; i < I_tot; i++) {
                 inputs.H_s.zx(i, j, k) =
-                        PSTD.ca[n][i] * inputs.H_s.zx(i, j, k) -
-                        PSTD.cb[n][i] * eh_vec[n][i][0] / ((double) PSTD.N_hx);
+                        PSTD.ca(n, i) * inputs.H_s.zx(i, j, k) -
+                        PSTD.cb(n, i) * eh_vec[n][i][0] / ((double) PSTD.N_hx);
               }
             }
           // PSTD, H_s.zx

--- a/tdms/src/simulation_manager/execute_update_Ex_split.cpp
+++ b/tdms/src/simulation_manager/execute_update_Ex_split.cpp
@@ -176,8 +176,8 @@ void SimulationManager::update_Exy(LoopVariables &lv) {
 
           eh_vec[n][j][0] = inputs.H_s.zy(i, j, k) + inputs.H_s.zx(i, j, k);
           eh_vec[n][j][1] = 0.;
-          PSTD.ca[n][j - 1] = Ca;
-          PSTD.cb[n][j - 1] = Cb;
+          PSTD.ca(n, j - 1) = Ca;
+          PSTD.cb(n, j - 1) = Cb;
         }
       }
       if (solver_method == SolverMethod::PseudoSpectral && J_tot > 1) {
@@ -188,8 +188,8 @@ void SimulationManager::update_Exy(LoopVariables &lv) {
                          inputs.E_s.xy.plan_f[n], inputs.E_s.xy.plan_b[n]);
         for (j = 1; j < J_tot; j++) {
           inputs.E_s.xy(i, j, k) =
-                  PSTD.ca[n][j - 1] * inputs.E_s.xy(i, j, k) +
-                  PSTD.cb[n][j - 1] * eh_vec[n][j][0] / ((double) PSTD.N_ey);
+                  PSTD.ca(n, j - 1) * inputs.E_s.xy(i, j, k) +
+                  PSTD.cb(n, j - 1) * eh_vec[n][j][0] / ((double) PSTD.N_ey);
         }
       }
     }
@@ -355,8 +355,8 @@ void SimulationManager::update_Exz(LoopVariables &lv) {
 
           eh_vec[n][k][0] = inputs.H_s.yx(i, j, k) + inputs.H_s.yz(i, j, k);
           eh_vec[n][k][1] = 0.;
-          PSTD.ca[n][k - 1] = Ca;
-          PSTD.cb[n][k - 1] = Cb;
+          PSTD.ca(n, k - 1) = Ca;
+          PSTD.cb(n, k - 1) = Cb;
         }
       }
       if (solver_method == SolverMethod::PseudoSpectral) {
@@ -369,8 +369,8 @@ void SimulationManager::update_Exz(LoopVariables &lv) {
 
         for (k = 1; k < K_tot; k++) {
           inputs.E_s.xz(i, j, k) =
-                  PSTD.ca[n][k - 1] * inputs.E_s.xz(i, j, k) -
-                  PSTD.cb[n][k - 1] * eh_vec[n][k][0] / ((double) PSTD.N_ez);
+                  PSTD.ca(n, k - 1) * inputs.E_s.xz(i, j, k) -
+                  PSTD.cb(n, k - 1) * eh_vec[n][k][0] / ((double) PSTD.N_ez);
         }
       }
     }

--- a/tdms/src/simulation_manager/execute_update_Ex_split.cpp
+++ b/tdms/src/simulation_manager/execute_update_Ex_split.cpp
@@ -25,11 +25,11 @@ void SimulationManager::update_Exy(LoopVariables &lv) {
         if (inputs.params.is_structure) {
           if (k > inputs.params.pml.Dzl &&
               k < (inputs.params.pml.Dzl + lv.n_non_pml_cells_in_K)) {
-            if ((k - inputs.structure[i][1]) <
+            if ((k - inputs.structure(1, i)) <
                         (lv.n_non_pml_cells_in_K + inputs.params.pml.Dzl) &&
-                (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-              k_loc = k - inputs.structure[i][1];
-            else if ((k - inputs.structure[i][1]) >=
+                (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+              k_loc = k - inputs.structure(1, i);
+            else if ((k - inputs.structure(1, i)) >=
                      (lv.n_non_pml_cells_in_K + inputs.params.pml.Dzl))
               k_loc = inputs.params.pml.Dzl + lv.n_non_pml_cells_in_K - 1;
             else
@@ -213,11 +213,11 @@ void SimulationManager::update_Exz(LoopVariables &lv) {
         if (inputs.params.is_structure)
           if (k > inputs.params.pml.Dzl &&
               k < (inputs.params.pml.Dzl + lv.n_non_pml_cells_in_K)) {
-            if ((k - inputs.structure[i][1]) <
+            if ((k - inputs.structure(1, i)) <
                         (lv.n_non_pml_cells_in_K + inputs.params.pml.Dzl) &&
-                (k - inputs.structure[i][1]) > inputs.params.pml.Dzl)
-              k_loc = k - inputs.structure[i][1];
-            else if ((k - inputs.structure[i][1]) >=
+                (k - inputs.structure(1, i)) > inputs.params.pml.Dzl)
+              k_loc = k - inputs.structure(1, i);
+            else if ((k - inputs.structure(1, i)) >=
                      (lv.n_non_pml_cells_in_K + inputs.params.pml.Dzl))
               k_loc = inputs.params.pml.Dzl + lv.n_non_pml_cells_in_K - 1;
             else

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -98,8 +98,8 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   // if exdetintegral is flagged, setup pupil, D_tilde, and f_vec accordingly
   if (params.exdetintegral) {
     INPUT_FILE.read(f_vec);
-    pupil.initialise(matrices_from_input_file["Pupil"], f_vec.x.size(),
-                     f_vec.y.size());
+    pupil.initialise_from_matlab(matrices_from_input_file["Pupil"],
+                                 f_vec.x.size(), f_vec.y.size());
     D_tilde.initialise(matrices_from_input_file["D_tilde"], f_vec.x.size(),
                        f_vec.y.size());
 

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -98,8 +98,7 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   // if exdetintegral is flagged, setup pupil, D_tilde, and f_vec accordingly
   if (params.exdetintegral) {
     INPUT_FILE.read(f_vec);
-    pupil.initialise_from_matlab(matrices_from_input_file["Pupil"],
-                                 f_vec.x.size(), f_vec.y.size());
+    INPUT_FILE.read("Pupil", pupil);
     D_tilde.initialise(matrices_from_input_file["D_tilde"], f_vec.x.size(),
                        f_vec.y.size());
 

--- a/tdms/src/vertex_phasors.cpp
+++ b/tdms/src/vertex_phasors.cpp
@@ -15,7 +15,7 @@ void VertexPhasors::set_from(const mxArray *ptr) {
   }
   assert_is_struct_with_n_fields(ptr, 2,
                                  "VertexPhasors (using campssample array)");
-  vertices.initialise(ptr);
+  vertices.initialise_from_matlab(ptr);
   components.initialise(ptr);
 }
 
@@ -91,8 +91,7 @@ void VertexPhasors::extractPhasorsVertices(int frequency_index,
   {
 #pragma omp for
     for (vindex = 0; vindex < n_vertices(); vindex++) {// loop over every vertex
-      CellCoordinate current_cell{vertices[0][vindex], vertices[1][vindex],
-                                  vertices[2][vindex]};
+      CellCoordinate current_cell = vertices.index_in_row(vindex);
 
       switch (params.dimension) {
         case Dimension::THREE:

--- a/tdms/tests/include/array_test_class.h
+++ b/tdms/tests/include/array_test_class.h
@@ -186,19 +186,6 @@ public:
   std::string get_class_name() override { return "GratingStructure"; }
 };
 
-/** @brief Unit tests for Pupil */
-class PupilTest : public AbstractArrayTest {
-private:
-  const int n_rows = 4, n_cols = 8;
-
-  void test_empty_construction() override;
-  void test_wrong_input_dimensions() override;
-  void test_correct_construction() override;
-
-public:
-  std::string get_class_name() override { return "Pupil"; }
-};
-
 /** @brief Unit tests for Tensor3D */
 class Tensor3DTest : public AbstractArrayTest {
 private:

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -8,7 +8,6 @@
 #include <spdlog/spdlog.h>
 
 #include "array_test_class.h"
-#include "arrays.h"
 #include "arrays/tdms_matrix.h"
 
 void MatrixTest::test_correct_construction() {
@@ -56,12 +55,12 @@ void VerticesTest::test_correct_construction() {
   // create object
   Vertices v;
   // initialise
-  v.initialise(matlab_input);
+  v.initialise_from_matlab(matlab_input);
   // we should have n_vertex_elements number of vertices stored
   REQUIRE(v.n_vertices() == n_numeric_elements);
   // what's more, we should have decremented all the elements of v from 0 to -1
   for (int i = 0; i < n_numeric_elements; i++) {
-    for (int j = 0; j < 3; j++) { CHECK(v[j][i] == -1); }
+    for (int j = 0; j < 3; j++) { CHECK(v(i, j) == -1); }
   }
 }
 

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -27,7 +27,7 @@ void MatrixTest::test_correct_construction() {
 
     // should be able to assign to these values without seg faults now
     for (int i = 0; i < n_rows; i++) {
-      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_double[i][j] = 1.); }
+      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_double(i, j) = 1.); }
     }
   }
 }
@@ -41,7 +41,7 @@ void MatrixTest::test_other_methods() {
 
     // should be able to assign to these values without seg faults now
     for (int i = 0; i < n_rows; i++) {
-      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_int[i][j] = 0); }
+      for (int j = 0; j < n_cols; j++) { CHECK_NOTHROW(M_int(i, j) = 0); }
     }
   }
 }

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -9,6 +9,7 @@
 
 #include "array_test_class.h"
 #include "arrays.h"
+#include "arrays/tdms_matrix.h"
 
 void MatrixTest::test_correct_construction() {
   // create a Matrix via the default constructor

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -2,7 +2,7 @@
  * @file test_Matrix.cpp
  * @author William Graham (ccaegra@ucl.ac.uk)
  * @brief Tests for the Matrix class and its subclasses (Vertices,
- * GratingStructure, Pupil)
+ * GratingStructure)
  */
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
@@ -114,55 +114,8 @@ void GratingStructureTest::test_correct_construction() {
   delete gs;
 }
 
-void PupilTest::test_empty_construction() {
-  Pupil p;
-  dimensions_2d[0] = 0;
-  dimensions_2d[1] = n_cols;
-  create_numeric_array(2, dimensions_2d);
-  // passing in an empty array to initialise() doesn't error, but also doesn't
-  // assign additionally, the rows and columns arguments aren't even used, so
-  // can be garbage
-  p.initialise_from_matlab(matlab_input, 1, 1);
-  REQUIRE(!p.has_elements());// shouldn't have assigned any memory or pointers
-}
-
-void PupilTest::test_wrong_input_dimensions() {
-  Pupil p;
-  SECTION("Wrong number of dimensions (3D)") {
-    dimensions_3d[0] = n_rows;
-    dimensions_3d[1] = n_cols;
-    dimensions_3d[2] = 2;
-    create_numeric_array(3, dimensions_3d);
-    REQUIRE_THROWS_AS(p.initialise_from_matlab(matlab_input, n_rows, n_cols),
-                      std::runtime_error);
-    REQUIRE(!p.has_elements());
-  }
-  SECTION("Wrong dimension size") {
-    dimensions_2d[0] = 2 * n_rows;
-    dimensions_2d[1] = n_cols + 1;
-    create_numeric_array(2, dimensions_2d);
-    REQUIRE_THROWS_AS(p.initialise_from_matlab(matlab_input, n_rows, n_cols),
-                      std::runtime_error);
-    REQUIRE(!p.has_elements());
-  }
-}
-
-void PupilTest::test_correct_construction() {
-  Pupil p;
-  SECTION("Default constructor") { REQUIRE(!p.has_elements()); }
-  SECTION("Overloaded constructor") {
-    dimensions_2d[0] = n_rows;
-    dimensions_2d[1] = n_cols;
-    create_numeric_array(2, dimensions_2d);
-    REQUIRE_NOTHROW(p.initialise_from_matlab(matlab_input, n_rows, n_cols));
-    REQUIRE(p.has_elements());
-  }
-}
-
 TEST_CASE("Matrix") { MatrixTest().run_all_class_tests(); }
 
 TEST_CASE("Vertices") { VerticesTest().run_all_class_tests(); }
 
 TEST_CASE("GratingStructure") { GratingStructureTest().run_all_class_tests(); }
-
-TEST_CASE("Pupil") { PupilTest().run_all_class_tests(); }

--- a/tdms/tests/unit/array_tests/test_Matrix.cpp
+++ b/tdms/tests/unit/array_tests/test_Matrix.cpp
@@ -123,7 +123,7 @@ void PupilTest::test_empty_construction() {
   // passing in an empty array to initialise() doesn't error, but also doesn't
   // assign additionally, the rows and columns arguments aren't even used, so
   // can be garbage
-  p.initialise(matlab_input, 1, 1);
+  p.initialise_from_matlab(matlab_input, 1, 1);
   REQUIRE(!p.has_elements());// shouldn't have assigned any memory or pointers
 }
 
@@ -134,7 +134,7 @@ void PupilTest::test_wrong_input_dimensions() {
     dimensions_3d[1] = n_cols;
     dimensions_3d[2] = 2;
     create_numeric_array(3, dimensions_3d);
-    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols),
+    REQUIRE_THROWS_AS(p.initialise_from_matlab(matlab_input, n_rows, n_cols),
                       std::runtime_error);
     REQUIRE(!p.has_elements());
   }
@@ -142,7 +142,7 @@ void PupilTest::test_wrong_input_dimensions() {
     dimensions_2d[0] = 2 * n_rows;
     dimensions_2d[1] = n_cols + 1;
     create_numeric_array(2, dimensions_2d);
-    REQUIRE_THROWS_AS(p.initialise(matlab_input, n_rows, n_cols),
+    REQUIRE_THROWS_AS(p.initialise_from_matlab(matlab_input, n_rows, n_cols),
                       std::runtime_error);
     REQUIRE(!p.has_elements());
   }
@@ -155,7 +155,7 @@ void PupilTest::test_correct_construction() {
     dimensions_2d[0] = n_rows;
     dimensions_2d[1] = n_cols;
     create_numeric_array(2, dimensions_2d);
-    REQUIRE_NOTHROW(p.initialise(matlab_input, n_rows, n_cols));
+    REQUIRE_NOTHROW(p.initialise_from_matlab(matlab_input, n_rows, n_cols));
     REQUIRE(p.has_elements());
   }
 }

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Matrix.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Matrix.cpp
@@ -27,7 +27,7 @@ TEST_CASE("HDF5: Read/Write Matrix") {
     SPDLOG_INFO("5-by-6 2D array");
     Matrix<double> counting_matrix(5, 6);
     for (int i = 0; i < 5; i++) {
-      for (int j = 0; j < 6; j++) { counting_matrix[i][j] = 6. * i + j; }
+      for (int j = 0; j < 6; j++) { counting_matrix(i, j) = 6. * i + j; }
     }
     Matrix<double> read_back;
 
@@ -43,9 +43,9 @@ TEST_CASE("HDF5: Read/Write Matrix") {
 
     for (unsigned int i = 0; i < 5; i++) {
       for (unsigned int j = 0; j < 6; j++) {
-        SPDLOG_INFO("Checking {} == {}", counting_matrix[i][j],
-                    read_back[i][j]);
-        CHECK(counting_matrix[i][j] == Catch::Approx(read_back[i][j]));
+        SPDLOG_INFO("Checking {} == {}", counting_matrix(i, j),
+                    read_back(i, j));
+        CHECK(counting_matrix(i, j) == Catch::Approx(read_back(i, j)));
       }
     }
   }


### PR DESCRIPTION
Concerns #285:
- Completes the `Matrix` and `CCoefficientMatrix` tasks
- Moves towards the derived class objectives too.
- Also detaches `Pupil` from MATLAB

# Description

Converts the `Matrix` template class to a wrapper for strided vector storage.
Derived class behaviour changes:
- `CCoefficientMatrix` is now just a `typedef` for `Matrix<double>`.
- `Pupil` is a `struct` that inherits from `Matrix<double>`.
- `Vertices` & `GratingStructure` are `struct`s that inherit from `Matrix<int>`.

Although the only thing the derived "structs" now add is a unique way to read these classes via MATLAB. Once they have their `MATLAB` dependency removed, we can probably just typedef them all to `Matrix<double/int>`.

## Testing

Tests are preserved for all existing classes.
