### PR TITLE
Clearer helper methods for `HDF5Base`

### DIFF
--- a/tdms/include/hdf5_io/hdf5_base.h
+++ b/tdms/include/hdf5_io/hdf5_base.h
@@ -90,12 +90,15 @@ public:
    * points to an object of the type provided.
    * @param path_under_root Path under file root to check existence of.
    * @param object_type Type of object to check exists at the path location.
+   * @param error_on_false If true, throw a runtime error when the path is not
+   * found or points to the wrong object, instead of returning false.
    * @return true The path exists, and points to the object of the type
    * provided.
    * @return false Otherwise.
    */
   bool path_exists(const std::string &path_under_root,
-                   const H5I_type_t &object_type) const;
+                   const H5I_type_t &object_type,
+                   bool error_on_false = false) const;
 
   /**
    * @brief Print the names of all datasets to std::out.

--- a/tdms/include/hdf5_io/hdf5_base.h
+++ b/tdms/include/hdf5_io/hdf5_base.h
@@ -45,6 +45,44 @@ protected:
    */
   ~HDF5Base() { file_->close(); }
 
+  /**
+   * @brief Determines whether /path_under_root exists in the HDF5 file.
+   * @details Returns true so long as the path provided is valid, irrespective
+   * of the type of object that the path points to.
+   * @param path_under_root Path under file root to check existence of.
+   * @return true The path exists.
+   * @return false The path does not exist.
+   */
+  bool path_exists(const std::string &path_under_root) const;
+  /**
+   * @brief Determines whether /path_under_root exists in the HDF5 file. If it
+   * does, returns the type of object stored at that location.
+   * @details Returns true so long as the path provided is valid, irrespective
+   * of the type of object that the path points to.
+   *
+   * The parameter points_to is not set if the path_under_root is invalid. Use
+   * the returned boolean value to check whether it is safe to dereference this
+   * pointer and avoid undefined behaviour.
+   * @param path_under_root Path under file root to check existence of.
+   * @param[out] points_to Type of object the path points to, if it exists.
+   * Value is not set if the path does not exist.
+   * @return true The path exists.
+   * @return false The path does not exist.
+   */
+  bool path_exists(const std::string &path_under_root,
+                   H5I_type_t *points_to) const;
+  /**
+   * @brief Determines whether /path_under_root exists in the HDF5 file, and
+   * points to an object of the type provided.
+   * @param path_under_root Path under file root to check existence of.
+   * @param object_type Type of object to check exists at the path location.
+   * @return true The path exists, and points to the object of the type
+   * provided.
+   * @return false Otherwise.
+   */
+  bool path_exists(const std::string &path_under_root,
+                   const H5I_type_t &object_type) const;
+
 public:
   /**
    * @brief Get the name of the file.
@@ -65,22 +103,11 @@ public:
 
   /**
    * @brief Return shape/dimensionality information about the array data stored
-   * with `dataname`.
-   * @param dataname The name of the data table.
+   * under /dataset_path.
+   * @param dataset_path Path under file root to the dataset; /dataset_path.
    * @return H5Dimension The dimensions of the data.
    */
-  H5Dimension shape_of(const std::string &dataname) const;
-  /**
-   * @brief Return shape/dimensionality information about array data stored
-   * within a group.
-   *
-   * @param group_name The name of the HDF5 Group in which the data array is
-   * stored.
-   * @param dataname The name of the data array to check dimensions of.
-   * @return The dimensions of the data.
-   */
-  H5Dimension shape_of(const std::string &group_name,
-                       const std::string &dataname) const;
+  H5Dimension shape_of(const std::string &dataset_path) const;
 
   /**
    * @brief Checks the file is a valid HDF5 file, and everything is OK.

--- a/tdms/include/hdf5_io/hdf5_base.h
+++ b/tdms/include/hdf5_io/hdf5_base.h
@@ -45,6 +45,20 @@ protected:
    */
   ~HDF5Base() { file_->close(); }
 
+public:
+  /**
+   * @brief Get the name of the file.
+   * @return std::string the filename.
+   */
+  std::string get_filename() const { return filename_; }
+
+  /**
+   * @brief Get the names of all datasets (data tables) currently in the file.
+   * @return std::vector<std::string> A vector of their names.
+   */
+  std::vector<std::string> get_datanames() const;
+
+
   /**
    * @brief Determines whether /path_under_root exists in the HDF5 file.
    * @details Returns true so long as the path provided is valid, irrespective
@@ -82,19 +96,6 @@ protected:
    */
   bool path_exists(const std::string &path_under_root,
                    const H5I_type_t &object_type) const;
