### PR TITLE
No leading underscore in version.

### DIFF
--- a/tdms/cmake/version_from_git.cmake
+++ b/tdms/cmake/version_from_git.cmake
@@ -27,9 +27,9 @@ if(GIT_FOUND)
 		OUTPUT_STRIP_TRAILING_WHITESPACE )
 
 	string(REGEX MATCH "v[0-9]+\.[0-9]+\.[0-9]+" IS_SEMVER "${TAG_OR_SHORT_HASH}")
-	if (CURRENT_BRANCH STREQUAL "main" AND IS_SEMVER)
-	    # If main is tagged with a sememantic version (of the form v1.2.3) then
-	    # that is the version.
+	if (CURRENT_BRANCH STREQUAL "main" OR CURRENT_BRANCH STREQUAL "" AND IS_SEMVER)
+	    # If we're on main or in a detatched head, and we're tagged with a
+	    # sememantic version (of the form v1.2.3) then that is the version.
 		set(TDMS_VERSION "${TAG_OR_SHORT_HASH}")
 	else()
 		# If it's not a tag on main or if it's a commit hash then the "version"


### PR DESCRIPTION
The problem was that a detatched head has no `branchname`. But that is precisely what we're expecting if we 
```{sh}
git checkout v1.0.1
```
So we were entering the "branchname is not main" part of the if statement with an empty branchname.

Fixes 
* #325

Follows on from
* #203 