### PR TITLE
Update doxygen-awesome to v2.3.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
       all-github-actions:
         patterns:
           - "*"
+  - package-ecosystem: gitsubmodule
+    directory: doc/
+    schedule:
+        interval: "monthly"
+    labels:
+      - "housekeeping"
+      - "technical"


### PR DESCRIPTION
Update to [doxygen-awesome-css v2.3.4](https://github.com/jothepro/doxygen-awesome-css/releases/tag/v2.3.4).

This _should_ now only use a session cookie. And therefore _should_ fix

- #370 