-
-public:
-  /**
-   * @brief Get the name of the file.
-   * @return std::string the filename.
-   */
-  std::string get_filename() const { return filename_; }
-
-  /**
-   * @brief Get the names of all datasets (data tables) currently in the file.
-   * @return std::vector<std::string> A vector of their names.
-   */
-  std::vector<std::string> get_datanames() const;
 
   /**
    * @brief Print the names of all datasets to std::out.

--- a/tdms/include/hdf5_io/hdf5_reader.h
+++ b/tdms/include/hdf5_io/hdf5_reader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "hdf5_io/hdf5_base.h"
+#include "hdf5_io/hdf5_dimension.h"
 
 #include "arrays.h"
 #include "arrays/cuboid.h"
@@ -101,7 +102,7 @@ public:
   void read(const std::string &dataset_name, Matrix<T> &data_location) const {
     spdlog::debug("Reading {} from file: {}", dataset_name, filename_);
 
-    std::vector<hsize_t> dimensions = shape_of(dataset_name);
+    H5Dimension dimensions = shape_of(dataset_name);
     if (dimensions.size() != 2) {
       throw std::runtime_error(
               "Cannot read " + dataset_name + " into a 2D matrix, it has " +

--- a/tdms/include/hdf5_io/hdf5_reader.h
+++ b/tdms/include/hdf5_io/hdf5_reader.h
@@ -24,56 +24,6 @@ public:
       : HDF5Base(filename, H5F_ACC_RDONLY) {}
 
   /**
-   * @brief Read the dataset stored within a group into the buffer provided.
-   * @details Can be used to read MATLAB structs by treating the struct as the
-   * Group and field as the Dataset.
-   * @tparam T C++ datatype to read data into.
-   * @param group The Group within the file in which the dataset lives.
-   * @param dataset The name of the dataset to fetch data from.
-   * @param data The buffer into which to write the data.
-   */
-  template<typename T>
-  void read_dataset_in_group(const std::string &group,
-                             const std::string &dataset, T *data) const {
-    spdlog::debug("Reading {} from file: {}", group, filename_);
-
-    // Structs are saved as groups, so we need to fetch the group this struct is
-    // contained in
-    H5::Group structure_array = file_->openGroup(group);
-    // Then fetch the requested data and read it into the buffer provided
-    H5::DataSet requested_field = structure_array.openDataSet(dataset);
-    requested_field.read(data, requested_field.getDataType());
-  }
-
-  /**
-   * @brief Read the dataset stored within a group into the buffer provided,
-   * resizing the vector buffer accordingly.
-   * @details Can be used to read MATLAB structs by treating the struct as the
-   * Group and field as the Dataset.
-   * @tparam T C++ datatype to read data into.
-   * @param group The Group within the file in which the dataset lives.
-   * @param dataset The name of the dataset to fetch data from.
-   * @param[out] data The buffer into which to write the data.
-   */
-  template<typename T>
-  void read_dataset_in_group(const std::string &group,
-                             const std::string &dataset,
-                             std::vector<T> &data) const {
-    spdlog::debug("Reading {} from file: {}", group, filename_);
-
-    // Structs are saved as groups, so we need to fetch the group this struct is
-    // contained in
-    H5::Group structure_array = file_->openGroup(group);
-    // Then fetch the requested data and read it into the buffer provided,
-    // resizing the buffer if necessary
-    H5::DataSet requested_field = structure_array.openDataSet(dataset);
-    H5Dimension field_size(requested_field);
-    int number_of_elements = field_size.number_of_elements();
-    data.resize(number_of_elements);
-    requested_field.read(data.data(), requested_field.getDataType());
-  }
-
-  /**
    * @brief Reads a named dataset from the HDF5 file.
    * @param dataname The name of the datset to be read.
    * @param data A pointer to an array of correct size.
@@ -89,6 +39,29 @@ public:
     // now get the data type
     dataset.read(data, dataset.getDataType());
     spdlog::trace("Read successful.");
+  }
+
+  /**
+   * @brief Reads the data from the dataset at the location (under file root)
+   * provided.
+   * @tparam T Datatype to read.
+   * @param path_to_dataset Path under file root of the dataset to read from.
+   * @param buffer Vector to read data into.
+   */
+  template<typename T>
+  void read(const std::string &path_to_dataset, std::vector<T> &buffer) const {
+    spdlog::debug("Reading {} from file", path_to_dataset, filename_);
+
+    if (path_exists(path_to_dataset, H5I_DATASET)) {
+      H5::DataSet dataset = file_->openDataSet(path_to_dataset);
+      H5Dimension dims = shape_of(path_to_dataset);
+      buffer.resize(dims.number_of_elements());
+      dataset.read(buffer.data(), dataset.getDataType());
+    } else {
+      // Path does not exist, throw error
+      throw std::runtime_error(path_to_dataset +
+                               " does not point to a dataset");
+    }
   }
 
   /**
@@ -130,35 +103,14 @@ public:
    * @param[in] plane The plane {I,J,K}{0,1} to read from the file.
    * @param[out] ic InterfaceComponent reference to populate/overwrite.
    */
