### PR TITLE
Install `libtdms_lib.so` correctly

### DIFF
--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -134,14 +134,18 @@ endif()
 
 
 # Install ---------------------------------------------------------------------
-if (APPLE)
-    list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../lib")
-elseif (UNIX)
-    list(APPEND CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
-endif()
-set_target_properties(tdms PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}")
+if (BUILD_TESTING)
+    if (APPLE)
+        list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../lib")
+    elseif (UNIX)
+        list(APPEND CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+    endif()
+    set_target_properties(tdms PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}")
 
-install(TARGETS tdms_lib tdms LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(TARGETS tdms_lib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+install(TARGETS tdms)
 
 
 # Code Coverage ---------------------------------------------------------------

--- a/tdms/CMakeLists.txt
+++ b/tdms/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 17)
 # Allow building with testing, and default to off
 option(BUILD_TESTING "" OFF)
 include(CTest)
+include(GNUInstallDirs)
 
 # Allow user to specify git access protocol (default to https)
 option(GIT_SSH "" OFF)
@@ -42,7 +43,6 @@ set(CMAKE_OSX_ARCHITECTURES "x86_64")
 # Set the RPATH for the executable to find the dynamically linked libraries
 get_filename_component(MATLAB_LIB_ROOT "${Matlab_MAT_LIBRARY}" DIRECTORY)
 set(CMAKE_INSTALL_RPATH ${MATLAB_LIB_ROOT})
-
 
 # FFTW3 -----------------------------------------------------------------------
 find_package(FFTW REQUIRED)
@@ -134,7 +134,14 @@ endif()
 
 
 # Install ---------------------------------------------------------------------
-install(TARGETS tdms)
+if (APPLE)
+    list(APPEND CMAKE_INSTALL_RPATH "@executable_path/../lib")
+elseif (UNIX)
+    list(APPEND CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
+endif()
+set_target_properties(tdms PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}")
+
+install(TARGETS tdms_lib tdms LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 
 # Code Coverage ---------------------------------------------------------------


### PR DESCRIPTION
Our cmake instructions do not actually place our shared library into the correct install location, nor tell `tdms` where to find this library. This meant that `tdms` cannot find `libtdms_lib.so` at runtime unless `LD_LIBRARY_PATH` had been manually set.

This PR fixes that. Now if `tdms` is to be installed to `/foo/bar/bin`, `tdms_lib.so` will be placed in `/foo/bar/lib`. Additionally, the `rpath` of `tdms` has been set to include _both_ the MATLAB directory _and_ the library directory so users shouldn't need to do any manual pathing.
