### PR TITLE
Add the `_OPENMP` version (date of spec) to `tdms --version`

### DIFF
--- a/tdms/src/argument_parser.cpp
+++ b/tdms/src/argument_parser.cpp
@@ -57,6 +57,7 @@ void ArgumentParser::print_help_message() {
 
 void ArgumentParser::print_version() {
   fprintf(stdout, "TDMS version: %s\n", tdms::VERSION.c_str());
+  fprintf(stdout, "OpenMP version: %i\n", _OPENMP);
 }
 
 ArgumentNamespace::ArgumentNamespace(int n_args, char *arg_ptrs[]) {


### PR DESCRIPTION
As title. `tdms --version` is called in our CI so we should be able to get what [version of the OpenMP spec](https://github.com/Kitware/CMake/blob/master/Modules/FindOpenMP.cmake#L435). VisualStudio is obeying the Windows runners.

Up to you if we actually want to spit the OpenMP version spec out with `tdms --version`. I'd say it doesn't hurt.