-  void read(const std::string &plane, InterfaceComponent *ic) const;
-  /**
-   * @brief Read an InterfaceComponent from the file.
-   *
-   * @param plane The plane {I,J,K}{0,1} to read from the file.
-   * @return InterfaceComponent corresponding to the requested plane.
-   */
-  InterfaceComponent read(const std::string &plane) const {
-    InterfaceComponent ic;
-    read(plane, &ic);
-    return ic;
-  }
+  void read(const std::string &plane, InterfaceComponent &ic) const;
 
   /**
    * @brief Read FrequencyVectors into the buffer provided.
    *
    * @param[out] f_vec FrequencyVectors reference to populate/overwrite.
    */
-  void read(FrequencyVectors *f_vec) const;
-  /**
-   * @brief Read FrequencyVectors from the file.
-   *
-   * @return FrequencyVectors object containing the data from the input file.
-   */
-  FrequencyVectors read() const {
-    FrequencyVectors f_vec;
-    read(&f_vec);
-    return f_vec;
-  }
+  void read(FrequencyVectors &f_vec) const;
 
   /**
    * @brief
@@ -167,7 +119,7 @@ public:
    * to be offset by -1 b/c indexing things
    * @param cube
    */
-  void read(Cuboid *cube) const;
+  void read(Cuboid &cube) const;
 
   /**
    * @brief Read data from the file into a DispersiveMultiLayerObject
@@ -178,5 +130,5 @@ public:
    * are populated with the corresponding data entries.
    * @param dml DispersiveMultiLayer object into which to write data.
    */
-  void read(DispersiveMultiLayer *dml) const;
+  void read(DispersiveMultiLayer &dml) const;
 };

