### PR TITLE
Update `upload-artifact`, `download-artifact` and `checkout` versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1.2.3
@@ -196,7 +196,7 @@ jobs:
         if: matrix.build_testing == 'OFF' && matrix.build_type == 'Debug'
         # If we use the build with testing ON, we'd also need to copy over (and
         # install) the libtdms.so so use the OFF build for simplicity.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tdms_build_${{ matrix.os }}
           path: ${{ runner.workspace }}/build/tdms_build.tar
@@ -232,7 +232,7 @@ jobs:
           python3 -m pip install -r ${GITHUB_WORKSPACE}/tdms/tests/requirements.txt
 
       - name: Download build result
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tdms_build_${{ matrix.os }}
           path: ${{ runner.workspace }}

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: "true"
 
@@ -45,7 +45,7 @@ jobs:
       shell: bash
 
     - name: Upload the website
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tdms_website
         path: html/*
@@ -61,7 +61,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Download the content for deployment
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: tdms_website
         path: html


### PR DESCRIPTION
Some maintenance. [Version 3 is deprecated](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts).