--- a/tdms/src/hdf5_io/hdf5_base.cpp
+++ b/tdms/src/hdf5_io/hdf5_base.cpp
@@ -95,17 +95,8 @@ bool HDF5Base::is_ok() const {
 }
 
 bool HDF5Base::flagged_MATLAB_empty(const std::string &object_path) const {
-  // Can't check anything if there's no file
-  if (!is_ok()) { throw std::runtime_error("Problem with the file!"); }
-
-  // Attempt to fetch the object requested
-  if (!file_->exists(object_path)) {
-    throw std::runtime_error(filename_ + " has no object " + object_path);
-  }
-  hid_t object_reference = file_->getObjId(object_path);
-
-  H5I_type_t object_type = file_->getHDFObjType(object_reference);
   H5::Attribute empty_attribute;// will point to the MATLAB_empty attribute
+
   if (path_exists(object_path, H5I_GROUP)) {
     // Dealing with a group
     H5::Group object = file_->openGroup(object_path);

--- a/tdms/src/hdf5_io/hdf5_base.cpp
+++ b/tdms/src/hdf5_io/hdf5_base.cpp
@@ -12,6 +12,40 @@
 #include <H5public.h>
 #include <spdlog/spdlog.h>
 
+bool HDF5Base::path_exists(const std::string &path_under_root) const {
+  // Can't check anything if there's no file
+  if (file_ == nullptr) { throw std::runtime_error("No file opened"); }
+
+  // Attempt to lookup the path
+  return file_->exists(path_under_root);
+}
+
+bool HDF5Base::path_exists(const std::string &path_under_root,
+                           H5I_type_t *points_to) const {
+  // Attempt to lookup the path
+  bool return_value = path_exists(path_under_root);
+
+  // Set object type if the path existed
+  if (return_value) {
+    hid_t object_reference = file_->getObjId(path_under_root);
+    *points_to = file_->getHDFObjType(object_reference);
+  }
+
+  return return_value;
+}
+
+bool HDF5Base::path_exists(const std::string &path_under_root,
+                           const H5I_type_t &object_type) const {
+  // Attempt to lookup the path
+  bool path_is_valid = path_exists(path_under_root);
+  // If the path is valid, check the object it points to is the correct type
+  if (path_is_valid) {
+    hid_t object_reference = file_->getObjId(path_under_root);
+    return file_->getHDFObjType(object_reference) == object_type;
+  }
+  return false;
+}
+
 std::vector<std::string> HDF5Base::get_datanames() const {
   std::vector<std::string> names;
 
@@ -34,19 +68,13 @@ void HDF5Base::ls() const {
   return;
 }
 
-H5Dimension HDF5Base::shape_of(const std::string &dataname) const {
-  // Get the dataspace (contains dimensionality info)
-  H5::DataSpace dataspace = file_->openDataSet(dataname).getSpace();
-  return H5Dimension(dataspace);
-}
-
-H5Dimension HDF5Base::shape_of(const std::string &group_name,
-                               const std::string &dataname) const {
-  // Open the group that contains the dataset
-  H5::Group group = file_->openGroup(group_name);
-  // Get the DataSpace for the DataSet within the group
-  H5::DataSpace dataspace = group.openDataSet(dataname).getSpace();
-  return H5Dimension(dataspace);
+H5Dimension HDF5Base::shape_of(const std::string &dataset_path) const {
+  if (path_exists(dataset_path, H5I_type_t::H5I_DATASET)) {
+    // Get the dataspace (contains dimensionality info)
+    return H5Dimension(file_->openDataSet(dataset_path).getSpace());
+  } else {
+    throw std::runtime_error(dataset_path + " does not point to a dataset");
+  }
 }
 
 bool HDF5Base::is_ok() const {
@@ -68,7 +96,8 @@ bool HDF5Base::flagged_MATLAB_empty(const std::string &object_path) const {
 
   H5I_type_t object_type = file_->getHDFObjType(object_reference);
   H5::Attribute empty_attribute;// will point to the MATLAB_empty attribute
-  if (object_type == H5I_GROUP) {
+  if (path_exists(object_path, H5I_GROUP)) {
+    // Dealing with a group
     H5::Group object = file_->openGroup(object_path);
     if (object.attrExists("MATLAB_empty")) {
       empty_attribute = object.openAttribute("MATLAB_empty");
@@ -77,7 +106,7 @@ bool HDF5Base::flagged_MATLAB_empty(const std::string &object_path) const {
       return false;
     }
     object.close();
-  } else if (object_type == H5I_DATASET) {
+  } else if (path_exists(object_path, H5I_DATASET)) {
     // Dealing with a dataset
     H5::DataSet object = file_->openDataSet(object_path);
     if (object.attrExists("MATLAB_empty")) {

--- a/tdms/src/hdf5_io/hdf5_base.cpp
+++ b/tdms/src/hdf5_io/hdf5_base.cpp
@@ -35,13 +35,23 @@ bool HDF5Base::path_exists(const std::string &path_under_root,
 }
 
 bool HDF5Base::path_exists(const std::string &path_under_root,
-                           const H5I_type_t &object_type) const {
+                           const H5I_type_t &object_type,
+                           const bool error_on_false) const {
   // Attempt to lookup the path
   bool path_is_valid = path_exists(path_under_root);
+  bool object_is_correct_type = false;
   // If the path is valid, check the object it points to is the correct type
   if (path_is_valid) {
     hid_t object_reference = file_->getObjId(path_under_root);
-    return file_->getHDFObjType(object_reference) == object_type;
+    object_is_correct_type =
+            file_->getHDFObjType(object_reference) == object_type;
+  }
+  // Return result, or throw error if running strictly
+  if (path_is_valid && object_is_correct_type) {
+    return true;
+  } else if (error_on_false) {
+    throw std::runtime_error(path_under_root +
+                             "does not point to an object of the correct type");
   }
   return false;
 }

--- a/tdms/src/hdf5_io/hdf5_reader.cpp
+++ b/tdms/src/hdf5_io/hdf5_reader.cpp
@@ -21,8 +21,8 @@ void HDF5Reader::read(const string &plane, InterfaceComponent *ic) const {
 
 void HDF5Reader::read(FrequencyVectors *f_vec) const {
   // Allocate memory in f_vec
-  H5Dimension x_dims = shape_of("f_vec", "fx_vec");
-  H5Dimension y_dims = shape_of("f_vec", "fy_vec");
+  H5Dimension x_dims = shape_of("f_vec/fx_vec");
+  H5Dimension y_dims = shape_of("f_vec/fy_vec");
   // Check that we have one dimensional arrays
   if (!x_dims.is_1D() || !y_dims.is_1D()) {
     throw runtime_error("f_vec members are not 1D arrays!");

--- a/tdms/src/simulation_manager/objects_from_infile.cpp
+++ b/tdms/src/simulation_manager/objects_from_infile.cpp
@@ -34,15 +34,15 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   HDF5Reader INPUT_FILE(matrices_from_input_file.input_filename);
 
   // Read the interface components
-  I0 = INPUT_FILE.read("I0");
-  I1 = INPUT_FILE.read("I1");
-  J0 = INPUT_FILE.read("J0");
-  J1 = INPUT_FILE.read("J1");
-  K0 = INPUT_FILE.read("K0");
-  K1 = INPUT_FILE.read("K1");
+  INPUT_FILE.read("I0", I0);
+  INPUT_FILE.read("I1", I1);
+  INPUT_FILE.read("J0", J0);
+  INPUT_FILE.read("J1", J1);
+  INPUT_FILE.read("K0", K0);
+  INPUT_FILE.read("K1", K1);
 
   // Read the layer structure of the obstacle
-  INPUT_FILE.read(&matched_layer);
+  INPUT_FILE.read(matched_layer);
 
   // unpack the parameters for this simulation
   params.unpack_from_input_matrices(matrices_from_input_file);
@@ -71,7 +71,7 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   // Get phasorsurface
   cuboid = Cuboid();
   if (params.exphasorssurface && params.run_mode == RunMode::complete) {
-    INPUT_FILE.read(&cuboid);
+    INPUT_FILE.read(cuboid);
     if (IJK_tot.j == 0 && cuboid[2] != cuboid[3]) {
       throw std::runtime_error("In a 2D simulation, J0 should equal J1 in "
                                "phasorsurface.");
@@ -97,7 +97,7 @@ IndependentObjectsFromInfile::IndependentObjectsFromInfile(
   D_tilde = DTilde();
   // if exdetintegral is flagged, setup pupil, D_tilde, and f_vec accordingly
   if (params.exdetintegral) {
-    f_vec = INPUT_FILE.read();
+    INPUT_FILE.read(f_vec);
     pupil.initialise(matrices_from_input_file["Pupil"], f_vec.x.size(),
                      f_vec.y.size());
     D_tilde.initialise(matrices_from_input_file["D_tilde"], f_vec.x.size(),

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_Cuboid.cpp
@@ -23,7 +23,7 @@ TEST_CASE("HDF5: Read Cuboid") {
 
   SECTION("Read into existing object") {
     HDF5Reader MATFile(tdms_object_data);
-    MATFile.read(&cube);
+    MATFile.read(cube);
     // Check expected values, noting the -1 offset that is applied because of
     // MATLAB indexing
     bool expected_values_recieved = cube[0] == 0 && cube[1] == 3 &&
@@ -35,6 +35,6 @@ TEST_CASE("HDF5: Read Cuboid") {
   SECTION("Throw error if too many elements provided") {
     HDF5Reader MATFile(tdms_bad_object_data);
     // Error should be thrown due to incorrect dimensions
-    REQUIRE_THROWS_AS(MATFile.read(&cube), std::runtime_error);
+    REQUIRE_THROWS_AS(MATFile.read(cube), std::runtime_error);
   }
 }

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_DispersiveMultiLayer.cpp
@@ -20,7 +20,7 @@ TEST_CASE("HDF5: Read DispersiveMultiLayer") {
     vector<double> consecutive_integers(10);
     for (int i = 0; i < 10; i++) { consecutive_integers[i] = (double) i; }
 
-    MATFile.read(&dml);
+    MATFile.read(dml);
 
     // Assert correct data - each entry should just be the integers 0->9
     // inclusive

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_FrequencyVector.cpp
@@ -37,9 +37,8 @@ TEST_CASE("HDF5: Read FrequencyVector") {
     HDF5Reader MATFile(tdms_object_data);
 
     SECTION("Read into existing FrequencyVectors object") {
-      MATFile.read(&f_vec);
+      MATFile.read(f_vec);
     }
-    SECTION("Return FrequencyVectors object") { f_vec = MATFile.read(); }
 
     // Confirm expected sizes
     CHECK(f_vec.x.size() == EXPECTED_VEC_SIZE);
@@ -60,6 +59,6 @@ TEST_CASE("HDF5: Read FrequencyVector") {
   // Bad object data provides a 2D array for fx_vec component
   SECTION("Incorrect sizes") {
     HDF5Reader MATFile(tdms_bad_object_data);
-    REQUIRE_THROWS_AS(MATFile.read(&f_vec), std::runtime_error);
+    REQUIRE_THROWS_AS(MATFile.read(f_vec), std::runtime_error);
   }
 }

--- a/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
+++ b/tdms/tests/unit/hdf5_and_tdms_objects/test_hdf5_InterfaceComponent.cpp
@@ -42,9 +42,9 @@ TEST_CASE("HDF5: Read InterfaceComponent") {
   SECTION("Read into existing InterfaceComponent") {
     InterfaceComponent I0, J0, K0;
 
-    MATFile.read("I0", &I0);
-    MATFile.read("J0", &J0);
-    MATFile.read("K0", &K0);
+    MATFile.read("I0", I0);
+    MATFile.read("J0", J0);
+    MATFile.read("K0", K0);
 
     bool I0_correct = (I0.index == 0) && (I0.apply == false);
     bool J0_correct = (J0.index == 1) && (J0.apply == false);
@@ -52,18 +52,5 @@ TEST_CASE("HDF5: Read InterfaceComponent") {
     CHECK(I0_correct);
     CHECK(J0_correct);
     CHECK(K0_correct);
-  }
-
-  SECTION("Return InterfaceComponent object") {
-    InterfaceComponent I1 = MATFile.read("I1");
-    InterfaceComponent J1 = MATFile.read("J1");
-    InterfaceComponent K1 = MATFile.read("K1");
-
-    bool I1_correct = (I1.index == 3) && (I1.apply == true);
-    bool J1_correct = (J1.index == 4) && (J1.apply == false);
-    bool K1_correct = (K1.index == 5) && (K1.apply == true);
-    CHECK(I1_correct);
-    CHECK(J1_correct);
-    CHECK(K1_correct);
   }
 }

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_base.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_base.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include <catch2/catch_test_macros.hpp>
 #include <spdlog/spdlog.h>
 
@@ -27,10 +29,15 @@ TEST_CASE("HDF5Base::path_exists()") {
     // read_in_test/vector is a dataset
     REQUIRE(matlab_file.path_exists("read_in_test/vector", H5I_DATASET));
     REQUIRE(!matlab_file.path_exists("read_in_test/vector", H5I_GROUP));
+    REQUIRE_THROWS_AS(
+            matlab_file.path_exists("read_in_test/vector", H5I_GROUP, true),
+            std::runtime_error);
 
     // read_in_test is a group
     REQUIRE(hdf5_file.path_exists("read_in_test", H5I_GROUP));
     REQUIRE(!hdf5_file.path_exists("read_in_test", H5I_ATTR));
+    REQUIRE_THROWS_AS(hdf5_file.path_exists("read_in_test", H5I_ATTR, true),
+                      std::runtime_error);
   }
 
   SECTION("Request object types") {

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_base.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_base.cpp
@@ -9,8 +9,52 @@ using tdms_unit_test_data::struct_testdata;
 
 // HDF5Base cannot be instantiated, so we use HDF5Reader just to avoid
 // accidental writes.
-TEST_CASE("HDF5Base: flagged_MATLAB_empty()") {
 
+TEST_CASE("HDF5Base::path_exists()") {
+  HDF5Reader matlab_file(struct_testdata);
+  HDF5Reader hdf5_file(hdf5_test_file);
+
+  SECTION("Paths that exist") {
+    spdlog::info("HDF5Base::path_exists() [Valid paths]");
+    // Point to a dataset that exists
+    REQUIRE(matlab_file.path_exists("empty_array"));
+    // Point to a group that exists
+    REQUIRE(matlab_file.path_exists("empty_struct"));
+  }
+
+  SECTION("Enforce object types") {
+    spdlog::info("HDF5Base::path_exists() [Forced types]");
+    // read_in_test/vector is a dataset
+    REQUIRE(matlab_file.path_exists("read_in_test/vector", H5I_DATASET));
+    REQUIRE(!matlab_file.path_exists("read_in_test/vector", H5I_GROUP));
+
+    // read_in_test is a group
+    REQUIRE(hdf5_file.path_exists("read_in_test", H5I_GROUP));
+    REQUIRE(!hdf5_file.path_exists("read_in_test", H5I_ATTR));
+  }
+
+  SECTION("Request object types") {
+    spdlog::info("HDF5Base::path_exists() [Request types]");
+    H5I_type_t dataset;
+    H5I_type_t group;
+
+    // Point to a dataset
+    REQUIRE(matlab_file.path_exists("read_in_test/vector", &dataset));
+    REQUIRE(dataset == H5I_DATASET);
+
+    // Point to a group
+    REQUIRE(hdf5_file.path_exists("read_in_test", &group));
+    REQUIRE(group == H5I_GROUP);
+  }
+
+  SECTION("Paths that do not exist") {
+    spdlog::info("HDF5Base::path_exists() [Invalid paths]");
+    REQUIRE(!hdf5_file.path_exists("this_path_is_invalid"));
+    REQUIRE(!matlab_file.path_exists("read_in_test/this_dataset_doesnt_exist"));
+  }
+}
+
+TEST_CASE("HDF5Base: flagged_MATLAB_empty()") {
   HDF5Reader matlab_file(struct_testdata);
   HDF5Reader hdf5_file(hdf5_test_file);
 

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_dimension.cpp
@@ -6,6 +6,7 @@
 #include "hdf5_io/hdf5_dimension.h"
 #include "hdf5_io/hdf5_reader.h"
 
+#include <stdexcept>
 #include <vector>
 
 #include <catch2/catch_test_macros.hpp>
@@ -19,23 +20,27 @@ TEST_CASE("Fetch dimensions correctly") {
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("2D array") {
-    H5Dimension two_by_two = MATFile.shape_of("example_struct", "double_22");
+    H5Dimension two_by_two = MATFile.shape_of("example_struct/double_22");
     bool two_by_two_dimensions_read_in =
             (two_by_two == vector<hsize_t>{2, 2}) && (!two_by_two.is_1D());
     REQUIRE(two_by_two_dimensions_read_in);
   }
 
   SECTION("3D array") {
-    H5Dimension three_four_five =
-            MATFile.shape_of("example_struct", "uint_345");
+    H5Dimension three_four_five = MATFile.shape_of("example_struct/uint_345");
     bool three_four_five_read_in =
             (three_four_five == vector<hsize_t>{3, 4, 5}) &&
             (!three_four_five.is_1D());
   }
 
   SECTION("1D char array") {
-    H5Dimension tdms_dims = MATFile.shape_of("example_struct", "string");
+    H5Dimension tdms_dims = MATFile.shape_of("example_struct/string");
     bool tdms_dims_correct = (tdms_dims.is_1D()) && (tdms_dims.max_dim() == 4);
     REQUIRE(tdms_dims_correct);
+  }
+
+  SECTION("Non-existant dataset") {
+    REQUIRE_THROWS_AS(MATFile.shape_of("a_dataset_that_isn't_there"),
+                      runtime_error);
   }
 }

--- a/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
+++ b/tdms/tests/unit/hdf5_io_tests/test_hdf5_reader.cpp
@@ -21,7 +21,7 @@ using namespace std;
 using tdms_tests::uint16s_to_string;
 using tdms_unit_test_data::struct_testdata, tdms_unit_test_data::hdf5_test_file;
 
-TEST_CASE("HDF5: Read from a MATLAB struct") {
+TEST_CASE("HDF5Reader::read() [.mat files]") {
   HDF5Reader MATFile(struct_testdata);
 
   SECTION("Read numeric scalars") {
@@ -30,10 +30,9 @@ TEST_CASE("HDF5: Read from a MATLAB struct") {
     double one_half = 0., unity = 0.;
     bool logical_read = false;
     // Read values
-    MATFile.read_dataset_in_group("example_struct", "double_half", &one_half);
-    MATFile.read_dataset_in_group("example_struct", "double_no_decimal",
-                                  &unity);
-    MATFile.read_dataset_in_group("example_struct", "boolean", &logical_read);
+    MATFile.read("example_struct/double_half", &one_half);
+    MATFile.read("example_struct/double_no_decimal", &unity);
+    MATFile.read("example_struct/boolean", &logical_read);
     // Validate read in data
     REQUIRE(one_half == Catch::Approx(0.5));
     REQUIRE(unity == Catch::Approx(1.));
@@ -47,15 +46,14 @@ TEST_CASE("HDF5: Read from a MATLAB struct") {
     // we need to convert manually...
     {
       uint16_t read_uints16[4];
-      MATFile.read_dataset_in_group("example_struct", "string", read_uints16);
+      MATFile.read("example_struct/string", read_uints16);
       string tdms = uint16s_to_string(read_uints16, 4);
       REQUIRE(tdms == "tdms");
     }
     // The uint 3*4*5 uint matrix contains only 1s
     {
       vector<uint8_t> uint_matrix(3 * 4 * 5, 0);
-      MATFile.read_dataset_in_group("example_struct", "uint_345",
-                                    uint_matrix.data());
+      MATFile.read("example_struct/uint_345", uint_matrix);
       bool all_values_unity = true;
       for (uint8_t &value : uint_matrix) {
         if (value != 1) { all_values_unity = false; }
@@ -65,7 +63,7 @@ TEST_CASE("HDF5: Read from a MATLAB struct") {
     // The double 2*2 matrix contains 0.25, 0.5, 0.75, 1.
     {
       double two_by_two[4];
-      MATFile.read_dataset_in_group("example_struct", "double_22", two_by_two);
+      MATFile.read("example_struct/double_22", two_by_two);
       REQUIRE(two_by_two[0] == Catch::Approx(0.25));
       REQUIRE(two_by_two[1] == Catch::Approx(0.75));
       REQUIRE(two_by_two[2] == Catch::Approx(0.5));
@@ -75,9 +73,9 @@ TEST_CASE("HDF5: Read from a MATLAB struct") {
   }
 }
 
-/** @brief Test the performance of read_dataset_in_group, on both MATLAB files
+/** @brief Test the performance of read(), on both MATLAB files
  * and HDF5 files */
-TEST_CASE("HDF5Reader::read_dataset_in_group") {
+TEST_CASE("HDF5Reader::read() [std::vector]") {
   vector<double> read_buffer;
   read_buffer.reserve(12);
   // Used to check that data has been read in correctly
@@ -91,17 +89,17 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
       // check confirms that both the int data and the doubles that they were
       // cast to are correct
       vector<int> int_buffer(12);
-      Hfile.read_dataset_in_group("read_in_test", "vector", int_buffer.data());
+      Hfile.read("read_in_test/vector", int_buffer);
       for (int i = 0; i < 12; i++) {
         entries_read_correctly = entries_read_correctly && int_buffer[i] == i;
         read_buffer[i] = (double) int_buffer[i];
       }
     }
     SECTION("Matrix [double]") {
-      Hfile.read_dataset_in_group("read_in_test", "matrix", read_buffer.data());
+      Hfile.read("read_in_test/matrix", read_buffer);
     }
     SECTION("Tensor [double]") {
-      Hfile.read_dataset_in_group("read_in_test", "tensor", read_buffer.data());
+      Hfile.read("read_in_test/tensor", read_buffer);
     }
   }
 
@@ -114,20 +112,17 @@ TEST_CASE("HDF5Reader::read_dataset_in_group") {
       // check confirms that both the int data and the doubles that they were
       // cast to are correct
       vector<int64_t> int_buffer(12);
-      Hfile.read_dataset_in_group("read_in_test", "vector_int",
-                                  int_buffer.data());
+      Hfile.read("read_in_test/vector_int", int_buffer);
       for (int i = 0; i < 12; i++) {
         entries_read_correctly = entries_read_correctly && int_buffer[i] == i;
         read_buffer[i] = (double) int_buffer[i];
       }
     }
     SECTION("Matrix [double]") {
-      Hfile.read_dataset_in_group("read_in_test", "matrix_double",
-                                  read_buffer.data());
+      Hfile.read("read_in_test/matrix_double", read_buffer);
     }
     SECTION("Tensor [double]") {
-      Hfile.read_dataset_in_group("read_in_test", "tensor_double",
-                                  read_buffer.data());
+      Hfile.read("read_in_test/tensor_double", read_buffer);
     }
   }
 


### PR DESCRIPTION
# Description

Adds a `path_exists` function to the `HDF5Base` class, wrapping the `C++` API functions behind some nicer errors and cleaner functionality. This also superceeds that `exists` function that was written on the `181-pairdev-write-dataset-to-group` branch.

Also, it appears that most (read most, not all) of the HDF5 functions can handle paths from the file root, rather than needing to recursively open `Groups` and then `DataSets`. As a result, `read_dataset_from_group` is no longer needed as we can just overload `read()` to look directly at absolute paths.

## Testing

- Tests added for `path_exists()` function.
- Existing tests for `read_dataset_in_group` have been set to use the new replacement method.
